### PR TITLE
(RE-4061) Build AIO w/ cfacter for Debian Jessie/testing

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -5,8 +5,8 @@ component "cfacter" do |pkg, settings, platform|
   pkg.build_requires "pl-gcc"
   pkg.build_requires "pl-cmake"
 
-  # SLES uses vanagon built pl-build-tools
-  if  platform.is_sles?
+  # SLES and Debian 8 uses vanagon built pl-build-tools
+  if platform.is_sles? or (platform.is_deb? and platform.os_version >= 8)
     pkg.build_requires "pl-boost"
     pkg.build_requires "pl-yaml-cpp"
   else

--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -1,0 +1,11 @@
+platform "debian-8-amd64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "sysv"
+  plat.codename "jessie"
+
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-jessie.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vcloud_name "debian-8-x86_64"
+end

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -1,0 +1,11 @@
+platform "debian-8-i386" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "sysv"
+  plat.codename "jessie"
+
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-jessie.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vcloud_name "debian-8-i386"
+end


### PR DESCRIPTION
  (RE-4061) Build AIO w/ cfacter for Debian Jessie

```
This commit includes platform definitions for Debian 8 (Jessie) and It
also modifies the component build instructions for cfacter to rely upon
the pl-buildtools-vanagon style build chain when doing the later debians
rather than only the pl-deps one.

If you want to build testing, just build Jessie right now and we will be
symlinking the repo targets after shipment.
```
