### PR TITLE
(RE-3937) Add pl-build-tools repo to Arista EOS platform definition

### DIFF
--- a/configs/platforms/eos-4-i386.rb
+++ b/configs/platforms/eos-4-i386.rb
@@ -3,13 +3,9 @@ platform "eos-4-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with %Q{
-echo '[device-upstream]
-name=device-upstream
-gpgcheck=0
-baseurl=http://osmirror.delivery.puppetlabs.net/eos-4-i386/RPMS.all/' > /etc/yum.repos.d/device-upstream.repo
-yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils
-}
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/eos/4/i386/pl-build-tools-el-4.repo"
+  plat.yum_repo "http://osmirror.delivery.puppetlabs.net/eos-4-i386/eos-4-i386.repo"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils"
 
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
   plat.vcloud_name "fedora-14-i386"


### PR DESCRIPTION
To build native tools, we need to C++ toolchain repo available. This
commit sets that up using the plat.yum_repo helper method.
