### PR TITLE
use ssh protocol for private repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '0.1.0', :github => 'puppetlabs/vanagon', :branch => 'master'
+gem 'vanagon', '~> 0.1', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+gem 'packaging', '0.4.0', :github => 'puppetlabs/packaging', :tag => '0.4.0'


### PR DESCRIPTION
The github option uses the git protocol which doesn't work from private repos like vanagon.
