### PR TITLE
Rename paths based on latest AIO definitions

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -31,7 +31,7 @@ component "puppet" do |pkg, settings, platform|
   end
 
   pkg.install do
-    "#{settings[:bindir]}/ruby install.rb --puppetdir=#{settings[:puppetdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_configdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
   pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
@@ -39,7 +39,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.configfile "/etc/logrotate.d/puppet"
 
   pkg.directory File.join(settings[:prefix], 'cache'), mode: '0750'
-  pkg.directory File.join(settings[:puppetdir], 'ssl'), mode: '0750'
+  pkg.directory File.join(settings[:puppet_configdir], 'ssl'), mode: '0750'
   pkg.directory settings[:puppet_configdir]
   pkg.directory settings[:puppet_codedir]
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,10 +1,9 @@
 project "puppet-agent" do |proj|
   # Project level settings our components will care about
   proj.setting(:prefix, "/opt/puppetlabs/puppet")
-  proj.setting(:sysconfdir, "/etc/puppetlabs/agent")
-  proj.setting(:puppetdir, proj.sysconfdir)
-  proj.setting(:puppet_configdir, File.join(proj.puppetdir, 'config'))
-  proj.setting(:puppet_codedir, File.join(proj.puppetdir, 'code'))
+  proj.setting(:sysconfdir, "/etc/puppetlabs/puppet")
+  proj.setting(:puppet_configdir, proj.sysconfdir)
+  proj.setting(:puppet_codedir, "/etc/puppetlabs/code")
   proj.setting(:logdir, "/var/log/puppetlabs/agent")
   proj.setting(:piddir, "/var/run/puppetlabs/agent")
   proj.setting(:bindir, File.join(proj.prefix, "bin"))


### PR DESCRIPTION
These commits change the `prefix` from `/opt/puppetlabs/agent/bin` to `/opt/puppetlabs/puppet/bin`, `sysconfdir` from `/etc/puppetlabs/agent` to `/etc/puppetlabs/puppet` (and becomes the same as `puppet_configdir`). The `puppet_codedir` changes from `/etc/puppetlabs/agent/code` to `/etc/puppetlabs/code`. In the process, the `puppetdir` is removed, and the invocation of `install.rb` uses `--configdir`.

Note that merging this will break the current AIO pipeline as it is still using the old versions too, e.g. [`/etc/puppetlabs/agent`](https://github.com/puppetlabs/puppet/blob/aio/lib/puppet/util/run_mode.rb#L66)
