### PR TITLE
(RE-4039) Update windows specific refs to use 'refs/tags'

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/4.0.0-rc1"
+  "ref": "refs/tags/4.0.0-rc1"
 }

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "origin/2.1.5.1-x86",
-    "x64": "origin/2.1.5.1-x64"
+    "x86": "refs/tags/2.1.5.1-x86",
+    "x64": "refs/tags/2.1.5.1-x64"
   }
 }


### PR DESCRIPTION
Origin works if referring to a branch, but not to a tag. Using
'origin/4.0.0-rc1' will not work, while 'refs/tags/4.0.0-rc1' will. This
commit updates the windows refs to use refs/tags instead of origin for
tags.
