### PR TITLE
(RE-4141) Add provides for PL projects

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -4,6 +4,7 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires 'ruby'
 
   pkg.replaces 'facter'
+  pkg.provides 'facter'
 
   pkg.install do
     ["#{settings[:bindir]}/ruby install.rb --sitelibdir=#{settings[:ruby_vendordir]} --quick --man --mandir=#{settings[:mandir]}"]

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -5,6 +5,7 @@ component "hiera" do |pkg, settings, platform|
   pkg.build_requires "rubygem-deep-merge"
 
   pkg.replaces 'hiera'
+  pkg.provides 'hiera'
 
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"

--- a/configs/components/mcollective.rb
+++ b/configs/components/mcollective.rb
@@ -8,6 +8,10 @@ component "mcollective" do |pkg, settings, platform|
   pkg.replaces 'mcollective-common'
   pkg.replaces 'mcollective-client'
 
+  pkg.provides 'mcollective'
+  pkg.provides 'mcollective-common'
+  pkg.provides 'mcollective-client'
+
   if platform.is_deb?
     pkg.replaces 'mcollective-doc'
   end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -6,9 +6,11 @@ component "puppet" do |pkg, settings, platform|
   pkg.build_requires "hiera"
 
   pkg.replaces 'puppet'
+  pkg.provides 'puppet'
 
   if platform.is_deb?
     pkg.replaces 'puppet-common'
+    pkg.provides 'puppet-common'
   end
 
   case platform.servicetype


### PR DESCRIPTION
Previously puppet-agent did not provide capabilities such as puppet,
facter, mcollective, or hiera. This has consequences for installing
packages that depend on those packages that would otherwise work, like
puppetdb 2.3 or mcollective plugins. This commit adds provides for those
components so that those packages can be successfully installed.
