### PR TITLE
(RE-1973) Rebase ruby-shadow to upstream 2.3.3

### DIFF
--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -1,7 +1,7 @@
 component "ruby-shadow" do |pkg, settings, platform|
-  pkg.version "2.2.0"
-  pkg.md5sum "11cddd40138172899b9cfc275e5272ed"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.2.0.tar.gz"
+  pkg.version "2.3.3"
+  pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.3.3.tar.gz"
 
   pkg.build_requires "ruby"
 


### PR DESCRIPTION
For the unified puppet-agent, rebase ruby-shadow to 2.3.3.
We're already shipping 2.3.3 for some of our PE-supported
platforms.
