### PR TITLE
(RE-4513) Enable EL agent upgrades from PE to Shallow Gravy

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -3,6 +3,8 @@ component 'augeas' do |pkg, settings, platform|
   pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
+  pkg.replaces 'pe-augeas'
+
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'
     pkg.requires 'libxml2'

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -18,6 +18,8 @@ component "facter" do |pkg, settings, platform|
   pkg.replaces 'cfacter', '0.5.0'
   pkg.provides 'cfacter', '0.5.0'
 
+  pkg.replaces 'pe-facter'
+
   pkg.build_requires "ruby"
 
   if use_facter_2x

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -7,6 +7,8 @@ component "hiera" do |pkg, settings, platform|
   pkg.replaces 'hiera', '2.0.0'
   pkg.provides 'hiera', '2.0.0'
 
+  pkg.replaces 'pe-hiera'
+
   pkg.install do
     "#{settings[:bindir]}/ruby install.rb --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -14,6 +14,10 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.provides 'mcollective-common', '3.0.0'
   pkg.provides 'mcollective-client', '3.0.0'
 
+  pkg.replaces 'pe-mcollective'
+  pkg.replaces 'pe-mcollective-common'
+  pkg.replaces 'pe-mcollective-client'
+
   if platform.is_deb?
     pkg.replaces 'mcollective-doc'
   end

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -3,6 +3,8 @@ component "openssl" do |pkg, settings, platform|
   pkg.md5sum "ea48d0ad53e10f06a9475d8cdc209dfa"
   pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
+  pkg.replaces 'pe-openssl'
+
   ca_certfile = File.join(settings[:prefix], 'ssl', 'cert.pem')
 
   case platform.name

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -8,6 +8,13 @@ component "puppet" do |pkg, settings, platform|
   pkg.replaces 'puppet', '4.0.0'
   pkg.provides 'puppet', '4.0.0'
 
+  pkg.replaces 'pe-puppet'
+  pkg.replaces 'pe-ruby-rgen'
+  pkg.replaces 'pe-cloud-provisioner-libs'
+  pkg.replaces 'pe-cloud-provisioner'
+  pkg.replaces 'pe-puppet-enterprise-release', '4.0.0'
+  pkg.replaces 'pe-agent'
+
   if platform.is_deb?
     pkg.replaces 'puppet-common', '4.0.0'
     pkg.provides 'puppet-common', '4.0.0'

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -3,6 +3,8 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-augeas-0.5.0.tgz"
 
+  pkg.replaces 'pe-ruby-augeas'
+
   pkg.build_requires "ruby"
   pkg.build_requires "augeas"
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -10,6 +10,8 @@ component "ruby-selinux" do |pkg, settings, platform|
 
   pkg.url "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
 
+  pkg.replaces 'pe-ruby-selinux'
+
   pkg.build_requires "ruby"
   pkg.build_requires "swig"
   pkg.build_requires "libsepol"

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -3,6 +3,8 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.3.3.tar.gz"
 
+  pkg.replaces 'pe-ruby-shadow'
+
   pkg.build_requires "ruby"
 
   pkg.build do

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -3,6 +3,8 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
   pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.gem"
 
+  pkg.replaces 'pe-ruby-stomp'
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -3,6 +3,13 @@ component "ruby" do |pkg, settings, platform|
   pkg.md5sum "6e5564364be085c45576787b48eeb75f"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
+  pkg.replaces 'pe-ruby'
+  pkg.replaces 'pe-rubygems'
+  pkg.replaces 'pe-libyaml'
+  pkg.replaces 'pe-libldap'
+  pkg.replaces 'pe-ruby-ldap'
+  pkg.replaces 'pe-rubygem-gem2rpm'
+
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
 
   pkg.build_requires "openssl"

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -3,6 +3,8 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
   pkg.url "http://buildsources.delivery.puppetlabs.net/deep_merge-#{pkg.get_version}.gem"
 
+  pkg.replaces "pe-rubygem-deep-merge"
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -3,6 +3,8 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.md5sum "797c9a7a9e25c781cbf6b77a0054bb2e"
   pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
 
+  pkg.replaces 'pe-rubygem-net-ssh'
+
   pkg.build_requires "ruby"
 
   pkg.install do

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -3,6 +3,8 @@ component "virt-what" do |pkg, settings, platform|
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
   pkg.url "http://buildsources.delivery.puppetlabs.net/virt-what-1.14.tar.gz"
 
+  pkg.replaces 'pe-virt-what'
+
   # Run-time requirements
   unless platform.is_deb?
     requires "util-linux"


### PR DESCRIPTION
The commit updates the AIO puppet-agent to obsolete the
the corresponding discrete packages in the pre-Shallow
Gravy PE agent stack.
