### PR TITLE
(RE-3589) Use vendored openssl c_rehash for SLES 10/11

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -51,7 +51,7 @@ component "openssl" do |pkg, settings, platform|
     case platform[:name]
     when /sles-10-.*$/, /sles-11-.*$/
       pkg.install do
-        "pushd '#{settings[:prefix]}/ssl/certs' 2>&1 >/dev/null; find /etc/ssl/certs -type f -a -name '\*pem' -print0 | xargs -0 --no-run-if-empty -n1 ln -sf; /usr/bin/c_rehash ."
+        "pushd '#{settings[:prefix]}/ssl/certs' 2>&1 >/dev/null; find /etc/ssl/certs -type f -a -name '\*pem' -print0 | xargs -0 --no-run-if-empty -n1 ln -sf; #{settings[:prefix]}/bin/c_rehash ."
       end
     when /sles-12-.*$/
       pkg.link '/etc/ssl/ca-bundle.pem', ca_certfile


### PR DESCRIPTION
Prior to this commit, a `gem install` fails with SSL
"certificate verify failed" errors on SLES 10 and 11.
This commit updates the AIO openssl config for SLES
10 and 11 to use the vendored openssl c_rehash
c_rehash instead of the system one.
