### PR TITLE
(RE-4677) Build using the pl-build-tools-vanagon repo

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -39,19 +39,8 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires "openssl"
     pkg.build_requires "pl-gcc"
     pkg.build_requires "pl-cmake"
-
-    # SLES and Debian 8 uses vanagon built pl-build-tools
-    if platform.is_sles? or (platform.os_name == 'debian' and platform.os_version.to_i >= 8) or
-      platform.name.match(/^ubuntu-14.10-.*$/) or platform.is_nxos?
-      pkg.build_requires "pl-boost"
-      pkg.build_requires "pl-yaml-cpp"
-    else
-      # these are from the pl-dependency repo
-      pkg.build_requires "pl-libboost-static"
-      pkg.build_requires "pl-libboost-devel"
-      pkg.build_requires "pl-libyaml-cpp-static"
-      pkg.build_requires "pl-libyaml-cpp-devel"
-    end
+    pkg.build_requires "pl-boost"
+    pkg.build_requires "pl-yaml-cpp"
 
     java_home = ''
     case platform.name


### PR DESCRIPTION
Previously we had branching in the facter component for build
requirements based on which version of linux and which distro you were
using. This removes all of that branching because we have built out the
complete C++ toolchain (gcc, cmake, yaml-cpp, boost) for all of our
supported linux distributions. This means that now we should be using
those for building so that if one of them gets updated, all puppet-agent
platforms will pick up the changes.
