### PR TITLE
(QENG-1558) Update facter config to use json to enable CI of AIO

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,0 +1,4 @@
+{
+  "url": "git://github.com/puppetlabs/facter",
+  "ref": "origin/master"
+}

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -1,9 +1,7 @@
 component "facter" do |pkg, settings, platform|
-  pkg.version "2.2.0.2"
-  pkg.md5sum "fcf9600d3656f0c455784b1659439ff8"
-  pkg.url "http://builds.puppetlabs.lan/pe-facter/2.2.0.2/repos/pe-facter-2.2.0.2.tar.gz"
+  pkg.load_from_json('configs/components/facter.json')
 
-  pkg.build_requires "ruby"
+  pkg.build_requires 'ruby'
 
   pkg.install do
     ["#{settings[:bindir]}/ruby install.rb --sitelibdir=#{settings[:ruby_vendordir]} --quick --man --mandir=#{settings[:mandir]}"]


### PR DESCRIPTION
In order for CI to be able to update the facter version cleanly, this
commit updates the config to load the git source information from a json
file instead of from the facter.rb config. It also includes a style
fixup to replace double quotes with single quotes.
