### PR TITLE
(maint) Merge master to aardwolf

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -10,3 +10,4 @@ sign_tar: FALSE
 vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
+build_tar: FALSE


### PR DESCRIPTION
This merge brings over the commit setting build_tar to false in build_defaults, which will be needed for a public ship of the agent.
