### PR TITLE
Bump puppet to 4.0.0-rc2

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/puppet.git",
-  "ref": "refs/tags/4.0.0-rc1"
+  "ref": "refs/tags/4.0.0-rc2"
 }


### PR DESCRIPTION
@melissa I've updated the puppet version to be 4.0.0-rc2. So can you push the tag on puppet and then merge this?
