### PR TITLE
(QENG-2476) Roll back vanagon to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.3.1')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.3.0')
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'


### PR DESCRIPTION
Commit 515c8e2c323a3c81cfbdc1882a253fb8fe9d14e1 of vanagon, in the 0.3.1
tag updated vanagon to build in /tmp instead of root's homedir. This
breaks builds on templates that have /tmp mounted separately from /,
such as fedora 20 and 21. This commit rolls vanagon back to a release
without that enabled.
