### PR TITLE
(RE-4039) Pin Windows dependencies for 4.0.0-rc1

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/master"
+  "ref": "origin/4.0.0-rc1"
 }

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "origin/2.1.x-x86",
-    "x64": "origin/2.1.x-x64"
+    "x86": "origin/2.1.5.1-x86",
+    "x64": "origin/2.1.5.1-x64"
   }
 }


### PR DESCRIPTION
- Ensure that we use a stable version of Ruby 2.1.5.1 for
  both x86 and x64 that has been tested in the build pipelines
- Ensure that the MSI repository is also pinned to a tagged
  4.0.0-rc1 version of the code
