### PR TITLE
(QENG-2001) Use marionette-collective not mcollective

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -30,7 +30,7 @@ PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))
 FACTER       = JSON.parse(File.read('configs/components/facter.json'))
 CFACTER      = JSON.parse(File.read('configs/components/cfacter.json'))
 HIERA        = JSON.parse(File.read('configs/components/hiera.json'))
-MCO          = JSON.parse(File.read('configs/components/mcollective.json'))
+MCO          = JSON.parse(File.read('configs/components/marionette-collective.json'))
 WINDOWS      = JSON.parse(File.read('configs/components/windows_puppet.json'))
 WINDOWS_RUBY = JSON.parse(File.read('configs/components/windows_ruby.json'))
 


### PR DESCRIPTION
Windows, the special snowflake that it is, was still using
mcollective.json, which was deleted in a previous PR. This commit
updates the json file to be marionette-collective.json, which is
consistent with the puppet-agent vanagon project config.
