### PR TITLE
Reapply confdir/vardir patch

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -11,6 +11,9 @@ component "puppet" do |pkg, settings, platform|
     pkg.replaces 'puppet-common'
   end
 
+  # Patches Puppet to use /opt/puppetlabs/agent and ../cache as conf_dir and var_dir.
+  pkg.apply_patch "resources/patches/puppet/update_confdir_vardir_in_puppet.patch"
+
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/systemd/puppet.service", "ext/redhat/client.sysconfig"

--- a/resources/patches/puppet/update_confdir_vardir_in_puppet.patch
+++ b/resources/patches/puppet/update_confdir_vardir_in_puppet.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/puppet/util/run_mode.rb b/lib/puppet/util/run_mode.rb
+index 9a736fb..4d70d26 100644
+--- a/lib/puppet/util/run_mode.rb
++++ b/lib/puppet/util/run_mode.rb
+@@ -55,11 +55,11 @@ module Puppet
+ 
+     class UnixRunMode < RunMode
+       def conf_dir
+-        which_dir("/etc/puppet", "~/.puppet")
++        which_dir("/etc/puppetlabs/agent", "~/.puppet")
+       end
+ 
+       def var_dir
+-        which_dir("/var/lib/puppet", "~/.puppet/var")
++        which_dir("/opt/puppetlabs/agent/cache", "~/.puppet/var")
+       end
+     end
+ 


### PR DESCRIPTION
In order to ensure the server can handle ssl requests correctly, this
old patch needs to be reapplied. It is not present in master and is
required to support the layout changes already present in puppet-agent.
