### PR TITLE
(RE-3718) Add ffi and libffi to puppet-agent

### DIFF
--- a/configs/components/libffi.rb
+++ b/configs/components/libffi.rb
@@ -1,0 +1,17 @@
+component "libffi" do |pkg, settings, platform|
+  pkg.version "3.2.1"
+  pkg.md5sum "83b89587607e3eb65c70d361f13bab43"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/libffi-#{pkg.get_version}.tar.gz"
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]} --disable-static"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,0 +1,11 @@
+component "rubygem-ffi" do |pkg, settings, platform|
+  pkg.version "1.9.6"
+  pkg.md5sum "8606c263037322ae957e1959245841be"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  pkg.install do
+    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri ffi-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -26,6 +26,8 @@ project "puppet-agent" do |proj|
   proj.component "facter"
   unless ( proj.get_platform.is_sles? or proj.get_platform.is_eos? )
     proj.component "cfacter"
+    proj.component "libffi"
+    proj.component "rubygem-ffi"
   end
   proj.component "hiera"
   proj.component "mcollective"


### PR DESCRIPTION
The CFacter ruby library currently has a dependency on the ffi gem, and
libffi. This commit adds both of those dependencies in to make them
available for CFacter.
