### PR TITLE
(RE-4167) Update fedora platform configs to ship to f21

### DIFF
--- a/configs/platforms/fedora-f20-i386.rb
+++ b/configs/platforms/fedora-f20-i386.rb
@@ -1,10 +1,10 @@
-platform "fedora-20-x86_64" do |plat|
+platform "fedora-f20-i386" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign coreutils"
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/x86_64/pl-build-tools-release-20-1.noarch.rpm"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/i386/pl-build-tools-release-20-1.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-20-x86_64"
+  plat.vcloud_name "fedora-20-i386"
 end

--- a/configs/platforms/fedora-f20-x86_64.rb
+++ b/configs/platforms/fedora-f20-x86_64.rb
@@ -1,10 +1,10 @@
-platform "fedora-20-i386" do |plat|
+platform "fedora-f20-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign coreutils"
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/i386/pl-build-tools-release-20-1.noarch.rpm"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/20/x86_64/pl-build-tools-release-20-1.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-20-i386"
+  plat.vcloud_name "fedora-20-x86_64"
 end

--- a/configs/platforms/fedora-f21-i386.rb
+++ b/configs/platforms/fedora-f21-i386.rb
@@ -1,10 +1,10 @@
-platform "fedora-21-x86_64" do |plat|
+platform "fedora-f21-i386" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/x86_64/pl-build-tools-release-21-11.noarch.rpm"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/i386/pl-build-tools-release-21-11.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-21-x86_64"
+  plat.vcloud_name "fedora-21-i386"
 end

--- a/configs/platforms/fedora-f21-x86_64.rb
+++ b/configs/platforms/fedora-f21-x86_64.rb
@@ -1,10 +1,10 @@
-platform "fedora-21-i386" do |plat|
+platform "fedora-f21-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/i386/pl-build-tools-release-21-11.noarch.rpm"
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/x86_64/pl-build-tools-release-21-11.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-21-i386"
+  plat.vcloud_name "fedora-21-x86_64"
 end


### PR DESCRIPTION
In order to match current standards with our yum repository, having
fedora packages under the fedora version prefixed with f is desirable.
The most straightforward way to do this is to simply update the platform
configs to use f20/f21 in their name, which this commit does.
