### PR TITLE
(CFACT-275) Set PATH for make test so ruby can be found

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -101,7 +101,7 @@ component "facter" do |pkg, settings, platform|
 
     pkg.build do
       # Until a `check` target exists, run tests are part of the build.
-      ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) && #{platform[:make]} test ARGS=-V"]
+      ["PATH=#{settings[:bindir]}:$$PATH #{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) && #{platform[:make]} test ARGS=-V"]
     end
 
     pkg.install do


### PR DESCRIPTION
On el4 and sles10, facter tests were failing because ruby could not be
found on the PATH. This commit updates the test call to include adding
/opt/puppetlabs/puppet/bin to PATH, so that the agent's ruby will be
used.
