### PR TITLE
(RE-4404) Update ruby to 2.1.6 for CVE-2015-1855

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,7 +1,7 @@
 component "ruby" do |pkg, settings, platform|
-  pkg.version "2.1.5"
-  pkg.md5sum "df4c1b23f624a50513c7a78cb51a13dc"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-2.1.5.tar.gz"
+  pkg.version "2.1.6"
+  pkg.md5sum "6e5564364be085c45576787b48eeb75f"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 


### PR DESCRIPTION
This commit updates the version in the ruby component config from 2.1.5
to 2.1.6 to address CVE-2015-1855.
