### PR TITLE
(RE-3875) Add virt-what to puppet-agent

### DIFF
--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,0 +1,32 @@
+component "virt-what" do |pkg, settings, platform|
+  pkg.version "1.1.4"
+  pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/virt-what-1.14.tar.gz"
+
+  # Run-time requirements
+  unless platform.is_deb?
+    requires "util-linux"
+  end
+  unless ( platform.name =~ /^el-4-.*$/ or platform.name =~ /^sles-(10|11)-.*$/ )
+    requires "dmidecode"
+  end
+  if platform.name =~ /^sles-(10|11)-.*$/
+    requires "pmtools"
+  end
+
+  if platform.is_rpm?
+    pkg.build_requires "util-linux"
+  end
+
+  pkg.configure do
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -41,6 +41,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby-shadow"
   proj.component "ruby-augeas"
   proj.component "openssl"
+  proj.component "virt-what"
 
   proj.directory proj.prefix
   proj.directory proj.sysconfdir


### PR DESCRIPTION
This commit adds virt-what to the AIO puppet-agent.
