### PR TITLE
(PUP-4067) Add environment.conf to production environment

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -40,6 +40,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'manifests')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'modules')
+  pkg.install_configfile 'conf/environment.conf', File.join(settings[:puppet_codedir], 'environments', 'production', 'environment.conf')
 
   pkg.link "#{settings[:bindir]}/puppet", "#{settings[:link_bindir]}/puppet"
 end


### PR DESCRIPTION
This commit adds a well annotated example environment.conf to the
default production environment that is laid down in the puppet-agent
package so that users will be familiar with what options they have to
customize their environments.
