### PR TITLE
(CISCO-26) Update readline dependency for augeas on NXOS

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -8,7 +8,11 @@ component 'augeas' do |pkg, settings, platform|
     pkg.requires 'libxml2'
 
     pkg.build_requires 'readline-devel'
-    pkg.requires 'readline'
+    if platform.is_nxos?
+      pkg.requires 'libreadline6'
+    else
+      pkg.requires 'readline'
+    end
 
     pkg.build_requires 'pkgconfig'
   elsif platform.is_deb?


### PR DESCRIPTION
NXOS is a bit unusual in that the readline package is named
libreadline6. This updates the RPM package dependency to reflect this.

Tested by comparing the output from rpm -qpR on the package.
