### PR TITLE
(RE-4826) Roll back to augeas 1.3.0 for osx

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,6 +1,12 @@
 component 'augeas' do |pkg, settings, platform|
-  pkg.version '1.4.0'
-  pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
+  if platform.is_osx?
+    # RE-4826 - Augeas 1.4.0 won't build on osx due to libedit incompatibilities
+    pkg.version '1.3.0'
+    pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
+  else
+    pkg.version '1.4.0'
+    pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
+  end
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-augeas'


### PR DESCRIPTION
OSX can't build augeas 1.4.0 because it is looking for readline
functions that aren't implemented in the version of libedit that is
available on osx. This commit conditionally builds augeas 1.3.0 on osx
platforms, and keeps augeas at 1.4.0 for other platforms.
