### PR TITLE
(RE-3836) Add packaging Rakefile for promotion workflow.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,38 @@
+RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
+
+build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    raise e
+  end
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
+
+  namespace :package do
+ #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+    task :bootstrap do
+      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd File.join(RAKE_ROOT, 'ext') do
+          %x{git clone #{@packaging_url}}
+        end
+      end
+    end
+ #   desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
+    end
+  end
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,2 +1,4 @@
 ---
 project: 'puppet-agent'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'


### PR DESCRIPTION
The current package promotion workflow needs to
bootstrap the packaging repo inside the git bundle that
has been transferred to the signing server.

This commit adds a Rakefile that bootstraps the packaging repo.
