### PR TITLE
(RE-4159) Use versioned provides and replaces in puppet-agent

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -3,8 +3,8 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires 'ruby'
 
-  pkg.replaces 'facter'
-  pkg.provides 'facter'
+  pkg.replaces 'facter', '2.4.2'
+  pkg.provides 'facter', '2.4.2'
 
   pkg.install do
     ["#{settings[:bindir]}/ruby install.rb --sitelibdir=#{settings[:ruby_vendordir]} --quick --man --mandir=#{settings[:mandir]}"]

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -4,8 +4,8 @@ component "hiera" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "rubygem-deep-merge"
 
-  pkg.replaces 'hiera'
-  pkg.provides 'hiera'
+  pkg.replaces 'hiera', '2.0.0'
+  pkg.provides 'hiera', '2.0.0'
 
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -4,13 +4,13 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "ruby-stomp"
 
-  pkg.replaces 'mcollective'
-  pkg.replaces 'mcollective-common'
-  pkg.replaces 'mcollective-client'
+  pkg.replaces 'mcollective', '2.8.1'
+  pkg.replaces 'mcollective-common', '2.8.1'
+  pkg.replaces 'mcollective-client', '2.8.1'
 
-  pkg.provides 'mcollective'
-  pkg.provides 'mcollective-common'
-  pkg.provides 'mcollective-client'
+  pkg.provides 'mcollective', '2.8.1'
+  pkg.provides 'mcollective-common', '2.8.1'
+  pkg.provides 'mcollective-client', '2.8.1'
 
   if platform.is_deb?
     pkg.replaces 'mcollective-doc'

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -5,12 +5,12 @@ component "puppet" do |pkg, settings, platform|
   pkg.build_requires "facter"
   pkg.build_requires "hiera"
 
-  pkg.replaces 'puppet'
-  pkg.provides 'puppet'
+  pkg.replaces 'puppet', '4.0.0'
+  pkg.provides 'puppet', '4.0.0'
 
   if platform.is_deb?
-    pkg.replaces 'puppet-common'
-    pkg.provides 'puppet-common'
+    pkg.replaces 'puppet-common', '4.0.0'
+    pkg.provides 'puppet-common', '4.0.0'
   end
 
   case platform.servicetype


### PR DESCRIPTION
Older packaging systems such as rpm on el5 cannot handle unversioned
provides and replaces, because they think the package is conflicting
with itself. This commit adds versions to the replaces and provides for
marionette-collective, facter, puppet and hiera so that puppet-agent
installation can succeed on these older platforms.
