### PR TITLE
(maint) Bump packaging version to 0.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'vanagon', '~> 0.1', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
-gem 'packaging', '0.4.0', :github => 'puppetlabs/packaging', :tag => '0.4.0'
+gem 'packaging', '0.4.1', :github => 'puppetlabs/packaging', :tag => '0.4.1'


### PR DESCRIPTION
Some packaging improvements have been merged with respect to vanagon
based projects, promotion, and shipping. It would be good to pick those
changes up so this commit moves the packaging version forward to get
those changes.
