### PR TITLE
(maint) Don't own/create ssldir in puppet component

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -39,7 +39,6 @@ component "puppet" do |pkg, settings, platform|
   pkg.configfile "/etc/logrotate.d/puppet"
 
   pkg.directory File.join(settings[:prefix], 'cache'), mode: '0750'
-  pkg.directory File.join(settings[:puppet_configdir], 'ssl'), mode: '0750'
   pkg.directory settings[:puppet_configdir]
   pkg.directory settings[:puppet_codedir]
 end


### PR DESCRIPTION
Due to the nature of packages, if the puppet-agent package owns the
ssldir for puppet, it will manage the owner and perms of it whenever the
package is upgraded (at least for rpm). This causes problems with the
puppetserver package, which needs the ssldir to be owned by the puppet
user and group and permissioned differently. This means that whenever
the puppet-agent package is upgraded, the perms/ownership would be
reverted which would break puppetserver. However, there is no need for
the puppet-agent package to create the directory, as it will be created
when the puppet agent starts up.
This commit removes the ssldir creation from the puppet-agent pacakge to
avoid this problem.
