### PR TITLE
(RE-4049) Add libcurl for Facter

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,0 +1,21 @@
+component 'curl' do |pkg, settings, platform|
+  pkg.version '7.42.1'
+  pkg.md5sum '8df5874c4a67ad55496bf3af548d99a2'
+  pkg.url "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
+
+  pkg.build_requires "openssl"
+
+  pkg.configure do
+    ["LDFLAGS='#{settings[:ldflags]}' \
+     ./configure --prefix=#{settings[:prefix]} \
+     --with-ssl=#{settings[:prefix]} --enable-threaded-resolver --disable-ldap --disable-ldaps"]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -94,6 +94,13 @@ component "facter" do |pkg, settings, platform|
       end
     end
 
+    # curl is only used for compute clusters (GCE, EC2); so rpm, deb, and Windows
+    skip_curl = 'ON'
+    if platform.is_rpm? || platform.is_deb?
+      pkg.build_requires "curl"
+      skip_curl = 'OFF'
+    end
+
     # cmake on OSX is provided by brew
     # a toolchain is not currently required for OSX since we're building with clang.
     if platform.is_osx?
@@ -116,7 +123,7 @@ component "facter" do |pkg, settings, platform|
           -DYAMLCPP_STATIC=ON \
           -DFACTER_PATH=#{settings[:bindir]} \
           -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{settings[:bindir]}/ruby -rrbconfig -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
-          -DWITHOUT_CURL=ON \
+          -DWITHOUT_CURL=#{skip_curl} \
           -DWITHOUT_BLKID=#{skip_blkid} \
           #{java_includedir} \
           ."]

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -36,6 +36,8 @@ project "puppet-agent" do |proj|
   # Then the dependencies
   proj.component "augeas"
   proj.component "cfpropertylist" if proj.get_platform.is_osx?
+  # Curl is only needed for compute clusters (GCE, EC2); so rpm, deb, and Windows
+  proj.component "curl" if proj.get_platform.is_rpm? || proj.get_platform.is_deb?
   proj.component "ruby"
   proj.component "ruby-stomp"
   proj.component "rubygem-deep-merge"


### PR DESCRIPTION
Facter uses libcurl for querying facts in GCE and EC2. Without this
change, those facts wouldn't resolve. Add libcurl on Linux platforms, as
Mac OS X isn't used in GCE and EC2.
