### PR TITLE
(maint) update nxos platform config to use pooler

### DIFF
--- a/configs/platforms/nxos-5-x86_64.rb
+++ b/configs/platforms/nxos-5-x86_64.rb
@@ -1,4 +1,4 @@
-platform "nxos-1-x86_64" do |plat|
+platform "nxos-5-x86_64" do |plat|
   plat.servicedir "/etc/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
@@ -6,6 +6,6 @@ platform "nxos-1-x86_64" do |plat|
   plat.provision_with "echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/nxos/1/$basearch' > /etc/yum/repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils;yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
 
-  plat.docker_image "nxos_base_image"
-  plat.ssh_port 2222
+  plat.vcloud_name "nxos-5-x86_64"
+
 end


### PR DESCRIPTION
This commit updates the nxos platform config to use the nxos-5-x86_64
pooler template.  The version is a bit arbitrary, but was selected since
the current image is based on Wind River Linux 5.
