### PR TITLE
(RE-3623) Add NXOS support to the AIO

### DIFF
--- a/configs/platforms/nxos-1-x86_64.rb
+++ b/configs/platforms/nxos-1-x86_64.rb
@@ -1,0 +1,9 @@
+platform "nxos-1-x86_64" do |plat|
+  plat.servicedir "/etc/rc.d/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+  plat.provision_with "echo"
+  plat.install_build_dependencies_with "echo "
+  plat.docker_image "nxos_base_image"
+  plat.ssh_port 2222
+end


### PR DESCRIPTION
This adds a platform definition for Cisco's NXOS. Right now this is the
only platform definition using docker by default. Additionally, it
doesn't need to be in any automated pipelines yet.

For information about the docker repo to get the nxos stuff, see:

https://github.com/puppetlabs/nxos-docker
