### PR TITLE
(maint) parse JSON output from vmpooler

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -32,8 +32,11 @@ ssh_key = ENV['VANAGON_SSH_KEY'] ? "-i #{ENV['VANAGON_SSH_KEY']}" : ''
 
 
 # Retrieve a vm
-curl_output=`curl -d --url http://vmpooler.delivery.puppetlabs.net/vm/win-2012-x86_64`
-hostname = /\"hostname\": \"(.*)\"/.match(curl_output)[1]
+vm_type = 'win-2012-x86_64'
+curl_output=`curl -d --url http://vmpooler.delivery.puppetlabs.net/vm/#{vm_type}`
+host_json = JSON.parse(curl_output)
+hostname = host_json[vm_type]['hostname'] + '.' + host_json['domain']
+puts "Acquired #{vm_type} VM from pooler at #{hostname}"
 
 # Set up the environment so I don't keep crying
 ssh_env = "export PATH=\'/cygdrive/c/tools/ruby215/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"


### PR DESCRIPTION
- Use FQDN of host instead of just the hostname, to allow this to work
  in environments (such as local VMs or over the VPN), that may not be
  able to resolve hostnames
