### PR TITLE
(RE-4611) Add hocon to puppet-agent

### DIFF
--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -1,0 +1,11 @@
+component "rubygem-hocon" do |pkg, settings, platform|
+  pkg.version "0.9.0"
+  pkg.md5sum "0e7817e5d8ebcc6c92b125fe638a1f9d"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/hocon-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  pkg.install do
+    ["#{settings[:bindir]}/gem install --no-rdoc --no-ri --local hocon-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -39,6 +39,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby-stomp"
   proj.component "rubygem-deep-merge"
   proj.component "rubygem-net-ssh"
+  proj.component "rubygem-hocon"
   proj.component "ruby-shadow"
   proj.component "ruby-augeas"
   proj.component "openssl"


### PR DESCRIPTION
This package is needed to allow puppet-agent to more easily manage
trapperkeeper apps.
