### PR TITLE
(RE-4833) Update Windows for OpenSSL, RubyGems CVEs

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.6.0-x86",
-    "x64": "refs/tags/2.1.6.0-x64"
+    "x86": "refs/tags/2.1.6.1-x86",
+    "x64": "refs/tags/2.1.6.1-x64"
   }
 }


### PR DESCRIPTION
This commit updates Windows Ruby to versions
containing OpenSSL 1.0.0.s and remediation for
RubyGems CVE-2015-4020.
