### PR TITLE
(RE-3977) Use SUSE init script for puppet

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -19,6 +19,8 @@ component "puppet" do |pkg, settings, platform|
   when "sysv"
     if platform.is_deb?
       pkg.install_service "ext/debian/puppet.init", "ext/debian/puppet.default"
+    elsif platform.is_sles?
+      pkg.install_service "ext/suse/client.init", "ext/redhat/client.sysconfig"
     elsif platform.is_rpm?
       pkg.install_service "ext/redhat/client.init", "ext/redhat/client.sysconfig"
     end


### PR DESCRIPTION
Prior to this commit, installation of puppet-agent
on SLES 11 throws innserv warnings due to missing
LSB tags in the puppet init script.

This commit updates the puppet component configuration
to use the SUSE specific one.
