### PR TITLE
(RE-4258) Update Gemfile to facilitate testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '0.2.0', :git => 'git@github.com:puppetlabs/vanagon', :tag => '0.2.0'
+def vanagon_location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  elsif place =~ /(\d+\.\d+\.\d+)/
+    [$1, {:git => 'git@github.com:puppetlabs/vanagon', :tag => $1}]
+  end
+end
+
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.2.0')
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'


### PR DESCRIPTION
In order to test builds of vanagon, we'll be using puppet-agent. Puppet
agent previously had a hard coded version for the vanagon version to use
in the Gemfile. This doesn't work well for testing, so this commit
updates it to use a method borrowed from puppet and modified slightly.
The method allows a jenkins job to override the vanagon version to use
to allow it to test different versions of vanagon.
