### PR TITLE
(RE-4100) Bump to required Vanagon version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.2.0')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.0')
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -45,7 +45,7 @@ component "openssl" do |pkg, settings, platform|
       no-srp \
       no-ssl2 \
       no-ssl3 \
-      #{settings[:cflags]}
+      #{settings[:cflags]} \
       #{ldflags}"]
   end
 


### PR DESCRIPTION
PR #157 merged support for OSX, but failed to update to a newer version
of Vanagon (0.3.0) required by the changes. Update the Gemfile to point
to that version, and allow for minor bug fixes to be pulled in.

Also fix an extra newline being generated in the Makefile.
