### PR TITLE
(CISCO-27) Fix location of NXOS init script dir

### DIFF
--- a/configs/platforms/nxos-1-x86_64.rb
+++ b/configs/platforms/nxos-1-x86_64.rb
@@ -1,5 +1,5 @@
 platform "nxos-1-x86_64" do |plat|
-  plat.servicedir "/etc/rc.d/init.d"
+  plat.servicedir "/etc/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
   plat.provision_with "echo"


### PR DESCRIPTION
NXOS keeps init scripts in /etc/init.d

Tested install of package in a NXOS docker container to confirm the postinst errors were fixed.
