### PR TITLE
(maint) Remove puppet logrotate from puppet-agent

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -24,19 +24,12 @@ component "puppet" do |pkg, settings, platform|
     fail "need to know where to put service files"
   end
 
-  if platform.is_deb?
-    pkg.install_file "ext/debian/puppet.logrotate", "/etc/logrotate.d/puppet"
-  elsif platform.is_rpm?
-    pkg.install_file "ext/redhat/logrotate", "/etc/logrotate.d/puppet"
-  end
-
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_configdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
   pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
   pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
-  pkg.configfile "/etc/logrotate.d/puppet"
 
   pkg.directory File.join(settings[:prefix], 'cache'), mode: '0750'
   pkg.directory settings[:puppet_configdir]


### PR DESCRIPTION
The puppet agent will never log to /var/log/puppetlabs/puppet.log. It
logs by default to syslog, and if it were to be configured to log
somewhere else by the user, we have no idea what that destination would
be. We don't need to logrotate a file that will never exist, so this
commit removes puppet's logrotate rule.
