### PR TITLE
Bump hiera to 2.0.0

### DIFF
--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,5 +1,5 @@
 {
   "url": "git://github.com/puppetlabs/hiera",
-  "ref": "refs/tags/2.0.0-rc1"
+  "ref": "refs/tags/2.0.0"
 }
 


### PR DESCRIPTION
@melissa this one should wait until after we push the tag on hiera 2.0.0 (should be later today).
