### PR TITLE
(maint) Ensure we use our ruby

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -10,7 +10,8 @@ component "cfacter" do |pkg, settings, platform|
   pkg.build_requires "pl-libyaml-cpp-devel"
 
   pkg.configure do
-    ["/opt/pl-build-tools/bin/cmake \
+    ["PATH=#{settings[:bindir]}:$$PATH \
+          /opt/pl-build-tools/bin/cmake \
           -DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \


### PR DESCRIPTION
Prior to this commit, we were using the system ruby to build cfacter.
Unfortunatley, this means that on most systems, we weren't using a
version of ruby that was recent enough. This commit ensures that we find
and use our ruby, which is definitely at a high enough version
