### PR TITLE
(maint) Create hard link to avoid chattr issues later

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -132,7 +132,7 @@ Kernel.system("scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/pupp
 # delete a vm only if we successfully brought back the msi
 msi_path = "output/windows/#{msi_file}"
 if File.exists?(msi_path)
-  FileUtils.ln_s("./#{msi_file}", "output/windows/puppet-agent-#{ARCH}.msi")
+  FileUtils.ln("./#{msi_file}", "output/windows/puppet-agent-#{ARCH}.msi")
   Kernel.system("curl -X DELETE --url \"http://vmpooler.delivery.puppetlabs.net/vm/#{hostname}\"")
   FileUtils.rm 'winconfig.yaml'
 end


### PR DESCRIPTION
Previously, we were creating a symlink to the msi, but the ship task
attempts to set the immutable bit on the symlink, which is not
supported.

So just create a hard link instead.
