### PR TITLE
(CPR-149) Add Ubuntu Utopic platforms

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -7,7 +7,8 @@ component "cfacter" do |pkg, settings, platform|
   pkg.build_requires "pl-cmake"
 
   # SLES and Debian 8 uses vanagon built pl-build-tools
-  if platform.is_sles? or (platform.os_name == 'debian' and platform.os_version.to_i >= 8)
+  if platform.is_sles? or (platform.os_name == 'debian' and platform.os_version.to_i >= 8) or
+      platform.name.match(/^ubuntu-14.10-.*$/)
     pkg.build_requires "pl-boost"
     pkg.build_requires "pl-yaml-cpp"
   else

--- a/configs/platforms/ubuntu-14.10-amd64.rb
+++ b/configs/platforms/ubuntu-14.10-amd64.rb
@@ -1,0 +1,11 @@
+platform "ubuntu-14.10-amd64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "sysv"
+  plat.codename "utopic"
+
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-utopic.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vcloud_name "ubuntu-1410-x86_64"
+end

--- a/configs/platforms/ubuntu-14.10-i386.rb
+++ b/configs/platforms/ubuntu-14.10-i386.rb
@@ -1,0 +1,11 @@
+platform "ubuntu-14.10-i386" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "sysv"
+  plat.codename "utopic"
+
+  plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-utopic.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vcloud_name "ubuntu-1410-i386"
+end


### PR DESCRIPTION
This adds Ubuntu 14.10 platform support. Tested by building puppet-agent for both architectures. 
