### PR TITLE
(RE-4414) Enable upgrades from PE 3.7.2 agent to AIO on EL 7

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -3,6 +3,9 @@ component 'augeas' do |pkg, settings, platform|
   pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
+  pkg.provides 'pe-augeas', '1.3.0'
+  pkg.replaces 'pe-augeas', '1.3.0'
+
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'
     pkg.requires 'libxml2'

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -1,6 +1,7 @@
 component "facter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/facter.json')
 
+
   # net-tools is required for ifconfig; it can be removed with Facter 3
   pkg.requires 'net-tools'
   pkg.build_requires 'ruby'
@@ -10,10 +11,14 @@ component "facter" do |pkg, settings, platform|
   if platform.is_rpm?
     # In our rpm packages, facter has an epoch set, so we need to account for that here
     pkg.replaces 'facter', '1:3.0.0'
+    pkg.replaces 'pe-facter', '1:3.0.0'
     pkg.provides 'facter', '1:3.0.0'
+    pkg.provides 'pe-facter', '1:3.0.0'
   else
     pkg.replaces 'facter', '3.0.0'
+    pkg.replaces 'pe-facter', '3.0.0'
     pkg.provides 'facter', '3.0.0'
+    pkg.provides 'pe-facter', '3.0.0'
   end
 
   pkg.install do

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -5,7 +5,9 @@ component "hiera" do |pkg, settings, platform|
   pkg.build_requires "rubygem-deep-merge"
 
   pkg.replaces 'hiera', '2.0.0'
+  pkg.replaces 'pe-hiera', '2.0.0'
   pkg.provides 'hiera', '2.0.0'
+  pkg.provides 'pe-hiera', '2.0.0'
 
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -9,13 +9,21 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.replaces 'mcollective', '3.0.0'
   pkg.replaces 'mcollective-common', '3.0.0'
   pkg.replaces 'mcollective-client', '3.0.0'
+  pkg.replaces 'pe-mcollective', '3.0.0'
+  pkg.replaces 'pe-mcollective-common', '3.0.0'
+  pkg.replaces 'pe-mcollective-client', '3.0.0'
+
 
   pkg.provides 'mcollective', '3.0.0'
   pkg.provides 'mcollective-common', '3.0.0'
   pkg.provides 'mcollective-client', '3.0.0'
+  pkg.provides 'pe-mcollective', '3.0.0'
+  pkg.provides 'pe-mcollective-common', '3.0.0'
+  pkg.provides 'pe-mcollective-client', '3.0.0'
 
   if platform.is_deb?
     pkg.replaces 'mcollective-doc'
+    pkg.replaces 'pe-mcollective-doc'
   end
 
   case platform.servicetype

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -3,6 +3,9 @@ component "openssl" do |pkg, settings, platform|
   pkg.md5sum "ea48d0ad53e10f06a9475d8cdc209dfa"
   pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
+  pkg.provides 'pe-openssl', '1.0.0r'
+  pkg.replaces 'pe-openssl', '1.0.0r'
+
   ca_certfile = File.join(settings[:prefix], 'ssl', 'cert.pem')
 
   pkg.configure do

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -7,10 +7,21 @@ component "puppet" do |pkg, settings, platform|
 
   pkg.replaces 'puppet', '4.0.0'
   pkg.provides 'puppet', '4.0.0'
+  pkg.replaces 'pe-puppet', '4.0.0'
+  pkg.provides 'pe-puppet', '4.0.0'
+  pkg.replaces 'pe-ruby-rgen'
+  pkg.replaces 'pe-cloud-provisioner-libs'
+  pkg.replaces 'pe-cloud-provisioner'
+  pkg.replaces 'pe-puppet-enterprise-release'
+  pkg.provides 'pe-puppet-enterprise-release'
+  pkg.replaces 'pe-agent'
+  pkg.provides 'pe-agent'
 
   if platform.is_deb?
     pkg.replaces 'puppet-common', '4.0.0'
     pkg.provides 'puppet-common', '4.0.0'
