### PR TITLE
(re-4183) Update to openssl 1.0.0r

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.5.1-x86",
-    "x64": "refs/tags/2.1.5.1-x64"
+    "x86": "refs/tags/2.1.5.2-x86",
+    "x64": "refs/tags/2.1.5.2-x64"
   }
 }


### PR DESCRIPTION
Fixes for March 2015 CVEs: https://www.openssl.org/news/secadv_20150319.txt
