### PR TITLE
(RE-4829) Update OpenSSL to 1.0.0s

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -1,6 +1,6 @@
 component "openssl" do |pkg, settings, platform|
-  pkg.version "1.0.0r"
-  pkg.md5sum "ea48d0ad53e10f06a9475d8cdc209dfa"
+  pkg.version "1.0.0s"
+  pkg.md5sum "fe54d58a42c6aa1c7a587378e27072f3"
   pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
   ca_certfile = File.join(settings[:prefix], 'ssl', 'cert.pem')


### PR DESCRIPTION
Due to the announcements in
http://marc.info/?l=openssl-announce&m=143403663912020&w=2 we need to
update our OpenSSL version to the latest secure version. This covers
multiple CVE fixes from OpenSSL.

CVE-2014-8176
CVE-2015-1788
CVE-2015-1789
CVE-2015-1790
CVE-2015-1791
CVE-2015-1792
CVE-2015-4000
