### PR TITLE
(maint) Roll back some changes for integration

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -7,8 +7,8 @@ component "hiera" do |pkg, settings, platform|
   pkg.replaces 'hiera'
 
   pkg.install do
-    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
-  pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
+  pkg.configfile File.join(settings[:sysconfdir], 'hiera.yaml')
 end

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,4 +1,4 @@
 {
-  "url": "git://github.com/nwolfe/puppet",
-  "ref": "pup3809-separate-code-conf-dirs"
+  "url": "git://github.com/puppetlabs/puppet",
+  "ref": "origin/master"
 }

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -31,15 +31,19 @@ component "puppet" do |pkg, settings, platform|
   end
 
   pkg.install do
-    "#{settings[:bindir]}/ruby install.rb --puppetdir=#{settings[:puppetdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    ["#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:sysconfdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}",
+    "mkdir -p #{settings[:sysconfdir]}",
+    "touch #{settings[:sysconfdir]}/puppet.conf",
+    ]
+
   end
 
-  pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
-  pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
+  pkg.configfile File.join(settings[:sysconfdir], 'puppet.conf')
+  pkg.configfile File.join(settings[:sysconfdir], 'auth.conf')
   pkg.configfile "/etc/logrotate.d/puppet"
 
   pkg.directory File.join(settings[:prefix], 'cache'), mode: '0750'
-  pkg.directory File.join(settings[:puppetdir], 'ssl'), mode: '0750'
+  pkg.directory File.join(settings[:sysconfdir], 'ssl'), mode: '0750'
   pkg.directory settings[:puppet_configdir]
   pkg.directory settings[:puppet_codedir]
 end


### PR DESCRIPTION
This commit rolls back some of the code/config separation changes in
order to enable a functional agent package for the puppetserver to run
alongside to test the agent package against. Once built, this can be
reverted.
