### PR TITLE
(maint) Relax perms on logdir in puppet-agent

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -47,7 +47,7 @@ project "puppet-agent" do |proj|
 
   proj.directory proj.prefix
   proj.directory proj.sysconfdir
-  proj.directory proj.logdir, mode: "0750"
+  proj.directory proj.logdir
   proj.directory proj.piddir
   proj.directory proj.link_bindir
 


### PR DESCRIPTION
The perms on logdir were inherited from puppet, but they don't need to
be this restrictive. Any components that may be logging sensitive
information can restrict the permissions of their logfiles as needed.
Currently, the puppet agent is not logging to this directory and
mcollective does not log any sensitive information to its logfiles. This
commit relaxes the perms of the logdir to the default of 755.
Additionally, with permissions of 750, other packages such as
puppetserver or puppetdb can't make subdirectories that will be
accessible for their service user (puppet/puppetdb). With permissions of
755, that is not an issue.
