### PR TITLE
(RE-4039) Properly generate cfacter.ps1 url

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -62,10 +62,10 @@ Kernel.system("#{ssh_command} 'source .bash_profile ; echo $PATH'")
 
 # Download and execute the cfacter build script
 # this script lives in the puppetlabs/cfacter repo
-cfacter_build_script = CFACTER['url'].sub('git://github.com','https://raw.githubusercontent.com') +
-  '/' + CFACTER['ref'].sub('origin/','') + '/contrib/cfacter.ps1'
+cfacter_build_script = ENV['CFACTER_BUILD_SCRIPT'] || 
+  "https://raw.githubusercontent.com/puppetlabs/cfacter/#{CFACTER['ref']}/contrib/cfacter.ps1"
 result = Kernel.system("#{ssh_command} \"curl -O #{cfacter_build_script} && powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./cfacter.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE} -cfacterRef #{CFACTER['ref']} -cfacterFork #{CFACTER['url']}\"")
-fail "It looks like the cfacter build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+fail "It looks like the cfacter build script #{cfacter_build_script} failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
 
 # Move all necessary dll's into cfacter bindir
 Kernel.system("#{ssh_command} \"cp /cygdrive/c/tools/mingw#{script_arch}/bin/libgcc_s_#{ARCH == 'x64' ? 'seh' : 'sjlj'}-1.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libstdc++-6.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libwinpthread-1.dll /home/Administrator/cfacter/release/bin/\"")

--- a/configs/components/cfacter.json
+++ b/configs/components/cfacter.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/cfacter",
-  "ref": "refs/tags/0.4.0"
+  "ref": "0.4.0"
 }


### PR DESCRIPTION
- When switching from origin/master as a ref to the
  CFacter repository in 4acff22, a bug was discovered in
  the script that packages AIO on Windows that relied too
  heavily on a convention.
  
  Instead, always assume we'll use the cfacter.ps1 on
  the public puppetlabs/cfacter repository at the specified
  ref, so that the script is less fragile.
  
  Allow overriding the url with CFACTER_BUILD_SCRIPT
  environment variable.
  
  Adjust the ref for cfacter.json so that it will interpolate
  correctly.