+    pkg.replaces 'pe-puppet-common', '4.0.0'
+    pkg.provides 'pe-puppet-common', '4.0.0'
   end
 
   case platform.servicetype

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -3,6 +3,9 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-augeas-0.5.0.tgz"
 
+  pkg.provides "pe-ruby-augeas", "0.5.0"
+  pkg.replaces "pe-ruby-augeas", "0.5.0.1"
+
   pkg.build_requires "ruby"
   pkg.build_requires "augeas"
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -4,10 +4,14 @@ if platform.name =~ /^el-(5|6|7)-.*/
       pkg.version "1.33.4"
       pkg.md5sum "08762379de2242926854080dad649b67"
       pkg.apply_patch "resources/patches/ruby-selinux/libselinux-rhat.patch"
+      pkg.replaces "pe-#{pkg.get_name}", "1.33.4.1"
     else
       pkg.version "2.0.94"
+      pkg.replaces "pe-#{pkg.get_name}", "2.0.94.1"
       pkg.md5sum "f814c71fca5a85ebfeb81b57afed59db"
     end
+
+    pkg.provides "pe-#{pkg.get_name}", pkg.get_version
 
     pkg.url "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
 

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -3,6 +3,9 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.3.3.tar.gz"
 
+  pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+  pkg.replaces "pe-#{pkg.get_name}", '2.3.3'
+
   pkg.build_requires "ruby"
 
   pkg.build do

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -3,6 +3,9 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
   pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.gem"
 
+  pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+  pkg.replaces "pe-#{pkg.get_name}", "1.3.3.1"
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -3,6 +3,18 @@ component "ruby" do |pkg, settings, platform|
   pkg.md5sum "df4c1b23f624a50513c7a78cb51a13dc"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-2.1.5.tar.gz"
 
+  pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+  pkg.provides "pe-rubygems"
+  pkg.provides "/opt/puppet/bin/ruby"
+  pkg.provides "pe-libyaml"
+
+  pkg.replaces "pe-#{pkg.get_name}", '2.1.5'
+  pkg.replaces "pe-rubygems"
+  pkg.replaces "pe-libyaml"
+  pkg.replaces "pe-libldap", "2.4.40"
+  pkg.replaces "pe-ruby-ldap", "0.9.13"
+
+
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 
   pkg.build_requires "openssl"

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -3,6 +3,9 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.md5sum "4bff008be5605bd6fb687a6e33c028e0"
   pkg.url "http://buildsources.delivery.puppetlabs.net/deep_merge-1.0.0.gem"
 
+  pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+  pkg.replaces "pe-#{pkg.get_name}", '1.0.1'
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -3,6 +3,9 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.md5sum "797c9a7a9e25c781cbf6b77a0054bb2e"
   pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
 
+ pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+ pkg.replaces "pe-#{pkg.get_name}", '2.1.5'
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -3,6 +3,9 @@ component "virt-what" do |pkg, settings, platform|
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
   pkg.url "http://buildsources.delivery.puppetlabs.net/virt-what-1.14.tar.gz"
 
+  pkg.provides "pe-#{pkg.get_name}", pkg.get_version
+  pkg.replaces "pe-#{pkg.get_name}", '1.15'
+
   # Run-time requirements
   unless platform.is_deb?
     requires "util-linux"


### PR DESCRIPTION
This is the first commit to get us going on upgrading PE agents to the
AIO. This has only been tested on EL7 thus far, but does work.

A few items of note:
1. pe-rubygem-gem2rpm is not obsoleted nor provided yet. I'm not sure
   the best way to handle that.
2. We are obsolting the ldap libraries since we're not using them any
   more in the agent.
3. We obsolete cloud provisioner without providing it.
4. I think the rest of the things are obsoleted and provided.
