### PR TITLE
(RE-4573) update puppet-agent to build cfacter on osx

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -1,7 +1,8 @@
 platform "osx-10.10-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
+  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10)-6.3"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
-  plat.install_build_dependencies_with "/usr/local/bin/brew install"
+  plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-1010-x86_64"
 end

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -1,6 +1,8 @@
 platform "osx-10.9-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
+  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X Mavericks)-6.2"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
+  plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-109-x86_64"
 end


### PR DESCRIPTION
This commit adds cfacter to the puppet-agent build for OSX 10.9 and 10.10.  The original plan was to pull in the pl-build-tools and use those components for building, but due to some issues building the tools we're going a different route for the time being.   clang and the native system tools provided by the CLT are utilized and other build requirements ( cmake, boost, yaml-cpp, java ) are fulfilled via brew. The platform configs were also updated to ensure we're using a more recent version of the CLT.
