### PR TITLE
(maint) Enable verbose output in cfacter tests

### DIFF
--- a/configs/components/cfacter.rb
+++ b/configs/components/cfacter.rb
@@ -46,7 +46,7 @@ component "cfacter" do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install ARGS='-V'"]
   end
 
   pkg.link "#{settings[:bindir]}/cfacter", "#{settings[:link_bindir]}/cfacter"


### PR DESCRIPTION
Previously when cfacter ran tests during `make install`, any failures
would be hard to debug because the tests generate very little output.
This commit adds -V to the `make install` invocation to ensure that the
tests give more and more useful output.
