### PR TITLE
(PUP-3809) Update puppet-agent for config/code separation

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -5,8 +5,8 @@ component "hiera" do |pkg, settings, platform|
   pkg.build_requires "rubygem-deep-merge"
 
   pkg.install do
-    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
-  pkg.configfile File.join(settings[:sysconfdir], 'hiera.yaml')
+  pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -25,13 +25,15 @@ component "puppet" do |pkg, settings, platform|
   end
 
   pkg.install do
-    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    "#{settings[:bindir]}/ruby install.rb --puppetdir=#{settings[:puppetdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
-  pkg.configfile File.join(settings[:sysconfdir], 'puppet.conf')
-  pkg.configfile File.join(settings[:sysconfdir], 'auth.conf')
+  pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
+  pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
   pkg.configfile "/etc/logrotate.d/puppet"
 
   pkg.directory File.join(settings[:prefix], 'cache'), mode: '0750'
-  pkg.directory File.join(settings[:sysconfdir], 'ssl'), mode: '0750'
+  pkg.directory File.join(settings[:puppetdir], 'ssl'), mode: '0750'
+  pkg.directory settings[:puppet_configdir]
+  pkg.directory settings[:puppet_codedir]
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -2,6 +2,9 @@ project "puppet-agent" do |proj|
   # Project level settings our components will care about
   proj.setting(:prefix, "/opt/puppetlabs/agent")
   proj.setting(:sysconfdir, "/etc/puppetlabs/agent")
+  proj.setting(:puppetdir, proj.sysconfdir)
+  proj.setting(:puppet_configdir, File.join(proj.puppetdir, 'config'))
+  proj.setting(:puppet_codedir, File.join(proj.puppetdir, 'code'))
   proj.setting(:logdir, "/var/log/puppetlabs/agent")
   proj.setting(:piddir, "/var/run/puppetlabs/agent")
   proj.setting(:bindir, File.join(proj.prefix, "bin"))


### PR DESCRIPTION
This commit updates puppet, hiera and the puppet-agent project to use
the new codedir and configdir for files. Specifically, puppet.conf and
auth.conf are moved to configdir (/etc/puppetlabs/agent/config), and
hiera.yaml is moved to codedir (/etc/puppetlabs/agent/code). Three new
project level settings are added, puppetdir, puppet_configdir, and
puppet_codedir and are also referenced in the resulting component
changes.
