### PR TITLE
(RE-4751) clang randomly segfaults while building facter on mavericks

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -2,7 +2,7 @@ platform "osx-10.10-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
   plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10)-6.3"'
-  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
+  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-1010-x86_64"
 end

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -2,7 +2,7 @@ platform "osx-10.9-x86_64" do |plat|
   plat.servicetype 'launchd'
   plat.servicedir '/Library/LaunchDaemons'
   plat.provision_with 'softwareupdate -i "Command Line Tools (OS X Mavericks)-6.2"'
-  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
+  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-109-x86_64"
 end


### PR DESCRIPTION
The older version of clang ( 600.0.57 ) available via the CLT on Mavericks
and the latest version of boost ( 1.58 ) provided via brew results in
random segfaults while building cfacter.  This commit pins boost to
1.57.
