### PR TITLE
(CPR-150) Add Fedora support to AIO Builds

### DIFF
--- a/configs/platforms/fedora-20-i386.rb
+++ b/configs/platforms/fedora-20-i386.rb
@@ -1,0 +1,10 @@
+platform "fedora-20-i386" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign coreutils"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/i386/pl-build-tools-release-20-1.noarch.rpm"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vcloud_name "fedora-20-i386"
+end

--- a/configs/platforms/fedora-20-x86_64.rb
+++ b/configs/platforms/fedora-20-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-20-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign coreutils"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/x86_64/pl-build-tools-release-20-1.noarch.rpm"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vcloud_name "fedora-20-x86_64"
+end

--- a/configs/platforms/fedora-21-i386.rb
+++ b/configs/platforms/fedora-21-i386.rb
@@ -1,0 +1,10 @@
+platform "fedora-21-i386" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/i386/pl-build-tools-release-21-1.noarch.rpm"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vcloud_name "fedora-21-i386"
+end

--- a/configs/platforms/fedora-21-x86_64.rb
+++ b/configs/platforms/fedora-21-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-21-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/x86_64/pl-build-tools-release-21-1.noarch.rpm"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vcloud_name "fedora-21-x86_64"
+end


### PR DESCRIPTION
This adds platform definitions for Fedora-{20,21}. The fun part here is
that we have to ensure we update coreutils on the host after
provisioning due to a crazy bug in coreutils.

https://bugzilla.redhat.com/show_bug.cgi?id=1001775

Outside of that, everything is awesome.
