### PR TITLE
(RE-3717) Update AIO to use the mcollective 2.8.x branch

### DIFF
--- a/configs/components/mcollective.json
+++ b/configs/components/mcollective.json
@@ -1,0 +1,4 @@
+{
+  "url": "git://github.com/puppetlabs/marionette-collective",
+  "ref": "origin/2.8.x"
+}


### PR DESCRIPTION
This commit updates the mcollective config to use the
mcollective 2.8.x branch, using json loading to specify
the git branch to use. In addition, this updates the mcollective
config to use AIO-specific files from ext/aio.
