### PR TITLE
(maint) CFacter.ps1 build script url incorrect

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -63,7 +63,7 @@ Kernel.system("#{ssh_command} 'source .bash_profile ; echo $PATH'")
 # Download and execute the cfacter build script
 # this script lives in the puppetlabs/cfacter repo
 cfacter_build_script = CFACTER['url'].sub('git://github.com','https://raw.githubusercontent.com') +
-  CFACTER['ref'].sub('origin/','') + '/contrib/cfacter.ps1'
+  '/' + CFACTER['ref'].sub('origin/','') + '/contrib/cfacter.ps1'
 result = Kernel.system("#{ssh_command} \"curl -O #{cfacter_build_script} && powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./cfacter.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE} -cfacterRef #{CFACTER['ref']} -cfacterFork #{CFACTER['url']}\"")
 fail "It looks like the cfacter build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
 


### PR DESCRIPTION
- When refactoring the url for legibility in
  https://github.com/Iristyle/puppet-agent/commit/426c058 a slash
  was missed in the url
