### PR TITLE
(PUP-4067) Create default manifest and module dirs for production enviro...

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -36,6 +36,8 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory settings[:puppet_codedir]
   pkg.directory File.join(settings[:puppet_codedir], "modules")
   pkg.directory File.join(settings[:prefix], "modules")
+  pkg.directory File.join(settings[:puppet_codedir], 'environments')
+  pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'manifests')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'modules')
 


### PR DESCRIPTION
...nment

This change is needed when running the puppet agent in a masterless
environment.
