### PR TITLE
(FACT-899) Facter depends on net-tools

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -1,6 +1,7 @@
 component "facter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/facter.json')
 
+  pkg.requires 'net-tools'
   pkg.build_requires 'ruby'
 
   pkg.replaces 'facter', '2.4.2'


### PR DESCRIPTION
Facter depends on ifconfig from net-tools being found. On EL 7 systems,
that's not installed by default, so add a runtime requirement.
