### PR TITLE
(RE-4248) Explicitly name mcollective service

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -18,15 +18,15 @@ component "marionette-collective" do |pkg, settings, platform|
 
   case platform.servicetype
   when "systemd"
-    pkg.install_service "ext/aio/redhat/mcollective.service", "ext/aio/redhat/mcollective.sysconfig"
+    pkg.install_service "ext/aio/redhat/mcollective.service", "ext/aio/redhat/mcollective.sysconfig", "mcollective"
     pkg.install_file "ext/aio/redhat/mcollective-systemd.logrotate", "/etc/logrotate.d/mcollective"
   when "sysv"
     if platform.is_deb?
-      pkg.install_service "ext/aio/debian/mcollective.init", "ext/aio/debian/mcollective.default"
+      pkg.install_service "ext/aio/debian/mcollective.init", "ext/aio/debian/mcollective.default", "mcollective"
     elsif platform.is_sles?
       pkg.install_service "ext/aio/suse/mcollective.init", "ext/aio/redhat/mcollective.sysconfig"
     elsif platform.is_rpm?
-      pkg.install_service "ext/aio/redhat/mcollective.init", "ext/aio/redhat/mcollective.sysconfig"
+      pkg.install_service "ext/aio/redhat/mcollective.init", "ext/aio/redhat/mcollective.sysconfig", "mcollective"
     end
 
     pkg.install_file "ext/aio/redhat/mcollective-sysv.logrotate", "/etc/logrotate.d/mcollective"


### PR DESCRIPTION
In vanagon, services default to the name of the component. When
mcollective's component name was changed to marionette-collective, this
had the unintended consequence of also changing the service name, which
breaks assumptions in the default file and init script. This commit
explicitly sets the mcollective service name to mcollective to avoid
this problem.
