### PR TITLE
(RE-3884) Enable building of AIO on SLES targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output/*
 .bundle
 Gemfile.lock
 Gemfile.local
+*.log

--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -5,10 +5,19 @@ component "cfacter" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "pl-gcc"
   pkg.build_requires "pl-cmake"
-  pkg.build_requires "pl-libboost-static"
-  pkg.build_requires "pl-libboost-devel"
-  pkg.build_requires "pl-libyaml-cpp-static"
-  pkg.build_requires "pl-libyaml-cpp-devel"
+
+  # SLES uses vanagon built pl-build-tools
+  if  platform.is_sles?
+    pkg.build_requires "pl-boost"
+    pkg.build_requires "pl-yaml-cpp"
+  else
+    # these are from the pl-depdenncy repo
+    pkg.build_requires "pl-libboost-static"
+    pkg.build_requires "pl-libboost-devel"
+    pkg.build_requires "pl-libyaml-cpp-static"
+    pkg.build_requires "pl-libyaml-cpp-devel"
+  end
+
 
   pkg.configure do
     ["PATH=#{settings[:bindir]}:$$PATH \

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -4,8 +4,14 @@ component "rubygem-ffi" do |pkg, settings, platform|
   pkg.url "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
+  if platform.is_sles? and platform.os_version == '10'
+    # The version of make on SLES 10 is too old to work with gem install ffi,
+    # so we built our own new one
+    pkg.build_requires "pl-make"
+  end
 
   pkg.install do
-    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri ffi-#{pkg.get_version}.gem"]
+    [ "export PATH=/opt/pl-build-tools/bin:$$PATH",
+      "#{settings[:bindir]}/gem install --no-rdoc --no-ri ffi-#{pkg.get_version}.gem"]
   end
 end

--- a/configs/platforms/sles-10-i386.rb
+++ b/configs/platforms/sles-10-i386.rb
@@ -3,7 +3,8 @@ platform "sles-10-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "zypper install -y autoconf automake createrepo rsync gcc make"
-  plat.install_build_dependencies_with "zypper install -y"
+  plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/10/i386/pl-build-tools-sles-10-i386.repo"
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vcloud_name "sles-10-i386"
 end

--- a/configs/platforms/sles-10-x86_64.rb
+++ b/configs/platforms/sles-10-x86_64.rb
@@ -3,7 +3,8 @@ platform "sles-10-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "zypper install -y autoconf automake createrepo rsync gcc make"
-  plat.install_build_dependencies_with "zypper install -y"
+  plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/10/x86_64/pl-build-tools-sles-10-x86_64.repo"
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vcloud_name "sles-10-x86_64"
 end

--- a/configs/platforms/sles-11-i386.rb
+++ b/configs/platforms/sles-11-i386.rb
@@ -3,7 +3,8 @@ platform "sles-11-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "zypper install -y autoconf automake createrepo rsync gcc make"
-  plat.install_build_dependencies_with "zypper install -y"
+  plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/i386/pl-build-tools-sles-11-i386.repo"
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vcloud_name "sles-11-i386"
 end

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -3,7 +3,9 @@ platform "sles-11-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "zypper install -y autoconf automake createrepo rsync gcc make"
-  plat.install_build_dependencies_with "zypper install -y"
+  plat.zypper_repo "http://osmirror.delivery.puppetlabs.net/sles-11-deps-x86_64/sles-11-deps-x86_64.repo"
+  plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vcloud_name "sles-11-x86_64"
 end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -3,7 +3,8 @@ platform "sles-12-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "zypper install -y autoconf automake createrepo rsync gcc make rpm-build"
-  plat.install_build_dependencies_with "zypper install -y"
+  plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/12/x86_64/pl-build-tools-sles-12-x86_64.repo"
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make rpm-build"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
   plat.vcloud_name "sles-12-x86_64"
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -27,7 +27,7 @@ project "puppet-agent" do |proj|
   # First our stuff
   proj.component "puppet"
   proj.component "facter"
-  unless ( proj.get_platform.is_sles? or proj.get_platform.is_eos? )
+  unless ( proj.get_platform.is_eos? or proj.get_platform.is_nxos? )
     proj.component "cfacter"
     proj.component "libffi"
     proj.component "rubygem-ffi"


### PR DESCRIPTION
This change set includes all required changes to have SLES 10, 11 and 12
build for i386 and x86_64. The primary changes are the build_requires
package names for cfacter (since the build tools are vanagon generated
for SLES) and updating of the sles platform definitions to include the
build tools repositories.

rubygem-ffi also adds the build_requires of pl-make on SLES 10, as that
make is too old to work with rubygems in this case.
