### PR TITLE
(PUP-4424) Pin Puppet FTW

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/master"
+  "ref": "origin/stable"
 }


### PR DESCRIPTION
When we pinned puppet-agent's stable branch to project stable branches,
we didn't pin puppet_for_the_win. Some changes to puppet_for_the_win
need to happen that shouldn't affect building puppet-agent stable, so
pin puppet-agent to the 4.0.0 tag.
