### PR TITLE
(RE-4545) puppet-agent should use tmpfiles.d w/ systemd

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -37,6 +37,23 @@ component "puppet" do |pkg, settings, platform|
     fail "need to know where to put service files"
   end
 
+  # To create a tmpfs directory for the piddir, it seems like it's either this
+  # or a PR against Puppet until that sort of support can be rolled into the
+  # Vanagon tooling directly. It's totally a hack, and I'm not proud of this
+  # in any meaningful way.
+  # - Ryan "I'm sorry. I'm so sorry." McKern, June 8 2015
+  # - Jira # RE-3954
+  if platform.servicetype == 'systemd'
+    pkg.build do
+      "echo 'd #{settings[:piddir]} 0755 root root -' > puppet-agent.conf"
+    end
+
+    # Also part of the ugly, ugly, ugly, sad, tragic hack.
+    # - Ryan "Rub some HEREDOC on it" McKern, June 8 2015
+    # - Jira # RE-3954
+    pkg.install_configfile 'puppet-agent.conf', File.join(settings[:tmpfilesdir], 'puppet-agent.conf')
+  end
+
   # Puppet requires tar, otherwise PMT will not install modules
   pkg.requires 'tar'
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -12,6 +12,7 @@ project "puppet-agent" do |proj|
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
+  proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   proj.description "The Puppet Agent package contains all of the elements needed to run puppet, including ruby, facter, hiera and mcollective."


### PR DESCRIPTION
On systemd platforms, the /var/run/puppetlabs directory will not be
automatically recreated after a reboot. We should use the tmpfiles.d
facility to create the /var/run/puppetlabs directory automatically
on reboot.

The way we're doing it now is a total, complete hack where we piggy-
back a tmpfiles.d config file into the Puppet component and use
that to get pieces in the right place. Ideally, this sort of
functionality can be rolled directly into Vanagon itself.
