### PR TITLE
(maint) Enable building native Facter on Cisco NXOS

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -1,5 +1,5 @@
 component "facter" do |pkg, settings, platform|
-  use_facter_2x = (platform.is_eos? || platform.is_nxos? || platform.is_osx?)
+  use_facter_2x = (platform.is_eos? || platform.is_osx?)
   if use_facter_2x
     # Build facter-2.x
     pkg.load_from_json('configs/components/facter-2.x.json')
@@ -42,7 +42,7 @@ component "facter" do |pkg, settings, platform|
 
     # SLES and Debian 8 uses vanagon built pl-build-tools
     if platform.is_sles? or (platform.os_name == 'debian' and platform.os_version.to_i >= 8) or
-      platform.name.match(/^ubuntu-14.10-.*$/)
+      platform.name.match(/^ubuntu-14.10-.*$/) or platform.is_nxos?
       pkg.build_requires "pl-boost"
       pkg.build_requires "pl-yaml-cpp"
     else
@@ -72,7 +72,7 @@ component "facter" do |pkg, settings, platform|
     # Skip blkid unless we can ensure it exists at build time. Otherwise we depend
     # on the vagaries of the system we build on.
     skip_blkid = 'ON'
-    if platform.is_deb?
+    if platform.is_deb? or platform.is_nxos?
       pkg.build_requires "libblkid-dev"
       skip_blkid = 'OFF'
     elsif platform.is_rpm?

--- a/configs/platforms/nxos-1-x86_64.rb
+++ b/configs/platforms/nxos-1-x86_64.rb
@@ -2,8 +2,10 @@ platform "nxos-1-x86_64" do |plat|
   plat.servicedir "/etc/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
-  plat.provision_with "echo"
-  plat.install_build_dependencies_with "echo "
+
+  plat.provision_with "echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/nxos/1/$basearch' > /etc/yum/repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils;yum update -y pkgconfig"
+  plat.install_build_dependencies_with "yum install -y"
+
   plat.docker_image "nxos_base_image"
   plat.ssh_port 2222
 end


### PR DESCRIPTION
Adds repo configuration to the Cisco NXOS platform config, and
 enables building native Facter on that platform.
