### PR TITLE
(RE-4030) Specify bindir in CFacter configuration

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -26,6 +26,7 @@ component "cfacter" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DBOOST_STATIC=ON \
           -DYAMLCPP_STATIC=ON \
+          -DFACTER_PATH=#{settings[:bindir]} \
           ."]
   end
 


### PR DESCRIPTION
Puppet-Agent builds its own virt-what binary. CFacter doesn't hard-code
the Puppet-Agent install location, and without this change our virt-what
won't be used when resolving virtualization facts in CFacter.

CFacter relies on a compile-time option to specify a path to override
the normal PATH lookup for virt-what. Add the compile-time option when
building CFacter.
