### PR TITLE
(maint) Update hardlink call to use path, not filename

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -132,7 +132,7 @@ Kernel.system("scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/pupp
 # delete a vm only if we successfully brought back the msi
 msi_path = "output/windows/#{msi_file}"
 if File.exists?(msi_path)
-  FileUtils.ln("./#{msi_file}", "output/windows/puppet-agent-#{ARCH}.msi")
+  FileUtils.ln("./#{msi_path}", "output/windows/puppet-agent-#{ARCH}.msi")
   Kernel.system("curl -X DELETE --url \"http://vmpooler.delivery.puppetlabs.net/vm/#{hostname}\"")
   FileUtils.rm 'winconfig.yaml'
 end


### PR DESCRIPTION
Because of where the ln call is made, the full relative path to the
target msi must be used instead of just the filename, which was
appropriate for a symlink. This commit makes that adjustment to use
msi_path instead of msi_file.
