### PR TITLE
(maint) Capitalize ARGS in make test cfacter call for more verbose ou…

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -101,7 +101,7 @@ component "facter" do |pkg, settings, platform|
 
     pkg.build do
       # Until a `check` target exists, run tests are part of the build.
-      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) && #{platform[:make]} test args=-V"]
+      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) && #{platform[:make]} test ARGS=-V"]
     end
 
     pkg.install do


### PR DESCRIPTION
…tput

A previous commit added args to the make test call in facter's build,
but it needs to be capitalized to be effective. This commit capitalizes
ARGS to ensure we get verbose output from make test.
