### PR TITLE
MCO-659 Update marionette-collective version

### DIFF
--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/marionette-collective",
-  "ref": "refs/tags/2.8.1"
+  "ref": "refs/tags/2.8.2"
 }


### PR DESCRIPTION
Here we bump the version of marionette-collective to 2.8.2

This shouldn't be merged until the tag has been pushed, which @melissa will do at part of resolving https://tickets.puppetlabs.com/browse/MCO-659
