### PR TITLE
(maint) Set build_tar to false in build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -10,3 +10,4 @@ sign_tar: FALSE
 vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
+build_tar: FALSE


### PR DESCRIPTION
Without this setting, the uber_ship will fail looking for a source
tarball, which doesn't exist for vanagon based projects. This commit
adds the setting to ensure that an uber_ship can succeed.
