### PR TITLE
(RE-4056) Use installed Git rather than Cygwin git

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -48,7 +48,7 @@ puts "Acquired #{vm_type} VM from pooler at #{hostname}"
 
 # Set up the environment so I don't keep crying
 ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no Administrator@#{hostname}"
-ssh_env = "export PATH=\'/cygdrive/c/tools/ruby215/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
+ssh_env = "export PATH=\'/cygdrive/c/Program Files (x86)/Git/cmd:/cygdrive/c/tools/ruby215/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
 
 result = Kernel.system("#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")
 fail "Unable to connect to the host. Is is possible that you aren't on VPN or connected to the internal PL network?" unless result


### PR DESCRIPTION
- This glue script currently uses the CFacter script to setup an
  appropriate environment.  This is done inside of a PowerShell session
  whose lifetime ends when the CFacter native bits are built.
  
  The intent was also to leverage the Git installed during that process
  but the PATH changes made inside of CFacter.ps1 are not reflected
  in the local machine SSH sessions properly due to the SSH server
  not being restarted.
  
  To workaround this particular issue, prepend to the .bash_profile,
  the installation path of Git that was installed during the CFacter
  build.
  
  The newer git should also help to resolve intermittent issues with
  cloning the puppet-win32-ruby repository which contains binaries,
  as the installed Git is 1.9.5, whereas the default Git for Cygwin
  is 1.7.9
