### PR TITLE
DO NOT MERGE Add a project-wide mirror_url for sources

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,7 +1,7 @@
 component 'augeas' do |pkg, settings, platform|
   pkg.version '1.3.0'
   pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:mirror_url]}#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -1,7 +1,7 @@
 component "openssl" do |pkg, settings, platform|
   pkg.version "1.0.0q"
   pkg.md5sum "8cafccab6f05e8048148e5c282ed5402"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:mirror_url]}openssl-#{pkg.get_version}.tar.gz"
 
   ca_certfile = File.join(settings[:prefix], 'ssl', 'cert.pem')
 

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -1,7 +1,7 @@
 component "ruby-augeas" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-augeas-0.5.0.tgz"
+  pkg.url "#{settings[:mirror_url]}ruby-augeas-0.5.0.tgz"
 
   pkg.build_requires "ruby"
   pkg.build_requires "augeas"

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -9,7 +9,7 @@ if platform.name =~ /^el-(5|6|7)-.*/
       pkg.md5sum "f814c71fca5a85ebfeb81b57afed59db"
     end
 
-    pkg.url "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
+    pkg.url "#{settings[:mirror_url]}libselinux-#{pkg.get_version}.tgz"
 
     pkg.build_requires "ruby"
     pkg.build_requires "swig"

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -1,7 +1,7 @@
 component "ruby-shadow" do |pkg, settings, platform|
   pkg.version "2.3.3"
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.3.3.tar.gz"
+  pkg.url "#{settings[:mirror_url]}ruby-shadow-2.3.3.tar.gz"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -1,7 +1,7 @@
 component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.3.3"
   pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.gem"
+  pkg.url "#{settings[:mirror_url]}stomp-1.3.3.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,7 +1,7 @@
 component "ruby" do |pkg, settings, platform|
   pkg.version "2.1.5"
   pkg.md5sum "df4c1b23f624a50513c7a78cb51a13dc"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-2.1.5.tar.gz"
+  pkg.url "#{settings[:mirror_url]}ruby-2.1.5.tar.gz"
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -1,7 +1,7 @@
 component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.version "1.0.0"
   pkg.md5sum "4bff008be5605bd6fb687a6e33c028e0"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/deep_merge-1.0.0.gem"
+  pkg.url "#{settings[:mirror_url]}deep_merge-1.0.0.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,7 +1,7 @@
 component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version "2.1.4"
   pkg.md5sum "797c9a7a9e25c781cbf6b77a0054bb2e"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
+  pkg.url "#{settings[:mirror_url]}net-ssh-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,7 +1,7 @@
 component "virt-what" do |pkg, settings, platform|
   pkg.version "1.1.4"
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/virt-what-1.14.tar.gz"
+  pkg.url "#{settings[:mirror_url]}virt-what-1.14.tar.gz"
 
   # Run-time requirements
   unless platform.is_deb?

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -12,6 +12,7 @@ project "puppet-agent" do |proj|
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
+  proj.setting(:mirror_url, "http://buildsources.delivery.puppetlabs.net/")
 
   proj.description "The Puppet Agent package contains all of the elements needed to run puppet, including ruby, facter, hiera and mcollective."
   proj.version_from_git


### PR DESCRIPTION
@haus I realize this wasn't what you originally suggested, but what are your thoughts on adding this as a project config option?

This allows users to easily change the url to a sources mirror of
their choosing.
