### PR TITLE
(CISCO-25) Remove dmidecode dependency for nxos platforms

### DIFF
--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -7,7 +7,7 @@ component "virt-what" do |pkg, settings, platform|
   unless platform.is_deb?
     requires "util-linux"
   end
-  unless ( platform.name =~ /^el-4-.*$/ or platform.name =~ /^sles-(10|11)-.*$/ )
+  unless ( platform.name =~ /^el-4-.*$/ or platform.name =~ /^sles-(10|11)-.*$/ or platform.is_nxos? )
     requires "dmidecode"
   end
   if platform.name =~ /^sles-(10|11)-.*$/


### PR DESCRIPTION
Tested by running rpm -qpR on the packages generated with and without this change.
