### PR TITLE
(RE-1926) Add net-ssh component to puppet-agent

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,0 +1,11 @@
+component "rubygem-net-ssh" do |pkg, settings, platform|
+  pkg.version "2.1.4"
+  pkg.md5sum "797c9a7a9e25c781cbf6b77a0054bb2e"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  pkg.install do
+    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri net-ssh-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -37,6 +37,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby"
   proj.component "ruby-stomp"
   proj.component "rubygem-deep-merge"
+  proj.component "rubygem-net-ssh"
   proj.component "ruby-selinux"
   proj.component "ruby-shadow"
   proj.component "ruby-augeas"


### PR DESCRIPTION
This commit adds the 'net-ssh' rubygem to the AIO puppet-agent.
