### PR TITLE
(RE-3662) Build in parallel when possible

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -17,10 +17,10 @@ component "augeas" do |pkg, settings, platform|
   end
 
   pkg.build do
-    ["#{platform[:make]}"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} install"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 end

--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -20,10 +20,10 @@ component "cfacter" do |pkg, settings, platform|
   end
 
   pkg.build do
-    ["#{platform[:make]}"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} install"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 end

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -11,11 +11,11 @@ component "ruby-augeas" do |pkg, settings, platform|
      "export CFLAGS=#{platform[:cflags]}",
      "export PKG_CONFIG_PATH=#{settings[:libdir]}/pkgconfig",
      "#{settings[:bindir]}/ruby ext/augeas/extconf.rb",
-     platform[:make]]
+     "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} DESTDIR=/ install",
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) DESTDIR=/ install",
      "install -d #{settings[:ruby_vendordir]}",
      "cp -pr lib/augeas.rb #{settings[:ruby_vendordir]}"]
   end

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -9,10 +9,10 @@ component "ruby-shadow" do |pkg, settings, platform|
     ["export CONFIGURE_ARGS='--vendor'",
      "export CFLAGS=#{settings[:cflags]}",
      "#{settings[:bindir]}/ruby extconf.rb",
-     platform[:make]]
+     "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} DESTDIR=/ install"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) DESTDIR=/ install"]
   end
 end

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -28,10 +28,10 @@ component "ruby" do |pkg, settings, platform|
   end
 
   pkg.build do
-    ["#{platform[:make]}"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} install"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 end


### PR DESCRIPTION
This commit takes advantage of new functionality added to vanagon to
allow builds to know the number of processes available for them to build
with. Using this information, we can pass it to make to let us have
multiple jobs running at the same time. This will help us speed up build
time.
