### PR TITLE
(maint) Move provides/replaces to 3.0.0 for mco, facter

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -5,13 +5,15 @@ component "facter" do |pkg, settings, platform|
   pkg.requires 'net-tools'
   pkg.build_requires 'ruby'
 
+  # Here we replace and provide facter 3 to ensure that even as we continue
+  # to release 2.x versions of facter upgrades to puppet-agent will be clean
   if platform.is_rpm?
     # In our rpm packages, facter has an epoch set, so we need to account for that here
-    pkg.replaces 'facter', '1:2.4.2'
-    pkg.provides 'facter', '1:2.4.2'
+    pkg.replaces 'facter', '1:3.0.0'
+    pkg.provides 'facter', '1:3.0.0'
   else
-    pkg.replaces 'facter', '2.4.2'
-    pkg.provides 'facter', '2.4.2'
+    pkg.replaces 'facter', '3.0.0'
+    pkg.provides 'facter', '3.0.0'
   end
 
   pkg.install do

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -4,13 +4,15 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.build_requires "ruby"
   pkg.build_requires "ruby-stomp"
 
-  pkg.replaces 'mcollective', '2.9.0'
-  pkg.replaces 'mcollective-common', '2.9.0'
-  pkg.replaces 'mcollective-client', '2.9.0'
+  # Here we replace and provide mcollective 3 to ensure that even as we continue
+  # to release 2.x versions of mcollective upgrades to puppet-agent will be clean
+  pkg.replaces 'mcollective', '3.0.0'
+  pkg.replaces 'mcollective-common', '3.0.0'
+  pkg.replaces 'mcollective-client', '3.0.0'
 
-  pkg.provides 'mcollective', '2.9.0'
-  pkg.provides 'mcollective-common', '2.9.0'
-  pkg.provides 'mcollective-client', '2.9.0'
+  pkg.provides 'mcollective', '3.0.0'
+  pkg.provides 'mcollective-common', '3.0.0'
+  pkg.provides 'mcollective-client', '3.0.0'
 
   if platform.is_deb?
     pkg.replaces 'mcollective-doc'


### PR DESCRIPTION
Mcollective and facter will continue to see package releases for some
time. In order to ensure that those packages will be able to cleanly
upgrade to puppet-agent, this commit moves the provides/replaces for
those packages to 3.0.0, a version that neither project is like to ship
packages for.
