### PR TITLE
[DO NOT MERGE](PUP-4631) Update Windows puppet for the win

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "refs/tags/4.1.0"
+  "ref": "refs/tags/4.2.0"
 }


### PR DESCRIPTION
Update to capture the changes for 4.2.0 of puppet_for_the_win. This
includes the new deprecation notices for Windows 2003.
