### PR TITLE
(RE-4603,RE-4680) bump augeas to 1.4.0

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,6 +1,6 @@
 component 'augeas' do |pkg, settings, platform|
-  pkg.version '1.3.0'
-  pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
+  pkg.version '1.4.0'
+  pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-augeas'


### PR DESCRIPTION
This version bump includes two lense fixes that we want to have
available. The first is a fix to the mco lense that updates where augeas
looks for client.cfg and server.cfg. The second is an update to the
nginx lense to expand the scope of what the lense can do (i.e. it's now
recursive, can handle nested blocks, etc.)

Rather than patching augeas 1.3.0 to include these fixes, we chose
simply to bump to the latest version (1.4.0), which includes these
updates.
