### PR TITLE
Use new puppet confdir and vardir in unified puppet-agent.

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -2,6 +2,9 @@ component "puppet" do |pkg, settings, platform|
   pkg.url "http://builds.puppetlabs.lan/pe-puppet/3.7.2.2/artifacts/pe-puppet-3.7.2.2.tar.gz"
   pkg.md5sum "4f0c81833af80aee77b45335b7e69a7f"
   pkg.version "3.7.2.2"
+  
+  # Patches Puppet 3.7.x to use /opt/puppetlabs/agent and ../cache as conf_dir and var_dir.
+  pkg.apply_patch "resources/patches/puppet/update_confdir_vardir_in_puppet_3_7"
 
   pkg.build_requires "ruby"
   pkg.build_requires "facter"

--- a/resources/patches/puppet/update_confdir_vardir_in_puppet_3_7
+++ b/resources/patches/puppet/update_confdir_vardir_in_puppet_3_7
@@ -1,0 +1,32 @@
+From aee472f4fec67f5a56bc271ee9676c90c240a5ab Mon Sep 17 00:00:00 2001
+From: Geoff Nichols <geoff.nichols@puppetlabs.com>
+Date: Tue, 25 Nov 2014 16:54:51 -0800
+Subject: [PATCH] Update confdir and vardir for unified puppet-agent
+
+This commit updates the "conf_dir" and "var_dir" methods
+with the new settings for the unified puppet agent.
+---
+ lib/puppet/util/run_mode.rb | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/puppet/util/run_mode.rb b/lib/puppet/util/run_mode.rb
+index b53bb79..4d70d26 100644
+--- a/lib/puppet/util/run_mode.rb
++++ b/lib/puppet/util/run_mode.rb
+@@ -55,11 +55,11 @@ module Puppet
+ 
+     class UnixRunMode < RunMode
+       def conf_dir
+-        which_dir("/etc/puppetlabs/puppet", "~/.puppet")
++        which_dir("/etc/puppetlabs/agent", "~/.puppet")
+       end
+ 
+       def var_dir
+-        which_dir("/var/opt/lib/pe-puppet", "~/.puppet/var")
++        which_dir("/opt/puppetlabs/agent/cache", "~/.puppet/var")
+       end
+     end
+ 
+-- 
+1.9.3 (Apple Git-50)
+


### PR DESCRIPTION
Prior to this commit, the puppet component of the unified puppet-
agent was using the legacy vardir (/var/opt/lib/pe-puppet).
This commit updates pe-puppet to use the new standard AIO vardir.
