### PR TITLE
(maint) Ensure wget installed before using

### DIFF
--- a/configs/platforms/debian-6-amd64.rb
+++ b/configs/platforms/debian-6-amd64.rb
@@ -4,7 +4,8 @@ platform "debian-6-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "squeeze"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb;dpkg -i pl-build-tools-release-squeeze.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-6-x86_64"
 end

--- a/configs/platforms/debian-6-i386.rb
+++ b/configs/platforms/debian-6-i386.rb
@@ -4,7 +4,8 @@ platform "debian-6-i386" do |plat|
   plat.servicetype "sysv"
   plat.codename "squeeze"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb;dpkg -i pl-build-tools-release-squeeze.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-6-i386"
 end

--- a/configs/platforms/debian-7-amd64.rb
+++ b/configs/platforms/debian-7-amd64.rb
@@ -4,7 +4,8 @@ platform "debian-7-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "wheezy"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb;dpkg -i pl-build-tools-release-wheezy.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-7-x86_64"
 end

--- a/configs/platforms/debian-7-i386.rb
+++ b/configs/platforms/debian-7-i386.rb
@@ -4,7 +4,8 @@ platform "debian-7-i386" do |plat|
   plat.servicetype "sysv"
   plat.codename "wheezy"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb;dpkg -i pl-build-tools-release-wheezy.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-7-i386"
 end

--- a/configs/platforms/ubuntu-10.04-amd64.rb
+++ b/configs/platforms/ubuntu-10.04-amd64.rb
@@ -4,7 +4,8 @@ platform "ubuntu-10.04-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "lucid"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb;dpkg -i pl-build-tools-release-lucid.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1004-x86_64"
 end

--- a/configs/platforms/ubuntu-10.04-i386.rb
+++ b/configs/platforms/ubuntu-10.04-i386.rb
@@ -4,7 +4,8 @@ platform "ubuntu-10.04-i386" do |plat|
   plat.servicetype "sysv"
   plat.codename "lucid"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb;dpkg -i pl-build-tools-release-lucid.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1004-i386"
 end

--- a/configs/platforms/ubuntu-12.04-amd64.rb
+++ b/configs/platforms/ubuntu-12.04-amd64.rb
@@ -4,7 +4,8 @@ platform "ubuntu-12.04-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "precise"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb;dpkg -i pl-build-tools-release-precise.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1204-x86_64"
 end

--- a/configs/platforms/ubuntu-12.04-i386.rb
+++ b/configs/platforms/ubuntu-12.04-i386.rb
@@ -4,7 +4,8 @@ platform "ubuntu-12.04-i386" do |plat|
   plat.servicetype "sysv"
   plat.codename "precise"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb;dpkg -i pl-build-tools-release-precise.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1204-i386"
 end

--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -4,7 +4,8 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "trusty"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb;dpkg -i pl-build-tools-release-trusty.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1404-x86_64"
 end

--- a/configs/platforms/ubuntu-14.04-i386.rb
+++ b/configs/platforms/ubuntu-14.04-i386.rb
@@ -4,7 +4,8 @@ platform "ubuntu-14.04-i386" do |plat|
   plat.servicetype "sysv"
   plat.codename "trusty"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; wget http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb;dpkg -i pl-build-tools-release-trusty.deb;apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "ubuntu-1404-i386"
 end


### PR DESCRIPTION
The debian and ubuntu platforms use wget to retrieve repo configuration.
Without this change, the machines may not have wget installed; this is
most likely to occur with Vanagon's docker adapter.

Install wget before using it on the platforms that use it in their
configuration.
