### PR TITLE
(RE-4016) Set libruby install location for cfacter

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -27,6 +27,7 @@ component "cfacter" do |pkg, settings, platform|
           -DBOOST_STATIC=ON \
           -DYAMLCPP_STATIC=ON \
           -DFACTER_PATH=#{settings[:bindir]} \
+          -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{settings[:bindir]}/ruby -rrbconfig -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
           ."]
   end
 

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -17,6 +17,7 @@ component "ruby" do |pkg, settings, platform|
     ["./configure \
         --prefix=#{settings[:prefix]} \
         --with-opt-dir=#{settings[:prefix]} \
+        --enable-shared \
         --disable-install-rdoc"]
   end
 


### PR DESCRIPTION
Enable building a dynamic library for Ruby, as required by cfacter.

Without this change cfacter uses its default search for libruby, which
involves querying the first Ruby that's found on the PATH. To avoid PATH
lookup of Ruby - which might find a different Ruby binary than ours -
and make cfacter a little faster in AIO, hard-code the install path at
compile time.
