### PR TITLE
(maint) Pin packaging to the minor series to pick up bugfixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.2')
-gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'
+gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'


### PR DESCRIPTION
Previously packaging was pinned to 0.4.2 which meant that bugfixes to
packaging would not be picked up. As packaging is only used for the ship
and repo creation, and not the build itself for puppet-agent, it should
be safe to use a more relaxed pin, which this commit applies.
