### PR TITLE
(RE-3836) Add build_defaults.yaml for puppet-agent promotion

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,3 +2,10 @@
 project: 'puppet-agent'
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
+gpg_name: 'info@puppetlabs.com'
+gpg_key: '4BD6EC30'
+deb_targets: 'trusty-i386 trusty-amd64'
+rpm_targets: 'el-6-i386 el-6-x86_64 el-7-x86_64'
+sign_tar: FALSE
+vanagon_project: TRUE
+build_pe: TRUE


### PR DESCRIPTION
This commit adds a minimal build_defaults.yaml to allow use
of existing package promotion automation.
