### PR TITLE
(RE-3608) Add ext/ yaml files for shipping

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,2 @@
+---
+project: 'puppet-agent'

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,0 +1,1 @@
+build_defaults.yaml


### PR DESCRIPTION
The ship binary leverages the packaging repo, which requires a minimal
set of data to function. This commit adds that in the form of a yaml
file in ext and a symlink. It only contains the project name currently.
