### PR TITLE
(maint) ensure relative symlinks for MSIs

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -126,12 +126,13 @@ fail "It seems there were some issues building the puppet-agent msi" unless resu
 
 # Fetch back the built installer
 FileUtils.mkdir_p("output/windows")
-Kernel.system("scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/pkg/puppet-agent-#{AGENT_VERSION_STRING}-#{ARCH}.msi output/windows/")
+msi_file = "puppet-agent-#{AGENT_VERSION_STRING}-#{ARCH}.msi"
+Kernel.system("scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/pkg/#{msi_file} output/windows/")
 
 # delete a vm only if we successfully brought back the msi
-msi_path = "output/windows/puppet-agent-#{AGENT_VERSION_STRING}-#{ARCH}.msi"
+msi_path = "output/windows/#{msi_file}"
 if File.exists?(msi_path)
-  FileUtils.ln_s(msi_path, "output/windows/puppet-agent-#{ARCH}.msi")
+  FileUtils.ln_s("./#{msi_file}", "output/windows/puppet-agent-#{ARCH}.msi")
   Kernel.system("curl -X DELETE --url \"http://vmpooler.delivery.puppetlabs.net/vm/#{hostname}\"")
   FileUtils.rm 'winconfig.yaml'
 end


### PR DESCRIPTION
- In the prior revision of this code, the symlinks being generated
  were broken.  To properly RSYNC using --links, the symlinks must be
  relative and not absolute.
  
  This commit represents the desired behavior:
  
  irb(main):001:0> require 'FileUtils'
  => true
  irb(main):002:0> FileUtils.ln_s('./foo.txt', 'nested/bar.txt')
  => 0
  irb(main):003:0> exit
  
  [test] cat nested/foo.txt
  nested
  
  [test] cat nested/bar.txt
  nested
  
  [test] ls -rtaFl nested
  total 16
  drwxr-xr-x+ 6 Iristyle  staff  204 Feb 18 19:42 ../
  -rw-r--r--+ 1 Iristyle  staff    7 Feb 18 19:42 foo.txt
  lrwxr-xr-x  1 Iristyle  staff    9 Feb 18 19:49 bar.txt@ -> ./foo.txt
  drwxr-xr-x+ 4 Iristyle  staff  136 Feb 18 19:49 ./
