### PR TITLE
(RE-4800) Patch Rubygems in AIO for CVE-2015-4020

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -11,6 +11,7 @@ component "ruby" do |pkg, settings, platform|
   pkg.replaces 'pe-rubygem-gem2rpm'
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
+  pkg.apply_patch "resources/patches/ruby/CVE-2015-4020.patch"
 
   pkg.build_requires "openssl"
 

--- a/resources/patches/ruby/CVE-2015-4020.patch
+++ b/resources/patches/ruby/CVE-2015-4020.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/rubygems.rb b/lib/rubygems.rb
+index ea18930..73d063e 100644
+--- a/lib/rubygems.rb
++++ b/lib/rubygems.rb
+@@ -8,7 +8,7 @@
+ require 'rbconfig'
+ 
+ module Gem
+-  VERSION = '2.2.3'
++  VERSION = '2.2.5'
+ end
+ 
+ # Must be first since it unloads the prelude from 1.9.2
+diff --git a/lib/rubygems/remote_fetcher.rb b/lib/rubygems/remote_fetcher.rb
+index 58991ca..ed2e171 100644
+--- a/lib/rubygems/remote_fetcher.rb
++++ b/lib/rubygems/remote_fetcher.rb
+@@ -90,7 +90,13 @@ class Gem::RemoteFetcher
+     rescue Resolv::ResolvError
+       uri
+     else
+-      URI.parse "#{uri.scheme}://#{res.target}#{uri.path}"
++      target = res.target.to_s.strip
++
++      if /\.#{Regexp.quote(host)}\z/ =~ target
++        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
++      end
++
++      uri
+     end
+   end
+ 


### PR DESCRIPTION
This will require bumping Vanagon to `0.3.1` or higher in `Gemfile`, but otherwise this is pretty straightforward.
