### PR TITLE
(PUP-4194) Create puppet logdir with mode 750

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -43,6 +43,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'manifests')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'modules')
   pkg.install_configfile 'conf/environment.conf', File.join(settings[:puppet_codedir], 'environments', 'production', 'environment.conf')
+  pkg.directory File.join(settings[:logdir], 'puppet'), mode: "0750"
 
   pkg.link "#{settings[:bindir]}/puppet", "#{settings[:link_bindir]}/puppet"
 end


### PR DESCRIPTION
The puppet logdir was relocated to ensure that permissions can be set on
the directory without affecting puppetserver running as the `puppet`
user.

This commit ensures the parent logdir is created with mode
755, and the puppet specific directory is created with mode 750.
