### PR TITLE
(RE-4053) Add missing ruby/openssl dependencies.

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -2,6 +2,7 @@ component "cfacter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/cfacter.json')
 
   pkg.build_requires "ruby"
+  pkg.build_requires "openssl"
   pkg.build_requires "pl-gcc"
   pkg.build_requires "pl-cmake"
 
@@ -10,7 +11,7 @@ component "cfacter" do |pkg, settings, platform|
     pkg.build_requires "pl-boost"
     pkg.build_requires "pl-yaml-cpp"
   else
-    # these are from the pl-depdenncy repo
+    # these are from the pl-dependency repo
     pkg.build_requires "pl-libboost-static"
     pkg.build_requires "pl-libboost-devel"
     pkg.build_requires "pl-libyaml-cpp-static"
@@ -23,11 +24,13 @@ component "cfacter" do |pkg, settings, platform|
           /opt/pl-build-tools/bin/cmake \
           -DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DBOOST_STATIC=ON \
           -DYAMLCPP_STATIC=ON \
           -DFACTER_PATH=#{settings[:bindir]} \
           -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{settings[:bindir]}/ruby -rrbconfig -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
+          -DWITHOUT_CURL=ON \
           ."]
   end
 


### PR DESCRIPTION
CFacter has a build dependency on OpenSSL that wasn't declared, and
was picking up the system OpenSSL.

Add the dependency to cfacter and specify CMAKE_PREFIX_PATH so build
dependencies will be picked up by cmake. Also explicitly disable linking
libcurl, as we don't have our own build of libcurl and trying to link
the system libcurl would fail due to a conflict with our openssl lib.
