### PR TITLE
(RE-3491) Add replaces declarations for mco, facter, hiera, puppet

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -3,6 +3,8 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires 'ruby'
 
+  pkg.replaces 'facter'
+
   pkg.install do
     ["#{settings[:bindir]}/ruby install.rb --sitelibdir=#{settings[:ruby_vendordir]} --quick --man --mandir=#{settings[:mandir]}"]
   end

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -4,6 +4,8 @@ component "hiera" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "rubygem-deep-merge"
 
+  pkg.replaces 'hiera'
+
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end

--- a/configs/components/mcollective.rb
+++ b/configs/components/mcollective.rb
@@ -4,6 +4,14 @@ component "mcollective" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "ruby-stomp"
 
+  pkg.replaces 'mcollective'
+  pkg.replaces 'mcollective-common'
+  pkg.replaces 'mcollective-client'
+
+  if platform.is_deb?
+    pkg.replaces 'mcollective-doc'
+  end
+
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/aio/redhat/mcollective.service", "ext/aio/redhat/mcollective.sysconfig"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -5,6 +5,12 @@ component "puppet" do |pkg, settings, platform|
   pkg.build_requires "facter"
   pkg.build_requires "hiera"
 
+  pkg.replaces 'puppet'
+
+  if platform.is_deb?
+    pkg.replaces 'puppet-common'
+  end
+
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/systemd/puppet.service", "ext/redhat/client.sysconfig"


### PR DESCRIPTION
This commit adds replaces calls for mcollective, facter, hiera, and
puppet, which will enforce that those packages are removed upon
installation of the puppet-agent package and avoid conflicts with
logrotate, sysconfig, and service files.
