### PR TITLE
Install ruby-stomp as gem in unified puppet-agent.

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -1,14 +1,11 @@
 component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.3.3"
-  pkg.md5sum "803344d3291a3fc3daa7da67b318165a"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.tar.gz"
+  pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.gem"
 
   pkg.build_requires "ruby"
 
   pkg.install do
-    ["install -d -m0755 #{settings[:ruby_vendordir]}",
-     "install -d -m0755 #{settings[:bindir]}",
-     "cp -pr lib/* #{settings[:ruby_vendordir]}",
-     "cp -pr bin/* #{settings[:bindir]}"]
+    [ "#{settings[:bindir]}/gem install --no-rdoc --no-ri stomp-1.3.3.gem"]
   end
 end


### PR DESCRIPTION
Prior to this commit, we installed ruby-stomp and
needed to use a potentially non-portable sed
expression to update stomp scripts to use our Ruby.

This commit updates the unified puppet-agent to install
stomp as a gem, which should hopefully be cleaner and
easier to maintain cross-platform.
