### PR TITLE
(maint) Use --local in gem install to avoid network access

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -6,6 +6,6 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.build_requires "ruby"
 
   pkg.install do
-    [ "#{settings[:bindir]}/gem install --no-rdoc --no-ri stomp-1.3.3.gem"]
+    [ "#{settings[:bindir]}/gem install --no-rdoc --no-ri --local stomp-1.3.3.gem"]
   end
 end

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -6,6 +6,6 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.build_requires "ruby"
 
   pkg.install do
-    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri deep_merge-1.0.0.gem"]
+    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri --local deep_merge-1.0.0.gem"]
   end
 end

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -6,6 +6,6 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.build_requires "ruby"
 
   pkg.install do
-    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri net-ssh-#{pkg.get_version}.gem"]
+    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri --local net-ssh-#{pkg.get_version}.gem"]
   end
 end


### PR DESCRIPTION
Without --local, `gem install foo.gem` still hits api.rubygems.org,
which is undesirable for several reasons. This api hit can be avoided by
passing --local to `gem install`, which this commit implements.
