### PR TITLE
(maint) Don't set build_pe to true in build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -8,4 +8,3 @@ deb_targets: 'trusty-i386 trusty-amd64'
 rpm_targets: 'el-6-i386 el-6-x86_64 el-7-x86_64'
 sign_tar: FALSE
 vanagon_project: TRUE
-build_pe: TRUE


### PR DESCRIPTION
We can't set build_pe to true in build_defaults.yaml, because it will
break deb repo creation, which will expect to find the repos in a pe
derived layout, which won't be the case. This commit removes that
setting from the file until we have a better solution for PE.
