### PR TITLE
(RE-3688) Mark configfiles for puppet, mcollective, hiera

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -9,4 +9,6 @@ component "hiera" do |pkg, settings, platform|
   pkg.install do
     ["#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"]
   end
+
+  pkg.configfile File.join(settings[:sysconfdir], 'hiera.yaml')
 end

--- a/configs/components/mcollective.rb
+++ b/configs/components/mcollective.rb
@@ -23,6 +23,10 @@ component "mcollective" do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{settings[:bindir]}/ruby install.rb --plugindir=#{settings[:prefix]}/mcollective/plugins --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"]
+    ["#{settings[:bindir]}/ruby install.rb --plugindir=#{settings[:prefix]}/mcollective/plugins --configdir=#{File.join(settings[:sysconfdir], 'mcollective')} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"]
   end
+
+  pkg.configfile File.join(settings[:sysconfdir], 'mcollective', 'client.cfg')
+  pkg.configfile File.join(settings[:sysconfdir], 'mcollective', 'server.cfg')
+  pkg.configfile "/etc/logrotate.d/mcollective"
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -28,6 +28,13 @@ component "puppet" do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"]
+    [
+      "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}",
+      "touch #{File.join(settings[:sysconfdir], 'puppet.conf')}"
+    ]
   end
+
+  pkg.configfile File.join(settings[:sysconfdir], 'puppet.conf')
+  pkg.configfile File.join(settings[:sysconfdir], 'auth.conf')
+  pkg.configfile "/etc/logrotate.d/puppet"
 end


### PR DESCRIPTION
This commit marks the configfiles from puppet, mcollective and hiera to
ensure that they are handled correctly on upgrades for the puppet-agent
package.
