### PR TITLE
(RE-3997) Patch puppet-agent Ruby for libyaml CVE-2014-9130

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -3,6 +3,8 @@ component "ruby" do |pkg, settings, platform|
   pkg.md5sum "df4c1b23f624a50513c7a78cb51a13dc"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-2.1.5.tar.gz"
 
+  pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
+
   pkg.build_requires "openssl"
 
   if platform.is_deb?

--- a/resources/patches/ruby/libyaml_cve-2014-9130.patch
+++ b/resources/patches/ruby/libyaml_cve-2014-9130.patch
@@ -1,0 +1,18 @@
+diff --git a/ext/psych/yaml/scanner.c b/ext/psych/yaml/scanner.c
+index af05766..965bdeb 100644
+--- a/ext/psych/yaml/scanner.c
++++ b/ext/psych/yaml/scanner.c
+@@ -1106,13 +1106,6 @@ yaml_parser_save_simple_key(yaml_parser_t *parser)
+             && parser->indent == (ptrdiff_t)parser->mark.column);
+ 
+     /*
+-     * A simple key is required only when it is the first token in the current
+-     * line.  Therefore it is always allowed.  But we add a check anyway.
+-     */
+-
+-    assert(parser->simple_key_allowed || !required);    /* Impossible. */
+-
+-    /*
+      * If the current position may start a simple key, save it.
+      */
+ 


### PR DESCRIPTION
This commit adds a patch for libyaml CVE-2014-9130 and updates
the puppet-agent Ruby component config to apply the patch.
