### PR TITLE
(RE-4407) Update puppet-agent requirements

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -1,6 +1,13 @@
 component "facter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/facter.json')
 
+  # facter requires the hostname command, which is provided by net-tools
+  # on el5/6, but by hostname on more recent el releases including fedora
+  # as well as all debian/ubuntu releases. The hostname package is not
+  # available on sles
+  if platform.is_deb? || (platform.is_el? && platform.os_version.to_i >= 7) || platform.is_fedora?
+    pkg.requires 'hostname'
+  end
   # net-tools is required for ifconfig; it can be removed with Facter 3
   pkg.requires 'net-tools'
   pkg.build_requires 'ruby'

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -28,6 +28,9 @@ component "puppet" do |pkg, settings, platform|
     fail "need to know where to put service files"
   end
 
+  # Puppet requires tar, otherwise PMT will not install modules
+  pkg.requires 'tar'
+
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_configdir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end


### PR DESCRIPTION
Puppet requires tar to be available on the system, otherwise PMT will
not install modules.

Likewise, facter requires the hostname command to be available,
otherwise certain facts will fail.
