### PR TITLE
(RE-4168) Pin puppet-agent to a vanagon release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '~> 0.1', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+gem 'vanagon', '0.2.0', :git => 'git@github.com:puppetlabs/vanagon', :tag => '0.2.0'
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'


### PR DESCRIPTION
While vanagon development was required for puppet-agent work, it made
sense to pin loosely for the vanagon dependency. Now that vanagon has
support for everything puppet-agent needs at the moment, it makes sense
to pin more conservatively. This commit pins vanagon to a specific git
tag to avoid introducing unintended changes in the packaging.
