### PR TITLE
(RE-4826) Apply patch for augeas readline functions

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,15 +1,10 @@
 component 'augeas' do |pkg, settings, platform|
-  if platform.is_osx?
-    # RE-4826 - Augeas 1.4.0 won't build on osx due to libedit incompatibilities
-    pkg.version '1.3.0'
-    pkg.md5sum 'c8890b11a04795ecfe5526eeae946b2d'
-  else
-    pkg.version '1.4.0'
-    pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
-  end
+  pkg.version '1.4.0'
+  pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-augeas'
+  pkg.apply_patch 'resources/patches/augeas/osx-stub-needed-readline-functions.patch'
 
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'

--- a/resources/patches/augeas/osx-stub-needed-readline-functions.patch
+++ b/resources/patches/augeas/osx-stub-needed-readline-functions.patch
@@ -1,0 +1,2915 @@
+diff -ru augeas-1.4.0/acinclude.m4 /home/lutter/code/augeas/acinclude.m4
+--- augeas-1.4.0/acinclude.m4	2015-05-22 11:46:09.000000000 -0700
++++ /home/lutter/code/augeas/acinclude.m4	2015-06-12 10:18:33.108594972 -0700
+@@ -142,7 +142,7 @@
+   if test $use_readline = yes; then
+       saved_libs=$LIBS
+       LIBS=$READLINE_LIBS
+-      AC_CHECK_FUNCS([rl_completion_matches])
++      AC_CHECK_FUNCS([rl_completion_matches rl_crlf rl_replace_line])
+       LIBS=$saved_libs
+   fi
+ ])
+diff -ru augeas-1.4.0/aclocal.m4 /home/lutter/code/augeas/aclocal.m4
+--- augeas-1.4.0/aclocal.m4	2015-06-01 17:23:19.000000000 -0700
++++ /home/lutter/code/augeas/aclocal.m4	2015-06-12 10:18:41.082585534 -0700
+@@ -1,6 +1,6 @@
+-# generated automatically by aclocal 1.14.1 -*- Autoconf -*-
++# generated automatically by aclocal 1.15 -*- Autoconf -*-
+ 
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ 
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -235,7 +235,7 @@
+ AS_VAR_IF([$1], [""], [$5], [$4])dnl
+ ])# PKG_CHECK_VAR
+ 
+-# Copyright (C) 2002-2013 Free Software Foundation, Inc.
++# Copyright (C) 2002-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -247,10 +247,10 @@
+ # generated from the m4 files accompanying Automake X.Y.
+ # (This private macro should not be called outside this file.)
+ AC_DEFUN([AM_AUTOMAKE_VERSION],
+-[am__api_version='1.14'
++[am__api_version='1.15'
+ dnl Some users find AM_AUTOMAKE_VERSION and mistake it for a way to
+ dnl require some minimum version.  Point them to the right macro.
+-m4_if([$1], [1.14.1], [],
++m4_if([$1], [1.15], [],
+       [AC_FATAL([Do not call $0, use AM_INIT_AUTOMAKE([$1]).])])dnl
+ ])
+ 
+@@ -266,14 +266,14 @@
+ # Call AM_AUTOMAKE_VERSION and AM_AUTOMAKE_VERSION so they can be traced.
+ # This function is AC_REQUIREd by AM_INIT_AUTOMAKE.
+ AC_DEFUN([AM_SET_CURRENT_AUTOMAKE_VERSION],
+-[AM_AUTOMAKE_VERSION([1.14.1])dnl
++[AM_AUTOMAKE_VERSION([1.15])dnl
+ m4_ifndef([AC_AUTOCONF_VERSION],
+   [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
+ _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
+ 
+ # AM_AUX_DIR_EXPAND                                         -*- Autoconf -*-
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -318,15 +318,14 @@
+ # configured tree to be moved without reconfiguration.
+ 
+ AC_DEFUN([AM_AUX_DIR_EXPAND],
+-[dnl Rely on autoconf to set up CDPATH properly.
+-AC_PREREQ([2.50])dnl
+-# expand $ac_aux_dir to an absolute path
+-am_aux_dir=`cd $ac_aux_dir && pwd`
++[AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
++# Expand $ac_aux_dir to an absolute path.
++am_aux_dir=`cd "$ac_aux_dir" && pwd`
+ ])
+ 
+ # AM_CONDITIONAL                                            -*- Autoconf -*-
+ 
+-# Copyright (C) 1997-2013 Free Software Foundation, Inc.
++# Copyright (C) 1997-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -357,7 +356,7 @@
+ Usually this means the macro was only invoked conditionally.]])
+ fi])])
+ 
+-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
++# Copyright (C) 1999-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -548,7 +547,7 @@
+ 
+ # Generate code to set up dependency tracking.              -*- Autoconf -*-
+ 
+-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
++# Copyright (C) 1999-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -624,7 +623,7 @@
+ 
+ # Do all the work for Automake.                             -*- Autoconf -*-
+ 
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -714,8 +713,8 @@
+ # <http://lists.gnu.org/archive/html/automake/2012-07/msg00001.html>
+ # <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
+ AC_SUBST([mkdir_p], ['$(MKDIR_P)'])
+-# We need awk for the "check" target.  The system "awk" is bad on
+-# some platforms.
++# We need awk for the "check" target (and possibly the TAP driver).  The
++# system "awk" is bad on some platforms.
+ AC_REQUIRE([AC_PROG_AWK])dnl
+ AC_REQUIRE([AC_PROG_MAKE_SET])dnl
+ AC_REQUIRE([AM_SET_LEADING_DOT])dnl
+@@ -788,7 +787,11 @@
+ END
+     AC_MSG_ERROR([Your 'rm' program is bad, sorry.])
+   fi
+-fi])
++fi
++dnl The trailing newline in this macro's definition is deliberate, for
++dnl backward compatibility and to allow trailing 'dnl'-style comments
++dnl after the AM_INIT_AUTOMAKE invocation. See automake bug#16841.
++])
+ 
+ dnl Hook into '_AC_COMPILER_EXEEXT' early to learn its expansion.  Do not
+ dnl add the conditional right here, as _AC_COMPILER_EXEEXT may be further
+@@ -817,7 +820,7 @@
+ done
+ echo "timestamp for $_am_arg" >`AS_DIRNAME(["$_am_arg"])`/stamp-h[]$_am_stamp_count])
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -828,7 +831,7 @@
+ # Define $install_sh.
+ AC_DEFUN([AM_PROG_INSTALL_SH],
+ [AC_REQUIRE([AM_AUX_DIR_EXPAND])dnl
+-if test x"${install_sh}" != xset; then
++if test x"${install_sh+set}" != xset; then
+   case $am_aux_dir in
+   *\ * | *\	*)
+     install_sh="\${SHELL} '$am_aux_dir/install-sh'" ;;
+@@ -838,7 +841,7 @@
+ fi
+ AC_SUBST([install_sh])])
+ 
+-# Copyright (C) 2003-2013 Free Software Foundation, Inc.
++# Copyright (C) 2003-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -859,7 +862,7 @@
+ 
+ # Check to see how 'make' treats includes.	            -*- Autoconf -*-
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -909,7 +912,7 @@
+ 
+ # Fake the existence of programs that GNU maintainers use.  -*- Autoconf -*-
+ 
+-# Copyright (C) 1997-2013 Free Software Foundation, Inc.
++# Copyright (C) 1997-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -950,7 +953,7 @@
+ # Obsolete and "removed" macros, that must however still report explicit
+ # error messages when used, to smooth transition.
+ #
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -977,7 +980,7 @@
+ 
+ # Helper functions for option handling.                     -*- Autoconf -*-
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1006,7 +1009,7 @@
+ AC_DEFUN([_AM_IF_OPTION],
+ [m4_ifset(_AM_MANGLE_OPTION([$1]), [$2], [$3])])
+ 
+-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
++# Copyright (C) 1999-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1053,7 +1056,7 @@
+ # For backward compatibility.
+ AC_DEFUN_ONCE([AM_PROG_CC_C_O], [AC_REQUIRE([AC_PROG_CC])])
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1072,7 +1075,7 @@
+ 
+ # Check to make sure that the build environment is sane.    -*- Autoconf -*-
+ 
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1153,7 +1156,7 @@
+ rm -f conftest.file
+ ])
+ 
+-# Copyright (C) 2009-2013 Free Software Foundation, Inc.
++# Copyright (C) 2009-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1213,7 +1216,7 @@
+ _AM_SUBST_NOTMAKE([AM_BACKSLASH])dnl
+ ])
+ 
+-# Copyright (C) 2001-2013 Free Software Foundation, Inc.
++# Copyright (C) 2001-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1241,7 +1244,7 @@
+ INSTALL_STRIP_PROGRAM="\$(install_sh) -c -s"
+ AC_SUBST([INSTALL_STRIP_PROGRAM])])
+ 
+-# Copyright (C) 2006-2013 Free Software Foundation, Inc.
++# Copyright (C) 2006-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -1260,7 +1263,7 @@
+ 
+ # Check how to create a tarball.                            -*- Autoconf -*-
+ 
+-# Copyright (C) 2004-2013 Free Software Foundation, Inc.
++# Copyright (C) 2004-2014 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+Only in /home/lutter/code/augeas/: augeas-0.8.0-1.fc15.err
+Only in /home/lutter/code/augeas/: augeas-1.4.0.tar.gz
+Only in /home/lutter/code/augeas/: augeas-1.4.0.tar.gz.sig
+Only in /home/lutter/code/augeas/: augeas.pc
+Only in /home/lutter/code/augeas/: autogen.sh
+Only in /home/lutter/code/augeas/: bootstrap
+diff -ru augeas-1.4.0/build/ac-aux/compile /home/lutter/code/augeas/build/ac-aux/compile
+--- augeas-1.4.0/build/ac-aux/compile	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/compile	2015-01-07 04:05:37.000000000 -0800
+@@ -3,7 +3,7 @@
+ 
+ scriptversion=2012-10-14.11; # UTC
+ 
+-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
++# Copyright (C) 1999-2014 Free Software Foundation, Inc.
+ # Written by Tom Tromey <tromey@cygnus.com>.
+ #
+ # This program is free software; you can redistribute it and/or modify
+diff -ru augeas-1.4.0/build/ac-aux/config.guess /home/lutter/code/augeas/build/ac-aux/config.guess
+--- augeas-1.4.0/build/ac-aux/config.guess	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/config.guess	2015-01-07 04:05:37.000000000 -0800
+@@ -1,8 +1,8 @@
+ #! /bin/sh
+ # Attempt to guess a canonical system name.
+-#   Copyright 1992-2014 Free Software Foundation, Inc.
++#   Copyright 1992-2015 Free Software Foundation, Inc.
+ 
+-timestamp='2014-03-23'
++timestamp='2015-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -24,12 +24,12 @@
+ # program.  This Exception is an additional permission under section 7
+ # of the GNU General Public License, version 3 ("GPLv3").
+ #
+-# Originally written by Per Bothner.
++# Originally written by Per Bothner; maintained since 2000 by Ben Elliston.
+ #
+ # You can get the latest version of this script from:
+ # http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
+ #
+-# Please send patches with a ChangeLog entry to config-patches@gnu.org.
++# Please send patches to <config-patches@gnu.org>.
+ 
+ 
+ me=`echo "$0" | sed -e 's,.*/,,'`
+@@ -50,7 +50,7 @@
+ GNU config.guess ($timestamp)
+ 
+ Originally written by Per Bothner.
+-Copyright 1992-2014 Free Software Foundation, Inc.
++Copyright 1992-2015 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -579,8 +579,9 @@
+ 	else
+ 		IBM_ARCH=powerpc
+ 	fi
+-	if [ -x /usr/bin/oslevel ] ; then
+-		IBM_REV=`/usr/bin/oslevel`
++	if [ -x /usr/bin/lslpp ] ; then
++		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
++			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
+ 	else
+ 		IBM_REV=${UNAME_VERSION}.${UNAME_RELEASE}
+ 	fi
+Only in /home/lutter/code/augeas/build/ac-aux: config.rpath~
+diff -ru augeas-1.4.0/build/ac-aux/config.sub /home/lutter/code/augeas/build/ac-aux/config.sub
+--- augeas-1.4.0/build/ac-aux/config.sub	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/config.sub	2015-01-07 04:05:37.000000000 -0800
+@@ -1,8 +1,8 @@
+ #! /bin/sh
+ # Configuration validation subroutine script.
+-#   Copyright 1992-2014 Free Software Foundation, Inc.
++#   Copyright 1992-2015 Free Software Foundation, Inc.
+ 
+-timestamp='2014-07-28'
++timestamp='2015-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -25,7 +25,7 @@
+ # of the GNU General Public License, version 3 ("GPLv3").
+ 
+ 
+-# Please send patches with a ChangeLog entry to config-patches@gnu.org.
++# Please send patches to <config-patches@gnu.org>.
+ #
+ # Configuration subroutine to validate and canonicalize a configuration type.
+ # Supply the specified configuration type as an argument.
+@@ -68,7 +68,7 @@
+ version="\
+ GNU config.sub ($timestamp)
+ 
+-Copyright 1992-2014 Free Software Foundation, Inc.
++Copyright 1992-2015 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -260,7 +260,7 @@
+ 	| c4x | c8051 | clipper \
+ 	| d10v | d30v | dlx | dsp16xx \
+ 	| epiphany \
+-	| fido | fr30 | frv \
++	| fido | fr30 | frv | ft32 \
+ 	| h8300 | h8500 | hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
+ 	| hexagon \
+ 	| i370 | i860 | i960 | ia64 \
+@@ -302,6 +302,7 @@
+ 	| pdp10 | pdp11 | pj | pjl \
+ 	| powerpc | powerpc64 | powerpc64le | powerpcle \
+ 	| pyramid \
++	| riscv32 | riscv64 \
+ 	| rl78 | rx \
+ 	| score \
+ 	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+@@ -312,6 +313,7 @@
+ 	| tahoe | tic4x | tic54x | tic55x | tic6x | tic80 | tron \
+ 	| ubicom32 \
+ 	| v850 | v850e | v850e1 | v850e2 | v850es | v850e2v3 \
++	| visium \
+ 	| we32k \
+ 	| x86 | xc16x | xstormy16 | xtensa \
+ 	| z8k | z80)
+@@ -326,6 +328,9 @@
+ 	c6x)
+ 		basic_machine=tic6x-unknown
+ 		;;
++	leon|leon[3-9])
++		basic_machine=sparc-$basic_machine
++		;;
+ 	m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x | nvptx | picochip)
+ 		basic_machine=$basic_machine-unknown
+ 		os=-none
+@@ -436,6 +441,7 @@
+ 	| ubicom32-* \
+ 	| v850-* | v850e-* | v850e1-* | v850es-* | v850e2-* | v850e2v3-* \
+ 	| vax-* \
++	| visium-* \
+ 	| we32k-* \
+ 	| x86-* | x86_64-* | xc16x-* | xps100-* \
+ 	| xstormy16-* | xtensa*-* \
+@@ -773,6 +779,9 @@
+ 		basic_machine=m68k-isi
+ 		os=-sysv
+ 		;;
++	leon-*|leon[3-9]-*)
++		basic_machine=sparc-`echo $basic_machine | sed 's/-.*//'`
++		;;
+ 	m68knommu)
+ 		basic_machine=m68k-unknown
+ 		os=-linux
+diff -ru augeas-1.4.0/build/ac-aux/depcomp /home/lutter/code/augeas/build/ac-aux/depcomp
+--- augeas-1.4.0/build/ac-aux/depcomp	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/depcomp	2015-01-07 04:05:37.000000000 -0800
+@@ -3,7 +3,7 @@
+ 
+ scriptversion=2013-05-30.07; # UTC
+ 
+-# Copyright (C) 1999-2013 Free Software Foundation, Inc.
++# Copyright (C) 1999-2014 Free Software Foundation, Inc.
+ 
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+Only in /home/lutter/code/augeas/build/ac-aux: .gitignore
+Only in /home/lutter/code/augeas/build/ac-aux: gitlog-to-changelog~
+diff -ru augeas-1.4.0/build/ac-aux/install-sh /home/lutter/code/augeas/build/ac-aux/install-sh
+--- augeas-1.4.0/build/ac-aux/install-sh	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/install-sh	2015-01-07 04:05:37.000000000 -0800
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ # install - install a program, script, or datafile
+ 
+-scriptversion=2011-11-20.07; # UTC
++scriptversion=2013-12-25.23; # UTC
+ 
+ # This originates from X11R5 (mit/util/scripts/install.sh), which was
+ # later released in X11R6 (xc/config/util/install.sh) with the
+@@ -41,19 +41,15 @@
+ # This script is compatible with the BSD install script, but was written
+ # from scratch.
+ 
++tab='	'
+ nl='
+ '
+-IFS=" ""	$nl"
++IFS=" $tab$nl"
+ 
+-# set DOITPROG to echo to test this script
++# Set DOITPROG to "echo" to test this script.
+ 
+-# Don't use :- since 4.3BSD and earlier shells don't like it.
+ doit=${DOITPROG-}
+-if test -z "$doit"; then
+-  doit_exec=exec
+-else
+-  doit_exec=$doit
+-fi
++doit_exec=${doit:-exec}
+ 
+ # Put in absolute file names if you don't have them in your path;
+ # or use environment vars.
+@@ -68,17 +64,6 @@
+ rmprog=${RMPROG-rm}
+ stripprog=${STRIPPROG-strip}
+ 
+-posix_glob='?'
+-initialize_posix_glob='
+-  test "$posix_glob" != "?" || {
+-    if (set -f) 2>/dev/null; then
+-      posix_glob=
+-    else
+-      posix_glob=:
+-    fi
+-  }
+-'
+-
+ posix_mkdir=
+ 
+ # Desired mode of installed file.
+@@ -97,7 +82,7 @@
+ dst_arg=
+ 
+ copy_on_change=false
+-no_target_directory=
++is_target_a_directory=possibly
+ 
+ usage="\
+ Usage: $0 [OPTION]... [-T] SRCFILE DSTFILE
+@@ -137,46 +122,57 @@
+     -d) dir_arg=true;;
+ 
+     -g) chgrpcmd="$chgrpprog $2"
+-	shift;;
++        shift;;
+ 
+     --help) echo "$usage"; exit $?;;
+ 
+     -m) mode=$2
+-	case $mode in
+-	  *' '* | *'	'* | *'
+-'*	  | *'*'* | *'?'* | *'['*)
+-	    echo "$0: invalid mode: $mode" >&2
+-	    exit 1;;
+-	esac
+-	shift;;
++        case $mode in
++          *' '* | *"$tab"* | *"$nl"* | *'*'* | *'?'* | *'['*)
++            echo "$0: invalid mode: $mode" >&2
++            exit 1;;
++        esac
++        shift;;
+ 
+     -o) chowncmd="$chownprog $2"
+-	shift;;
++        shift;;
+ 
+     -s) stripcmd=$stripprog;;
+ 
+-    -t) dst_arg=$2
+-	# Protect names problematic for 'test' and other utilities.
+-	case $dst_arg in
+-	  -* | [=\(\)!]) dst_arg=./$dst_arg;;
+-	esac
+-	shift;;
++    -t)
++        is_target_a_directory=always
++        dst_arg=$2
++        # Protect names problematic for 'test' and other utilities.
++        case $dst_arg in
++          -* | [=\(\)!]) dst_arg=./$dst_arg;;
++        esac
++        shift;;
+ 
+-    -T) no_target_directory=true;;
++    -T) is_target_a_directory=never;;
+ 
+     --version) echo "$0 $scriptversion"; exit $?;;
+ 
+-    --)	shift
+-	break;;
++    --) shift
++        break;;
+ 
+-    -*)	echo "$0: invalid option: $1" >&2
+-	exit 1;;
++    -*) echo "$0: invalid option: $1" >&2
++        exit 1;;
+ 
+     *)  break;;
+   esac
+   shift
+ done
+ 
++# We allow the use of options -d and -T together, by making -d
++# take the precedence; this is for compatibility with GNU install.
++
++if test -n "$dir_arg"; then
++  if test -n "$dst_arg"; then
++    echo "$0: target directory not allowed when installing a directory." >&2
++    exit 1
++  fi
++fi
++
+ if test $# -ne 0 && test -z "$dir_arg$dst_arg"; then
+   # When -d is used, all remaining arguments are directories to create.
+   # When -t is used, the destination is already specified.
+@@ -208,6 +204,15 @@
+ fi
+ 
+ if test -z "$dir_arg"; then
++  if test $# -gt 1 || test "$is_target_a_directory" = always; then
++    if test ! -d "$dst_arg"; then
++      echo "$0: $dst_arg: Is not a directory." >&2
++      exit 1
++    fi
++  fi
++fi
++
++if test -z "$dir_arg"; then
+   do_exit='(exit $ret); exit $ret'
+   trap "ret=129; $do_exit" 1
+   trap "ret=130; $do_exit" 2
+@@ -223,16 +228,16 @@
+ 
+     *[0-7])
+       if test -z "$stripcmd"; then
+-	u_plus_rw=
++        u_plus_rw=
+       else
+-	u_plus_rw='% 200'
++        u_plus_rw='% 200'
+       fi
+       cp_umask=`expr '(' 777 - $mode % 1000 ')' $u_plus_rw`;;
+     *)
+       if test -z "$stripcmd"; then
+-	u_plus_rw=
++        u_plus_rw=
+       else
+-	u_plus_rw=,u+rw
++        u_plus_rw=,u+rw
+       fi
+       cp_umask=$mode$u_plus_rw;;
+   esac
+@@ -269,41 +274,15 @@
+     # If destination is a directory, append the input filename; won't work
+     # if double slashes aren't ignored.
+     if test -d "$dst"; then
+-      if test -n "$no_target_directory"; then
+-	echo "$0: $dst_arg: Is a directory" >&2
+-	exit 1
++      if test "$is_target_a_directory" = never; then
++        echo "$0: $dst_arg: Is a directory" >&2
++        exit 1
+       fi
+       dstdir=$dst
+       dst=$dstdir/`basename "$src"`
+       dstdir_status=0
+     else
+-      # Prefer dirname, but fall back on a substitute if dirname fails.
+-      dstdir=`
+-	(dirname "$dst") 2>/dev/null ||
+-	expr X"$dst" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
+-	     X"$dst" : 'X\(//\)[^/]' \| \
+-	     X"$dst" : 'X\(//\)$' \| \
+-	     X"$dst" : 'X\(/\)' \| . 2>/dev/null ||
+-	echo X"$dst" |
+-	    sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+-		   s//\1/
+-		   q
+-		 }
+-		 /^X\(\/\/\)[^/].*/{
+-		   s//\1/
+-		   q
+-		 }
+-		 /^X\(\/\/\)$/{
+-		   s//\1/
+-		   q
+-		 }
+-		 /^X\(\/\).*/{
+-		   s//\1/
+-		   q
+-		 }
+-		 s/.*/./; q'
+-      `
+-
++      dstdir=`dirname "$dst"`
+       test -d "$dstdir"
+       dstdir_status=$?
+     fi
+@@ -314,74 +293,74 @@
+   if test $dstdir_status != 0; then
+     case $posix_mkdir in
+       '')
+-	# Create intermediate dirs using mode 755 as modified by the umask.
+-	# This is like FreeBSD 'install' as of 1997-10-28.
+-	umask=`umask`
+-	case $stripcmd.$umask in
+-	  # Optimize common cases.
+-	  *[2367][2367]) mkdir_umask=$umask;;
+-	  .*0[02][02] | .[02][02] | .[02]) mkdir_umask=22;;
+-
+-	  *[0-7])
+-	    mkdir_umask=`expr $umask + 22 \
+-	      - $umask % 100 % 40 + $umask % 20 \
+-	      - $umask % 10 % 4 + $umask % 2
+-	    `;;
+-	  *) mkdir_umask=$umask,go-w;;
+-	esac
+-
+-	# With -d, create the new directory with the user-specified mode.
+-	# Otherwise, rely on $mkdir_umask.
+-	if test -n "$dir_arg"; then
+-	  mkdir_mode=-m$mode
+-	else
+-	  mkdir_mode=
+-	fi
+-
+-	posix_mkdir=false
+-	case $umask in
+-	  *[123567][0-7][0-7])
+-	    # POSIX mkdir -p sets u+wx bits regardless of umask, which
+-	    # is incompatible with FreeBSD 'install' when (umask & 300) != 0.
+-	    ;;
+-	  *)
+-	    tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
+-	    trap 'ret=$?; rmdir "$tmpdir/d" "$tmpdir" 2>/dev/null; exit $ret' 0
+-
+-	    if (umask $mkdir_umask &&
+-		exec $mkdirprog $mkdir_mode -p -- "$tmpdir/d") >/dev/null 2>&1
+-	    then
+-	      if test -z "$dir_arg" || {
+-		   # Check for POSIX incompatibilities with -m.
+-		   # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
+-		   # other-writable bit of parent directory when it shouldn't.
+-		   # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
+-		   ls_ld_tmpdir=`ls -ld "$tmpdir"`
+-		   case $ls_ld_tmpdir in
+-		     d????-?r-*) different_mode=700;;
+-		     d????-?--*) different_mode=755;;
+-		     *) false;;
+-		   esac &&
+-		   $mkdirprog -m$different_mode -p -- "$tmpdir" && {
+-		     ls_ld_tmpdir_1=`ls -ld "$tmpdir"`
+-		     test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
+-		   }
+-		 }
+-	      then posix_mkdir=:
+-	      fi
+-	      rmdir "$tmpdir/d" "$tmpdir"
+-	    else
+-	      # Remove any dirs left behind by ancient mkdir implementations.
+-	      rmdir ./$mkdir_mode ./-p ./-- 2>/dev/null
+-	    fi
+-	    trap '' 0;;
+-	esac;;
++        # Create intermediate dirs using mode 755 as modified by the umask.
++        # This is like FreeBSD 'install' as of 1997-10-28.
++        umask=`umask`
++        case $stripcmd.$umask in
++          # Optimize common cases.
++          *[2367][2367]) mkdir_umask=$umask;;
++          .*0[02][02] | .[02][02] | .[02]) mkdir_umask=22;;
++
++          *[0-7])
++            mkdir_umask=`expr $umask + 22 \
++              - $umask % 100 % 40 + $umask % 20 \
++              - $umask % 10 % 4 + $umask % 2
++            `;;
++          *) mkdir_umask=$umask,go-w;;
++        esac
++
++        # With -d, create the new directory with the user-specified mode.
++        # Otherwise, rely on $mkdir_umask.
++        if test -n "$dir_arg"; then
++          mkdir_mode=-m$mode
++        else
++          mkdir_mode=
++        fi
++
++        posix_mkdir=false
++        case $umask in
++          *[123567][0-7][0-7])
++            # POSIX mkdir -p sets u+wx bits regardless of umask, which
++            # is incompatible with FreeBSD 'install' when (umask & 300) != 0.
++            ;;
++          *)
++            tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
++            trap 'ret=$?; rmdir "$tmpdir/d" "$tmpdir" 2>/dev/null; exit $ret' 0
++
++            if (umask $mkdir_umask &&
++                exec $mkdirprog $mkdir_mode -p -- "$tmpdir/d") >/dev/null 2>&1
++            then
++              if test -z "$dir_arg" || {
++                   # Check for POSIX incompatibilities with -m.
++                   # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
++                   # other-writable bit of parent directory when it shouldn't.
++                   # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
++                   ls_ld_tmpdir=`ls -ld "$tmpdir"`
++                   case $ls_ld_tmpdir in
++                     d????-?r-*) different_mode=700;;
++                     d????-?--*) different_mode=755;;
++                     *) false;;
++                   esac &&
++                   $mkdirprog -m$different_mode -p -- "$tmpdir" && {
++                     ls_ld_tmpdir_1=`ls -ld "$tmpdir"`
++                     test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
++                   }
++                 }
++              then posix_mkdir=:
++              fi
++              rmdir "$tmpdir/d" "$tmpdir"
++            else
++              # Remove any dirs left behind by ancient mkdir implementations.
++              rmdir ./$mkdir_mode ./-p ./-- 2>/dev/null
++            fi
++            trap '' 0;;
++        esac;;
+     esac
+ 
+     if
+       $posix_mkdir && (
+-	umask $mkdir_umask &&
+-	$doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir"
++        umask $mkdir_umask &&
++        $doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir"
+       )
+     then :
+     else
+@@ -391,53 +370,51 @@
+       # directory the slow way, step by step, checking for races as we go.
+ 
+       case $dstdir in
+-	/*) prefix='/';;
+-	[-=\(\)!]*) prefix='./';;
+-	*)  prefix='';;
++        /*) prefix='/';;
++        [-=\(\)!]*) prefix='./';;
++        *)  prefix='';;
+       esac
+ 
+-      eval "$initialize_posix_glob"
+-
+       oIFS=$IFS
+       IFS=/
+-      $posix_glob set -f
++      set -f
+       set fnord $dstdir
+       shift
+-      $posix_glob set +f
++      set +f
+       IFS=$oIFS
+ 
+       prefixes=
+ 
+       for d
+       do
+-	test X"$d" = X && continue
++        test X"$d" = X && continue
+ 
+-	prefix=$prefix$d
+-	if test -d "$prefix"; then
+-	  prefixes=
+-	else
+-	  if $posix_mkdir; then
+-	    (umask=$mkdir_umask &&
+-	     $doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir") && break
+-	    # Don't fail if two instances are running concurrently.
+-	    test -d "$prefix" || exit 1
+-	  else
+-	    case $prefix in
+-	      *\'*) qprefix=`echo "$prefix" | sed "s/'/'\\\\\\\\''/g"`;;
+-	      *) qprefix=$prefix;;
+-	    esac
+-	    prefixes="$prefixes '$qprefix'"
+-	  fi
+-	fi
+-	prefix=$prefix/
++        prefix=$prefix$d
++        if test -d "$prefix"; then
++          prefixes=
++        else
++          if $posix_mkdir; then
++            (umask=$mkdir_umask &&
++             $doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir") && break
++            # Don't fail if two instances are running concurrently.
++            test -d "$prefix" || exit 1
++          else
++            case $prefix in
++              *\'*) qprefix=`echo "$prefix" | sed "s/'/'\\\\\\\\''/g"`;;
++              *) qprefix=$prefix;;
++            esac
++            prefixes="$prefixes '$qprefix'"
++          fi
++        fi
++        prefix=$prefix/
+       done
+ 
+       if test -n "$prefixes"; then
+-	# Don't fail if two instances are running concurrently.
+-	(umask $mkdir_umask &&
+-	 eval "\$doit_exec \$mkdirprog $prefixes") ||
+-	  test -d "$dstdir" || exit 1
+-	obsolete_mkdir_used=true
++        # Don't fail if two instances are running concurrently.
++        (umask $mkdir_umask &&
++         eval "\$doit_exec \$mkdirprog $prefixes") ||
++          test -d "$dstdir" || exit 1
++        obsolete_mkdir_used=true
+       fi
+     fi
+   fi
+@@ -472,15 +449,12 @@
+ 
+     # If -C, don't bother to copy if it wouldn't change the file.
+     if $copy_on_change &&
+-       old=`LC_ALL=C ls -dlL "$dst"	2>/dev/null` &&
+-       new=`LC_ALL=C ls -dlL "$dsttmp"	2>/dev/null` &&
+-
+-       eval "$initialize_posix_glob" &&
+-       $posix_glob set -f &&
++       old=`LC_ALL=C ls -dlL "$dst"     2>/dev/null` &&
++       new=`LC_ALL=C ls -dlL "$dsttmp"  2>/dev/null` &&
++       set -f &&
+        set X $old && old=:$2:$4:$5:$6 &&
+        set X $new && new=:$2:$4:$5:$6 &&
+-       $posix_glob set +f &&
+-
++       set +f &&
+        test "$old" = "$new" &&
+        $cmpprog "$dst" "$dsttmp" >/dev/null 2>&1
+     then
+@@ -493,24 +467,24 @@
+       # to itself, or perhaps because mv is so ancient that it does not
+       # support -f.
+       {
+-	# Now remove or move aside any old file at destination location.
+-	# We try this two ways since rm can't unlink itself on some
+-	# systems and the destination file might be busy for other
+-	# reasons.  In this case, the final cleanup might fail but the new
+-	# file should still install successfully.
+-	{
+-	  test ! -f "$dst" ||
+-	  $doit $rmcmd -f "$dst" 2>/dev/null ||
+-	  { $doit $mvcmd -f "$dst" "$rmtmp" 2>/dev/null &&
+-	    { $doit $rmcmd -f "$rmtmp" 2>/dev/null; :; }
+-	  } ||
+-	  { echo "$0: cannot unlink or rename $dst" >&2
+-	    (exit 1); exit 1
+-	  }
+-	} &&
++        # Now remove or move aside any old file at destination location.
++        # We try this two ways since rm can't unlink itself on some
++        # systems and the destination file might be busy for other
++        # reasons.  In this case, the final cleanup might fail but the new
++        # file should still install successfully.
++        {
++          test ! -f "$dst" ||
++          $doit $rmcmd -f "$dst" 2>/dev/null ||
++          { $doit $mvcmd -f "$dst" "$rmtmp" 2>/dev/null &&
++            { $doit $rmcmd -f "$rmtmp" 2>/dev/null; :; }
++          } ||
++          { echo "$0: cannot unlink or rename $dst" >&2
++            (exit 1); exit 1
++          }
++        } &&
+ 
+-	# Now rename the file to the real destination.
+-	$doit $mvcmd "$dsttmp" "$dst"
++        # Now rename the file to the real destination.
++        $doit $mvcmd "$dsttmp" "$dst"
+       }
+     fi || exit 1
+ 
+diff -ru augeas-1.4.0/build/ac-aux/missing /home/lutter/code/augeas/build/ac-aux/missing
+--- augeas-1.4.0/build/ac-aux/missing	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/missing	2015-01-07 04:05:37.000000000 -0800
+@@ -3,7 +3,7 @@
+ 
+ scriptversion=2013-10-28.13; # UTC
+ 
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ # Originally written by Fran,cois Pinard <pinard@iro.umontreal.ca>, 1996.
+ 
+ # This program is free software; you can redistribute it and/or modify
+Only in /home/lutter/code/augeas/build/ac-aux/snippet: arg-nonnull.h~
+Only in /home/lutter/code/augeas/build/ac-aux/snippet: c++defs.h~
+Only in /home/lutter/code/augeas/build/ac-aux/snippet: .gitignore
+Only in /home/lutter/code/augeas/build/ac-aux/snippet: unused-parameter.h~
+Only in /home/lutter/code/augeas/build/ac-aux/snippet: warn-on-use.h~
+diff -ru augeas-1.4.0/build/ac-aux/test-driver /home/lutter/code/augeas/build/ac-aux/test-driver
+--- augeas-1.4.0/build/ac-aux/test-driver	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/test-driver	2015-01-07 04:05:37.000000000 -0800
+@@ -3,7 +3,7 @@
+ 
+ scriptversion=2013-07-13.22; # UTC
+ 
+-# Copyright (C) 2011-2013 Free Software Foundation, Inc.
++# Copyright (C) 2011-2014 Free Software Foundation, Inc.
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+@@ -106,11 +106,14 @@
+ # Test script is run here.
+ "$@" >$log_file 2>&1
+ estatus=$?
++
+ if test $enable_hard_errors = no && test $estatus -eq 99; then
+-  estatus=1
++  tweaked_estatus=1
++else
++  tweaked_estatus=$estatus
+ fi
+ 
+-case $estatus:$expect_failure in
++case $tweaked_estatus:$expect_failure in
+   0:yes) col=$red res=XPASS recheck=yes gcopy=yes;;
+   0:*)   col=$grn res=PASS  recheck=no  gcopy=no;;
+   77:*)  col=$blu res=SKIP  recheck=no  gcopy=yes;;
+@@ -119,6 +122,12 @@
+   *:*)   col=$red res=FAIL  recheck=yes gcopy=yes;;
+ esac
+ 
++# Report the test outcome and exit status in the logs, so that one can
++# know whether the test passed or failed simply by looking at the '.log'
++# file, without the need of also peaking into the corresponding '.trs'
++# file (automake bug#11814).
++echo "$res $test_name (exit status: $estatus)" >>$log_file
++
+ # Report outcome to console.
+ echo "${col}${res}${std}: $test_name"
+ 
+diff -ru augeas-1.4.0/build/ac-aux/ylwrap /home/lutter/code/augeas/build/ac-aux/ylwrap
+--- augeas-1.4.0/build/ac-aux/ylwrap	2014-09-10 04:57:56.000000000 -0700
++++ /home/lutter/code/augeas/build/ac-aux/ylwrap	2015-01-07 04:05:37.000000000 -0800
+@@ -3,7 +3,7 @@
+ 
+ scriptversion=2013-01-12.17; # UTC
+ 
+-# Copyright (C) 1996-2013 Free Software Foundation, Inc.
++# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ #
+ # Written by Tom Tromey <tromey@cygnus.com>.
+ #
+Only in /home/lutter/code/augeas/build: augcmds.txt
+Only in /home/lutter/code/augeas/build: augcmds.txt~
+Only in /home/lutter/code/augeas/build: gdbcmds.txt
+Only in /home/lutter/code/augeas/build: preserve
+Only in /home/lutter/code/augeas/build: test-augtool
+Only in /home/lutter/code/augeas/build: test-bug-1
+Only in /home/lutter/code/augeas/build: test-events-saved
+Only in /home/lutter/code/augeas/build: test-idempotent
+Only in /home/lutter/code/augeas/build: test-load
+Only in /home/lutter/code/augeas/build: test-put-symlink
+Only in /home/lutter/code/augeas/build: test-put-symlink-augnew
+Only in /home/lutter/code/augeas/build: test-put-symlink-augsave
+Only in /home/lutter/code/augeas/build: test-put-symlink-augtemp
+Only in /home/lutter/code/augeas/build: test-save
+Only in /home/lutter/code/augeas/build: test-save-empty
+Only in /home/lutter/code/augeas/build: test-save-mode
+Only in /home/lutter/code/augeas/build: test-unlink-error
+Only in /home/lutter/code/augeas/build: try
+Only in /home/lutter/code/augeas/: config.h
+diff -ru augeas-1.4.0/config.h.in /home/lutter/code/augeas/config.h.in
+--- augeas-1.4.0/config.h.in	2015-06-01 17:23:36.000000000 -0700
++++ /home/lutter/code/augeas/config.h.in	2015-06-12 10:18:57.863565674 -0700
+@@ -1001,6 +1001,12 @@
+ /* Define to 1 if you have the `rl_completion_matches' function. */
+ #undef HAVE_RL_COMPLETION_MATCHES
+ 
++/* Define to 1 if you have the `rl_crlf' function. */
++#undef HAVE_RL_CRLF
++
++/* Define to 1 if you have the `rl_replace_line' function. */
++#undef HAVE_RL_REPLACE_LINE
++
+ /* Define to 1 if you have the <search.h> header file. */
+ #undef HAVE_SEARCH_H
+ 
+Only in /home/lutter/code/augeas/: config.h.in~
+Only in /home/lutter/code/augeas/: config.log
+Only in /home/lutter/code/augeas/: config.status
+diff -ru augeas-1.4.0/configure /home/lutter/code/augeas/configure
+--- augeas-1.4.0/configure	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/configure	2015-06-12 10:18:42.367584014 -0700
+@@ -3427,7 +3427,7 @@
+ 
+ ac_config_headers="$ac_config_headers config.h"
+ 
+-am__api_version='1.14'
++am__api_version='1.15'
+ 
+ # Find a good install program.  We prefer a C program (faster),
+ # so one script is as good as another.  But avoid the broken or
+@@ -3599,8 +3599,8 @@
+ ac_script='s/[\\$]/&&/g;s/;s,x,x,$//'
+ program_transform_name=`$as_echo "$program_transform_name" | sed "$ac_script"`
+ 
+-# expand $ac_aux_dir to an absolute path
+-am_aux_dir=`cd $ac_aux_dir && pwd`
++# Expand $ac_aux_dir to an absolute path.
++am_aux_dir=`cd "$ac_aux_dir" && pwd`
+ 
+ if test x"${MISSING+set}" != xset; then
+   case $am_aux_dir in
+@@ -3619,7 +3619,7 @@
+ $as_echo "$as_me: WARNING: 'missing' script is too old or missing" >&2;}
+ fi
+ 
+-if test x"${install_sh}" != xset; then
++if test x"${install_sh+set}" != xset; then
+   case $am_aux_dir in
+   *\ * | *\	*)
+     install_sh="\${SHELL} '$am_aux_dir/install-sh'" ;;
+@@ -3948,8 +3948,8 @@
+ # <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
+ mkdir_p='$(MKDIR_P)'
+ 
+-# We need awk for the "check" target.  The system "awk" is bad on
+-# some platforms.
++# We need awk for the "check" target (and possibly the TAP driver).  The
++# system "awk" is bad on some platforms.
+ # Always define AMTAR for backward compatibility.  Yes, it's still used
+ # in the wild :-(  We should find a proper way to deprecate it ...
+ AMTAR='$${TAR-tar}'
+@@ -4006,6 +4006,7 @@
+     as_fn_error $? "Your 'rm' program is bad, sorry." "$LINENO" 5
+   fi
+ fi
++
+ # Check whether --enable-silent-rules was given.
+ if test "${enable_silent_rules+set}" = set; then :
+   enableval=$enable_silent_rules;
+@@ -15081,12 +15082,13 @@
+   if test $use_readline = yes; then
+       saved_libs=$LIBS
+       LIBS=$READLINE_LIBS
+-      for ac_func in rl_completion_matches
++      for ac_func in rl_completion_matches rl_crlf rl_replace_line
+ do :
+-  ac_fn_c_check_func "$LINENO" "rl_completion_matches" "ac_cv_func_rl_completion_matches"
+-if test "x$ac_cv_func_rl_completion_matches" = xyes; then :
++  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
++ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
++if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+   cat >>confdefs.h <<_ACEOF
+-#define HAVE_RL_COMPLETION_MATCHES 1
++#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+ _ACEOF
+ 
+ fi
+Only in /home/lutter/code/augeas/doc: cutest-license.txt
+Only in /home/lutter/code/augeas/doc: etc.txt
+Only in /home/lutter/code/augeas/doc: examples.txt
+Only in /home/lutter/code/augeas/doc: Makefile
+diff -ru augeas-1.4.0/doc/Makefile.in /home/lutter/code/augeas/doc/Makefile.in
+--- augeas-1.4.0/doc/Makefile.in	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/doc/Makefile.in	2015-06-12 10:18:42.267584132 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -15,7 +15,17 @@
+ @SET_MAKE@
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -78,7 +88,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ subdir = doc
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -215,6 +224,7 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -303,6 +313,7 @@
+ ETAGS = etags
+ CTAGS = ctags
+ DIST_SUBDIRS = $(SUBDIRS)
++am__DIST_COMMON = $(srcdir)/Makefile.in
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ am__relativize = \
+   dir0=`pwd`; \
+@@ -1185,7 +1196,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu doc/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu doc/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1508,6 +1518,8 @@
+ 	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
+ 	tags tags-am uninstall uninstall-am uninstall-nobase_vimDATA
+ 
++.PRECIOUS: Makefile
++
+ 
+ all-local: $(PDFDOCS)
+ 
+Only in /home/lutter/code/augeas/doc/naturaldocs: Makefile
+diff -ru augeas-1.4.0/doc/naturaldocs/Makefile.in /home/lutter/code/augeas/doc/naturaldocs/Makefile.in
+--- augeas-1.4.0/doc/naturaldocs/Makefile.in	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/doc/naturaldocs/Makefile.in	2015-06-12 10:18:42.335584051 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -14,7 +14,17 @@
+ 
+ @SET_MAKE@
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -77,7 +87,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ subdir = doc/naturaldocs
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -214,6 +223,7 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -238,6 +248,7 @@
+     *) (install-info --version) >/dev/null 2>&1;; \
+   esac
+ am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
++am__DIST_COMMON = $(srcdir)/Makefile.in
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ pkglibexecdir = @pkglibexecdir@
+ ACLOCAL = @ACLOCAL@
+@@ -1097,7 +1108,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu doc/naturaldocs/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu doc/naturaldocs/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1274,6 +1284,8 @@
+ 	mostlyclean-libtool pdf pdf-am ps ps-am tags-am uninstall \
+ 	uninstall-am
+ 
++.PRECIOUS: Makefile
++
+ 
+ @ND_ENABLED_TRUE@all-local: NaturalDocs
+ 
+Only in /home/lutter/code/augeas/examples: .deps
+Only in /home/lutter/code/augeas/examples: examples.sh
+Only in /home/lutter/code/augeas/examples: fadot
+Only in /home/lutter/code/augeas/examples: fadot.o
+Only in /home/lutter/code/augeas/examples: .libs
+Only in /home/lutter/code/augeas/examples: Makefile
+diff -ru augeas-1.4.0/examples/Makefile.in /home/lutter/code/augeas/examples/Makefile.in
+--- augeas-1.4.0/examples/Makefile.in	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/examples/Makefile.in	2015-06-12 10:18:42.428583941 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -15,7 +15,17 @@
+ @SET_MAKE@
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -79,8 +89,6 @@
+ host_triplet = @host@
+ bin_PROGRAMS = fadot$(EXEEXT)
+ subdir = examples
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+-	$(top_srcdir)/build/ac-aux/depcomp
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -217,6 +225,7 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -290,6 +299,8 @@
+   done | $(am__uniquify_input)`
+ ETAGS = etags
+ CTAGS = ctags
++am__DIST_COMMON = $(srcdir)/Makefile.in \
++	$(top_srcdir)/build/ac-aux/depcomp
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ pkglibexecdir = @pkglibexecdir@
+ ACLOCAL = @ACLOCAL@
+@@ -1148,7 +1159,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu examples/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu examples/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1460,6 +1470,8 @@
+ 	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
+ 	tags tags-am uninstall uninstall-am uninstall-binPROGRAMS
+ 
++.PRECIOUS: Makefile
++
+ 
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+Only in /home/lutter/code/augeas/: .git
+Only in /home/lutter/code/augeas/: .gitignore
+Only in /home/lutter/code/augeas/: .gitmodules
+Only in /home/lutter/code/augeas/gnulib/lib: alloca.h
+Only in /home/lutter/code/augeas/gnulib/lib: arg-nonnull.h
+Only in /home/lutter/code/augeas/gnulib/lib: asnprintf.lo
+Only in /home/lutter/code/augeas/gnulib/lib: asnprintf.o
+Only in /home/lutter/code/augeas/gnulib/lib: c++defs.h
+Only in /home/lutter/code/augeas/gnulib/lib: charset.alias
+Only in /home/lutter/code/augeas/gnulib/lib: configmake.h
+Only in /home/lutter/code/augeas/gnulib/lib: ctype.h
+Only in /home/lutter/code/augeas/gnulib/lib: .deps
+Only in /home/lutter/code/augeas/gnulib/lib: fcntl.h
+Only in /home/lutter/code/augeas/gnulib/lib: getfilecon.lo
+Only in /home/lutter/code/augeas/gnulib/lib: getfilecon.o
+Only in /home/lutter/code/augeas/gnulib/lib: .gitignore
+Only in /home/lutter/code/augeas/gnulib/lib: langinfo.h
+Only in /home/lutter/code/augeas/gnulib/lib: libgnu.la
+Only in /home/lutter/code/augeas/gnulib/lib: .libs
+Only in /home/lutter/code/augeas/gnulib/lib: localcharset.lo
+Only in /home/lutter/code/augeas/gnulib/lib: localcharset.o
+Only in /home/lutter/code/augeas/gnulib/lib: locale.h
+Only in /home/lutter/code/augeas/gnulib/lib: Makefile
+diff -ru augeas-1.4.0/gnulib/lib/Makefile.in /home/lutter/code/augeas/gnulib/lib/Makefile.in
+--- augeas-1.4.0/gnulib/lib/Makefile.in	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/gnulib/lib/Makefile.in	2015-06-12 10:18:42.586583754 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -40,7 +40,17 @@
+ 
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -103,8 +113,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ subdir = gnulib/lib
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am alloca.c \
+-	$(top_srcdir)/build/ac-aux/depcomp $(noinst_HEADERS)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -241,6 +249,8 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
++	$(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -336,6 +346,8 @@
+ ETAGS = etags
+ CTAGS = ctags
+ DIST_SUBDIRS = $(SUBDIRS)
++am__DIST_COMMON = $(srcdir)/Makefile.in \
++	$(top_srcdir)/build/ac-aux/depcomp alloca.c
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ am__relativize = \
+   dir0=`pwd`; \
+@@ -1316,7 +1328,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnits gnulib/lib/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnits gnulib/lib/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1726,6 +1737,8 @@
+ 	mostlyclean-libtool mostlyclean-local pdf pdf-am ps ps-am tags \
+ 	tags-am uninstall uninstall-am uninstall-local
+ 
++.PRECIOUS: Makefile
++
+ 
+ # We need the following in order to create <alloca.h> when the system
+ # doesn't have one that works with the given compiler.
+Only in /home/lutter/code/augeas/gnulib/lib: malloca.lo
+Only in /home/lutter/code/augeas/gnulib/lib: malloca.o
+Only in /home/lutter/code/augeas/gnulib/lib: printf-args.lo
+Only in /home/lutter/code/augeas/gnulib/lib: printf-args.o
+Only in /home/lutter/code/augeas/gnulib/lib: printf-parse.lo
+Only in /home/lutter/code/augeas/gnulib/lib: printf-parse.o
+Only in /home/lutter/code/augeas/gnulib/lib: ref-add.sed
+Only in /home/lutter/code/augeas/gnulib/lib: ref-del.sed
+Only in /home/lutter/code/augeas/gnulib/lib: safe-alloc.lo
+Only in /home/lutter/code/augeas/gnulib/lib: safe-alloc.o
+Only in /home/lutter/code/augeas/gnulib/lib: selinux
+Only in /home/lutter/code/augeas/gnulib/lib: stdio.h
+Only in /home/lutter/code/augeas/gnulib/lib: stdlib.h
+Only in /home/lutter/code/augeas/gnulib/lib: string.h
+Only in /home/lutter/code/augeas/gnulib/lib: strnlen1.lo
+Only in /home/lutter/code/augeas/gnulib/lib: strnlen1.o
+Only in /home/lutter/code/augeas/gnulib/lib: sys
+Only in /home/lutter/code/augeas/gnulib/lib: tempname.lo
+Only in /home/lutter/code/augeas/gnulib/lib: tempname.o
+Only in /home/lutter/code/augeas/gnulib/lib: time.h
+Only in /home/lutter/code/augeas/gnulib/lib: unistd.h
+Only in /home/lutter/code/augeas/gnulib/lib: unused-parameter.h
+Only in /home/lutter/code/augeas/gnulib/lib: vasnprintf.lo
+Only in /home/lutter/code/augeas/gnulib/lib: vasnprintf.o
+Only in /home/lutter/code/augeas/gnulib/lib: warn-on-use.h
+Only in /home/lutter/code/augeas/gnulib/lib: wchar.h
+Only in /home/lutter/code/augeas/gnulib/lib: wctype.h
+Only in /home/lutter/code/augeas/gnulib/m4: .gitignore
+Only in /home/lutter/code/augeas/gnulib/m4: gnulib-cache.m4
+Only in /home/lutter/code/augeas/gnulib/m4: gnulib-tool.m4
+Only in /home/lutter/code/augeas/gnulib/m4: math_h.m4
+Only in /home/lutter/code/augeas/gnulib/tests: arg-nonnull.h
+Only in /home/lutter/code/augeas/gnulib/tests: c-ctype.o
+Only in /home/lutter/code/augeas/gnulib/tests: c++defs.h
+Only in /home/lutter/code/augeas/gnulib/tests: c-strcasecmp.o
+Only in /home/lutter/code/augeas/gnulib/tests: c-strncasecmp.o
+Only in /home/lutter/code/augeas/gnulib/tests: .deps
+Only in /home/lutter/code/augeas/gnulib/tests: fd-hook.o
+Only in /home/lutter/code/augeas/gnulib/tests: .gitignore
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: .deps
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: .dirstamp
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: .gitignore
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: lock.o
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: threadlib.o
+Only in /home/lutter/code/augeas/gnulib/tests/glthread: thread.o
+Only in /home/lutter/code/augeas/gnulib/tests: inttypes.h
+Only in /home/lutter/code/augeas/gnulib/tests: .libs
+Only in /home/lutter/code/augeas/gnulib/tests: libtests.a
+Only in /home/lutter/code/augeas/gnulib/tests: localename.o
+Only in /home/lutter/code/augeas/gnulib/tests: Makefile
+diff -ru augeas-1.4.0/gnulib/tests/Makefile.in /home/lutter/code/augeas/gnulib/tests/Makefile.in
+--- augeas-1.4.0/gnulib/tests/Makefile.in	2015-06-01 17:23:21.000000000 -0700
++++ /home/lutter/code/augeas/gnulib/tests/Makefile.in	2015-06-12 10:18:42.852583439 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -39,7 +39,17 @@
+ 
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -179,9 +189,6 @@
+ 	test-verify$(EXEEXT) test-wchar$(EXEEXT) test-wcrtomb$(EXEEXT) \
+ 	test-wcrtomb-w32$(EXEEXT) test-wctype-h$(EXEEXT)
+ subdir = gnulib/tests
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+-	$(top_srcdir)/build/ac-aux/depcomp $(noinst_HEADERS) \
+-	$(top_srcdir)/build/ac-aux/test-driver
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -318,6 +325,8 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
++	$(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -1050,6 +1059,9 @@
+ TEST_LOG_COMPILE = $(TEST_LOG_COMPILER) $(AM_TEST_LOG_FLAGS) \
+ 	$(TEST_LOG_FLAGS)
+ DIST_SUBDIRS = $(SUBDIRS)
++am__DIST_COMMON = $(srcdir)/Makefile.in \
++	$(top_srcdir)/build/ac-aux/depcomp \
++	$(top_srcdir)/build/ac-aux/test-driver
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ am__relativize = \
+   dir0=`pwd`; \
+@@ -2070,7 +2082,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign gnulib/tests/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --foreign gnulib/tests/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -2716,7 +2727,7 @@
+ 	if test -n "$$am__remaking_logs"; then \
+ 	  echo "fatal: making $(TEST_SUITE_LOG): possible infinite" \
+ 	       "recursion detected" >&2; \
+-	else \
++	elif test -n "$$redo_logs"; then \
+ 	  am__remaking_logs=yes $(MAKE) $(AM_MAKEFLAGS) $$redo_logs; \
+ 	fi; \
+ 	if $(am__make_dryrun); then :; else \
+@@ -3702,6 +3713,8 @@
+ 	mostlyclean-generic mostlyclean-libtool mostlyclean-local pdf \
+ 	pdf-am ps ps-am recheck tags tags-am uninstall uninstall-am
+ 
++.PRECIOUS: Makefile
++
+ 
+ # We need the following in order to create <inttypes.h> when the system
+ # doesn't have one that works with the given compiler.
+Only in /home/lutter/code/augeas/gnulib/tests: test-alloca-opt
+Only in /home/lutter/code/augeas/gnulib/tests: test-alloca-opt.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-alloca-opt.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-alloca-opt.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-binary-io
+Only in /home/lutter/code/augeas/gnulib/tests: test-binary-io.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-binary-io.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-binary-io.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-btowc.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-canonicalize-lgpl
+Only in /home/lutter/code/augeas/gnulib/tests: test-canonicalize-lgpl.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-canonicalize-lgpl.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-canonicalize-lgpl.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-ctype
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-ctype.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-ctype.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-ctype.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-close
+Only in /home/lutter/code/augeas/gnulib/tests: test-close.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-close.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-close.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strcasecmp
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strcasecmp.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strcase.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strcase.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strncasecmp
+Only in /home/lutter/code/augeas/gnulib/tests: test-c-strncasecmp.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-ctype
+Only in /home/lutter/code/augeas/gnulib/tests: test-ctype.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-ctype.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-ctype.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-dup2
+Only in /home/lutter/code/augeas/gnulib/tests: test-dup2.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-dup2.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-dup2.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-environ
+Only in /home/lutter/code/augeas/gnulib/tests: test-environ.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-environ.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-environ.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-errno
+Only in /home/lutter/code/augeas/gnulib/tests: test-errno.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-errno.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-errno.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fcntl-h
+Only in /home/lutter/code/augeas/gnulib/tests: test-fcntl-h.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fcntl-h.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fcntl-h.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fdopen
+Only in /home/lutter/code/augeas/gnulib/tests: test-fdopen.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fdopen.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fdopen.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fgetc
+Only in /home/lutter/code/augeas/gnulib/tests: test-fgetc.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fgetc.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fgetc.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-float
+Only in /home/lutter/code/augeas/gnulib/tests: test-float.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-float.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-float.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fnmatch
+Only in /home/lutter/code/augeas/gnulib/tests: test-fnmatch.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fnmatch.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fnmatch.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fputc
+Only in /home/lutter/code/augeas/gnulib/tests: test-fputc.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fputc.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fputc.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fread
+Only in /home/lutter/code/augeas/gnulib/tests: test-fread.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fread.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fread.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fstat
+Only in /home/lutter/code/augeas/gnulib/tests: test-fstat.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fstat.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fstat.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-fwrite
+Only in /home/lutter/code/augeas/gnulib/tests: test-fwrite.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-fwrite.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-fwrite.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-getcwd-lgpl
+Only in /home/lutter/code/augeas/gnulib/tests: test-getcwd-lgpl.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-getcwd-lgpl.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-getcwd-lgpl.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-getdelim
+Only in /home/lutter/code/augeas/gnulib/tests: test-getdelim.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-getdelim.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-getdelim.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-getline
+Only in /home/lutter/code/augeas/gnulib/tests: test-getline.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-getline.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-getline.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-getopt
+Only in /home/lutter/code/augeas/gnulib/tests: test-getopt.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-getopt.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-getopt.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-gettimeofday
+Only in /home/lutter/code/augeas/gnulib/tests: test-gettimeofday.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-gettimeofday.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-gettimeofday.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-ignore-value
+Only in /home/lutter/code/augeas/gnulib/tests: test-ignore-value.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-ignore-value.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-ignore-value.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-init.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-init.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-intprops
+Only in /home/lutter/code/augeas/gnulib/tests: test-intprops.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-intprops.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-intprops.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-inttypes
+Only in /home/lutter/code/augeas/gnulib/tests: test-inttypes.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-inttypes.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-inttypes.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-isblank
+Only in /home/lutter/code/augeas/gnulib/tests: test-isblank.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-isblank.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-isblank.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-langinfo
+Only in /home/lutter/code/augeas/gnulib/tests: test-langinfo.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-langinfo.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-langinfo.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-locale
+Only in /home/lutter/code/augeas/gnulib/tests: test-localeconv
+Only in /home/lutter/code/augeas/gnulib/tests: test-localeconv.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-localeconv.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-localeconv.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-locale.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-localename
+Only in /home/lutter/code/augeas/gnulib/tests: test-localename.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-localename.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-localename.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-locale.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-locale.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-lock
+Only in /home/lutter/code/augeas/gnulib/tests: test-lock.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-lock.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-lock.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-lstat
+Only in /home/lutter/code/augeas/gnulib/tests: test-lstat.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-lstat.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-lstat.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloca
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloca.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloca.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloca.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloc-gnu
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloc-gnu.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloc-gnu.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-malloc-gnu.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc3.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc3.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc4.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc4.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-3.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-3.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-4.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-4.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-5.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32-5.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbrtowc-w32.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsinit
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsinit.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsinit.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsinit.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs3.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs3.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs4.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs4.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-mbsrtowcs.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-memchr
+Only in /home/lutter/code/augeas/gnulib/tests: test-memchr.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-memchr.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-memchr.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-nl_langinfo
+Only in /home/lutter/code/augeas/gnulib/tests: test-nl_langinfo.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-nl_langinfo.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-nl_langinfo.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-open
+Only in /home/lutter/code/augeas/gnulib/tests: test-open.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-open.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-open.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-pathmax
+Only in /home/lutter/code/augeas/gnulib/tests: test-pathmax.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-pathmax.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-pathmax.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-rawmemchr
+Only in /home/lutter/code/augeas/gnulib/tests: test-rawmemchr.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-rawmemchr.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-rawmemchr.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-readlink
+Only in /home/lutter/code/augeas/gnulib/tests: test-readlink.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-readlink.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-readlink.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-safe-alloc
+Only in /home/lutter/code/augeas/gnulib/tests: test-safe-alloc.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-safe-alloc.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-safe-alloc.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-setenv
+Only in /home/lutter/code/augeas/gnulib/tests: test-setenv.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-setenv.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-setenv.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale1
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale1.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale2
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale2.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-setlocale2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stat
+Only in /home/lutter/code/augeas/gnulib/tests: test-stat.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stat.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stat.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdbool
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdbool.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdbool.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdbool.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stddef
+Only in /home/lutter/code/augeas/gnulib/tests: test-stddef.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stddef.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stddef.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdint
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdint.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdint.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdint.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdio
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdio.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdio.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdio.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdlib
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdlib.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdlib.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-stdlib.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-strchrnul
+Only in /home/lutter/code/augeas/gnulib/tests: test-strchrnul.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-strchrnul.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-strchrnul.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-string
+Only in /home/lutter/code/augeas/gnulib/tests: test-string.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-string.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-string.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-strnlen
+Only in /home/lutter/code/augeas/gnulib/tests: test-strnlen.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-strnlen.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-strnlen.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-strstr
+Only in /home/lutter/code/augeas/gnulib/tests: test-strstr.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-strstr.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-strstr.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-suite.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-symlink
+Only in /home/lutter/code/augeas/gnulib/tests: test-symlink.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-symlink.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-symlink.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_stat
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_stat.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_stat.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_stat.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_time
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_time.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_time.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_time.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_types
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_types.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_types.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_types.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_wait
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_wait.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_wait.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-sys_wait.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_create
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_create.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_create.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_create.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_self
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_self.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_self.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-thread_self.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-time
+Only in /home/lutter/code/augeas/gnulib/tests: test-time.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-time.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-time.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-unistd
+Only in /home/lutter/code/augeas/gnulib/tests: test-unistd.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-unistd.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-unistd.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-unsetenv
+Only in /home/lutter/code/augeas/gnulib/tests: test-unsetenv.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-unsetenv.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-unsetenv.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasnprintf
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasnprintf.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasnprintf.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasnprintf.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasprintf
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasprintf.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasprintf.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-vasprintf.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-verify
+Only in /home/lutter/code/augeas/gnulib/tests: test-verify.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-verify.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-verify.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-verify.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wchar
+Only in /home/lutter/code/augeas/gnulib/tests: test-wchar.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wchar.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-wchar.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-1.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-1.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-2.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-2.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-3.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-3.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-4.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-4.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-5.sh.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32-5.sh.trs
+Only in /home/lutter/code/augeas/gnulib/tests: test-wcrtomb-w32.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-wctype-h
+Only in /home/lutter/code/augeas/gnulib/tests: test-wctype-h.log
+Only in /home/lutter/code/augeas/gnulib/tests: test-wctype-h.o
+Only in /home/lutter/code/augeas/gnulib/tests: test-wctype-h.trs
+Only in /home/lutter/code/augeas/gnulib/tests: unused-parameter.h
+Only in /home/lutter/code/augeas/gnulib/tests: warn-on-use.h
+Only in /home/lutter/code/augeas/: .gnulib
+Only in /home/lutter/code/augeas/lenses: hocon_lite.aug~
+Only in /home/lutter/code/augeas/lenses: postfix_sasl_smtpd.aug~
+Only in /home/lutter/code/augeas/lenses/tests: test_hocon_lite.aug~
+Only in /home/lutter/code/augeas/lenses/tests: test_postfix_sasl_smtpd.aug~
+Only in /home/lutter/code/augeas/lenses/tests: test_region.aug~
+Only in /home/lutter/code/augeas/lenses/tests: test_spacing.aug~
+Only in /home/lutter/code/augeas/: libtool
+Only in /home/lutter/code/augeas/: Makefile
+diff -ru augeas-1.4.0/Makefile.in /home/lutter/code/augeas/Makefile.in
+--- augeas-1.4.0/Makefile.in	2015-06-01 17:23:20.000000000 -0700
++++ /home/lutter/code/augeas/Makefile.in	2015-06-12 10:18:42.194584218 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -15,7 +15,17 @@
+ @SET_MAKE@
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -78,23 +88,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ subdir = .
+-DIST_COMMON = INSTALL NEWS README AUTHORS ChangeLog \
+-	$(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+-	$(top_srcdir)/configure $(am__configure_deps) \
+-	$(srcdir)/config.h.in $(srcdir)/augeas.pc.in \
+-	$(srcdir)/augeas.spec.in $(dist_lens_DATA) \
+-	$(dist_lenstest_DATA) COPYING build/ac-aux/compile \
+-	build/ac-aux/config.guess build/ac-aux/config.rpath \
+-	build/ac-aux/config.sub build/ac-aux/depcomp \
+-	build/ac-aux/install-sh build/ac-aux/missing \
+-	build/ac-aux/ylwrap build/ac-aux/ltmain.sh \
+-	$(top_srcdir)/build/ac-aux/compile \
+-	$(top_srcdir)/build/ac-aux/config.guess \
+-	$(top_srcdir)/build/ac-aux/config.rpath \
+-	$(top_srcdir)/build/ac-aux/config.sub \
+-	$(top_srcdir)/build/ac-aux/install-sh \
+-	$(top_srcdir)/build/ac-aux/ltmain.sh \
+-	$(top_srcdir)/build/ac-aux/missing
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -231,6 +224,9 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(top_srcdir)/configure \
++	$(am__configure_deps) $(dist_lens_DATA) $(dist_lenstest_DATA) \
++	$(am__DIST_COMMON)
+ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
+  configure.lineno config.status.lineno
+ mkinstalldirs = $(install_sh) -d
+@@ -324,6 +320,20 @@
+ CTAGS = ctags
+ CSCOPE = cscope
+ DIST_SUBDIRS = $(SUBDIRS)
++am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/augeas.pc.in \
++	$(srcdir)/augeas.spec.in $(srcdir)/config.h.in \
++	$(top_srcdir)/build/ac-aux/compile \
++	$(top_srcdir)/build/ac-aux/config.guess \
++	$(top_srcdir)/build/ac-aux/config.rpath \
++	$(top_srcdir)/build/ac-aux/config.sub \
++	$(top_srcdir)/build/ac-aux/install-sh \
++	$(top_srcdir)/build/ac-aux/ltmain.sh \
++	$(top_srcdir)/build/ac-aux/missing AUTHORS COPYING ChangeLog \
++	INSTALL NEWS README build/ac-aux/compile \
++	build/ac-aux/config.guess build/ac-aux/config.rpath \
++	build/ac-aux/config.sub build/ac-aux/depcomp \
++	build/ac-aux/install-sh build/ac-aux/ltmain.sh \
++	build/ac-aux/missing build/ac-aux/ylwrap
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ distdir = $(PACKAGE)-$(VERSION)
+ top_distdir = $(distdir)
+@@ -1228,7 +1238,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1526,15 +1535,15 @@
+ 	$(am__post_remove_distdir)
+ 
+ dist-tarZ: distdir
+-	@echo WARNING: "Support for shar distribution archives is" \
+-	               "deprecated." >&2
++	@echo WARNING: "Support for distribution archives compressed with" \
++		       "legacy program 'compress' is deprecated." >&2
+ 	@echo WARNING: "It will be removed altogether in Automake 2.0" >&2
+ 	tardir=$(distdir) && $(am__tar) | compress -c >$(distdir).tar.Z
+ 	$(am__post_remove_distdir)
+ 
+ dist-shar: distdir
+-	@echo WARNING: "Support for distribution archives compressed with" \
+-		       "legacy program 'compress' is deprecated." >&2
++	@echo WARNING: "Support for shar distribution archives is" \
++	               "deprecated." >&2
+ 	@echo WARNING: "It will be removed altogether in Automake 2.0" >&2
+ 	shar $(distdir) | GZIP=$(GZIP_ENV) gzip -c >$(distdir).shar.gz
+ 	$(am__post_remove_distdir)
+@@ -1570,17 +1579,17 @@
+ 	esac
+ 	chmod -R a-w $(distdir)
+ 	chmod u+w $(distdir)
+-	mkdir $(distdir)/_build $(distdir)/_inst
++	mkdir $(distdir)/_build $(distdir)/_build/sub $(distdir)/_inst
+ 	chmod a-w $(distdir)
+ 	test -d $(distdir)/_build || exit 0; \
+ 	dc_install_base=`$(am__cd) $(distdir)/_inst && pwd | sed -e 's,^[^:\\/]:[\\/],/,'` \
+ 	  && dc_destdir="$${TMPDIR-/tmp}/am-dc-$$$$/" \
+ 	  && am__cwd=`pwd` \
+-	  && $(am__cd) $(distdir)/_build \
+-	  && ../configure \
++	  && $(am__cd) $(distdir)/_build/sub \
++	  && ../../configure \
+ 	    $(AM_DISTCHECK_CONFIGURE_FLAGS) \
+ 	    $(DISTCHECK_CONFIGURE_FLAGS) \
+-	    --srcdir=.. --prefix="$$dc_install_base" \
++	    --srcdir=../.. --prefix="$$dc_install_base" \
+ 	  && $(MAKE) $(AM_MAKEFLAGS) \
+ 	  && $(MAKE) $(AM_MAKEFLAGS) dvi \
+ 	  && $(MAKE) $(AM_MAKEFLAGS) check \
+@@ -1765,6 +1774,8 @@
+ 	uninstall-dist_lensDATA uninstall-dist_lenstestDATA \
+ 	uninstall-pkgconfigDATA
+ 
++.PRECIOUS: Makefile
++
+ 
+ distclean-local:
+ 	-find $(top_builddir)/build/* -maxdepth 0 -not -name ac-aux | xargs rm -rf
+Only in /home/lutter/code/augeas/: Makefile.maint
+Only in /home/lutter/code/augeas/man: Makefile
+diff -ru augeas-1.4.0/man/Makefile.in /home/lutter/code/augeas/man/Makefile.in
+--- augeas-1.4.0/man/Makefile.in	2015-06-01 17:23:21.000000000 -0700
++++ /home/lutter/code/augeas/man/Makefile.in	2015-06-12 10:18:42.945583329 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -14,7 +14,17 @@
+ 
+ @SET_MAKE@
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -77,7 +87,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ subdir = man
+-DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+ 	$(top_srcdir)/gnulib/m4/alloca.m4 \
+@@ -214,6 +223,7 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -269,6 +279,7 @@
+ NROFF = nroff
+ MANS = $(man1_MANS)
+ am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
++am__DIST_COMMON = $(srcdir)/Makefile.in
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ pkglibexecdir = @pkglibexecdir@
+ ACLOCAL = @ACLOCAL@
+@@ -1121,7 +1132,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu man/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu man/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1343,6 +1353,8 @@
+ 	ps ps-am tags-am uninstall uninstall-am uninstall-man \
+ 	uninstall-man1
+ 
++.PRECIOUS: Makefile
++
+ 
+ %.1: %.pod
+ 	pod2man -c "Augeas" -r "Augeas $(VERSION)" $< > $@
+Only in /home/lutter/code/augeas/: misc
+Only in /home/lutter/code/augeas/: README.md
+Only in /home/lutter/code/augeas/: site
+Only in /home/lutter/code/augeas/src: ast.lo
+Only in /home/lutter/code/augeas/src: ast.o
+Only in /home/lutter/code/augeas/src: augeas.lo
+Only in /home/lutter/code/augeas/src: augeas.o
+Only in /home/lutter/code/augeas/src: augparse
+Only in /home/lutter/code/augeas/src: augparse.o
+Only in /home/lutter/code/augeas/src: augrun.lo
+Only in /home/lutter/code/augeas/src: augrun.o
+Only in /home/lutter/code/augeas/src: augtool
+diff -ru augeas-1.4.0/src/augtool.c /home/lutter/code/augeas/src/augtool.c
+--- augeas-1.4.0/src/augtool.c	2015-06-01 15:03:07.000000000 -0700
++++ /home/lutter/code/augeas/src/augtool.c	2015-06-12 10:18:33.109594971 -0700
+@@ -201,6 +201,21 @@
+ }
+ #endif
+ 
++#ifndef HAVE_RL_CRLF
++static int rl_crlf(void) {
++    if (rl_outstream != NULL)
++        putc('\n', rl_outstream);
++    return 0;
++}
++#endif
++
++#ifndef HAVE_RL_REPLACE_LINE
++static void rl_replace_line(ATTRIBUTE_UNUSED const char *text,
++                              ATTRIBUTE_UNUSED int clear_undo) {
++    return;
++}
++#endif
++
+ static char **readline_completion(const char *text, int start,
+                                   ATTRIBUTE_UNUSED int end) {
+     if (start == 0)
+Only in /home/lutter/code/augeas/src: augtool.o
+Only in /home/lutter/code/augeas/src: builtin.lo
+Only in /home/lutter/code/augeas/src: builtin.o
+Only in /home/lutter/code/augeas/src: datadir.h
+Only in /home/lutter/code/augeas/src: .deps
+Only in /home/lutter/code/augeas/src: errcode.lo
+Only in /home/lutter/code/augeas/src: errcode.o
+Only in /home/lutter/code/augeas/src: fa.lo
+Only in /home/lutter/code/augeas/src: fa.o
+Only in /home/lutter/code/augeas/src: get.lo
+Only in /home/lutter/code/augeas/src: get.o
+Only in /home/lutter/code/augeas/src: hash.lo
+Only in /home/lutter/code/augeas/src: hash.o
+Only in /home/lutter/code/augeas/src: info.lo
+Only in /home/lutter/code/augeas/src: info.o
+Only in /home/lutter/code/augeas/src: internal.lo
+Only in /home/lutter/code/augeas/src: internal.o
+Only in /home/lutter/code/augeas/src: jmt.lo
+Only in /home/lutter/code/augeas/src: jmt.o
+Only in /home/lutter/code/augeas/src: lens.lo
+Only in /home/lutter/code/augeas/src: lens.o
+Only in /home/lutter/code/augeas/src: libaugeas.la
+Only in /home/lutter/code/augeas/src: libfa.la
+Only in /home/lutter/code/augeas/src: liblexer.la
+Only in /home/lutter/code/augeas/src: liblexer_la-lexer.lo
+Only in /home/lutter/code/augeas/src: liblexer_la-lexer.o
+Only in /home/lutter/code/augeas/src: .libs
+Only in /home/lutter/code/augeas/src: Makefile
+diff -ru augeas-1.4.0/src/Makefile.in /home/lutter/code/augeas/src/Makefile.in
+--- augeas-1.4.0/src/Makefile.in	2015-06-01 17:23:21.000000000 -0700
++++ /home/lutter/code/augeas/src/Makefile.in	2015-06-12 10:18:43.080583170 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -26,7 +26,17 @@
+ 
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -89,10 +99,6 @@
+ build_triplet = @build@
+ host_triplet = @host@
+ bin_PROGRAMS = augtool$(EXEEXT) augparse$(EXEEXT)
+-DIST_COMMON = $(top_srcdir)/Makefile.inc $(srcdir)/Makefile.in \
+-	$(srcdir)/Makefile.am parser.h parser.c lexer.c \
+-	$(top_srcdir)/build/ac-aux/depcomp \
+-	$(top_srcdir)/build/ac-aux/ylwrap $(include_HEADERS)
+ subdir = src
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+@@ -230,6 +236,8 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(include_HEADERS) \
++	$(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -379,6 +387,9 @@
+   done | $(am__uniquify_input)`
+ ETAGS = etags
+ CTAGS = ctags
++am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/Makefile.inc \
++	$(top_srcdir)/build/ac-aux/depcomp \
++	$(top_srcdir)/build/ac-aux/ylwrap lexer.c parser.c parser.h
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ pkglibexecdir = @pkglibexecdir@
+ ACLOCAL = @ACLOCAL@
+@@ -1265,7 +1276,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu src/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu src/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1274,7 +1284,7 @@
+ 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)'; \
+ 	    cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe);; \
+ 	esac;
+-$(top_srcdir)/Makefile.inc:
++$(top_srcdir)/Makefile.inc $(am__empty):
+ 
+ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+ 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
+@@ -1710,6 +1720,8 @@
+ 	tags tags-am uninstall uninstall-am uninstall-binPROGRAMS \
+ 	uninstall-includeHEADERS uninstall-libLTLIBRARIES
+ 
++.PRECIOUS: Makefile
++
+ 
+ FAILMALLOC_START ?= 1
+ FAILMALLOC_REP   ?= 20
+Only in /home/lutter/code/augeas/src: memory.lo
+Only in /home/lutter/code/augeas/src: memory.o
+Only in /home/lutter/code/augeas/src: parser.lo
+Only in /home/lutter/code/augeas/src: parser.o
+Only in /home/lutter/code/augeas/src: pathx.lo
+Only in /home/lutter/code/augeas/src: pathx.o
+Only in /home/lutter/code/augeas/src: put.lo
+Only in /home/lutter/code/augeas/src: put.o
+Only in /home/lutter/code/augeas/src: ref.lo
+Only in /home/lutter/code/augeas/src: ref.o
+Only in /home/lutter/code/augeas/src: regexp.lo
+Only in /home/lutter/code/augeas/src: regexp.o
+Only in /home/lutter/code/augeas/src: syntax.lo
+Only in /home/lutter/code/augeas/src: syntax.o
+Only in /home/lutter/code/augeas/src: transform.lo
+Only in /home/lutter/code/augeas/src: transform.o
+Only in /home/lutter/code/augeas/: stamp-h1
+Only in /home/lutter/code/augeas/tests: cutest.o
+Only in /home/lutter/code/augeas/tests: .deps
+Only in /home/lutter/code/augeas/tests: fatest
+Only in /home/lutter/code/augeas/tests: fatest.log
+Only in /home/lutter/code/augeas/tests: fatest.o
+Only in /home/lutter/code/augeas/tests: fatest.trs
+Only in /home/lutter/code/augeas/tests: leak
+Only in /home/lutter/code/augeas/tests: leak.o
+Only in /home/lutter/code/augeas/tests: lens-access.sh.log
+Only in /home/lutter/code/augeas/tests: lens-access.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-activemq_conf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-activemq_conf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-activemq_xml.sh.log
+Only in /home/lutter/code/augeas/tests: lens-activemq_xml.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-afs_cellalias.sh.log
+Only in /home/lutter/code/augeas/tests: lens-afs_cellalias.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-aliases.sh.log
+Only in /home/lutter/code/augeas/tests: lens-aliases.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-anacron.sh.log
+Only in /home/lutter/code/augeas/tests: lens-anacron.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-approx.sh.log
+Only in /home/lutter/code/augeas/tests: lens-approx.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-aptcacherngsecurity.sh.log
+Only in /home/lutter/code/augeas/tests: lens-aptcacherngsecurity.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-aptconf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-aptconf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-aptpreferences.sh.log
+Only in /home/lutter/code/augeas/tests: lens-aptpreferences.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-aptsource.sh.log
+Only in /home/lutter/code/augeas/tests: lens-aptsource.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-apt_update_manager.sh.log
+Only in /home/lutter/code/augeas/tests: lens-apt_update_manager.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-authorized_keys.sh.log
+Only in /home/lutter/code/augeas/tests: lens-authorized_keys.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-automaster.sh.log
+Only in /home/lutter/code/augeas/tests: lens-automaster.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-automounter.sh.log
+Only in /home/lutter/code/augeas/tests: lens-automounter.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-avahi.sh.log
+Only in /home/lutter/code/augeas/tests: lens-avahi.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-backuppchosts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-backuppchosts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-bbhosts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-bbhosts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-bootconf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-bootconf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-build.sh.log
+Only in /home/lutter/code/augeas/tests: lens-build.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cachefilesd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cachefilesd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-carbon.sh.log
+Only in /home/lutter/code/augeas/tests: lens-carbon.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cgconfig.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cgconfig.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cgrules.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cgrules.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-channels.sh.log
+Only in /home/lutter/code/augeas/tests: lens-channels.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-chrony.sh.log
+Only in /home/lutter/code/augeas/tests: lens-chrony.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-clamav.sh.log
+Only in /home/lutter/code/augeas/tests: lens-clamav.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cobblermodules.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cobblermodules.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cobblersettings.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cobblersettings.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-collectd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-collectd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cpanel.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cpanel.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cronallow.sh
+Only in /home/lutter/code/augeas/tests: lens-cron.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cron.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-crypttab.sh.log
+Only in /home/lutter/code/augeas/tests: lens-crypttab.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cups.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cups.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-cyrus_imapd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-cyrus_imapd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-darkice.sh.log
+Only in /home/lutter/code/augeas/tests: lens-darkice.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-debctrl.sh.log
+Only in /home/lutter/code/augeas/tests: lens-debctrl.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-desktop.sh.log
+Only in /home/lutter/code/augeas/tests: lens-desktop.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-device_map.sh.log
+Only in /home/lutter/code/augeas/tests: lens-device_map.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dhclient.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dhclient.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dhcpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dhcpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dnsmasq.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dnsmasq.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dns_zone.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dns_zone.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dovecot.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dovecot.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dpkg.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dpkg.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-dput.sh.log
+Only in /home/lutter/code/augeas/tests: lens-dput.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-erlang.sh.log
+Only in /home/lutter/code/augeas/tests: lens-erlang.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ethers.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ethers.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-exports.sh.log
+Only in /home/lutter/code/augeas/tests: lens-exports.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-fai_diskconfig.sh.log
+Only in /home/lutter/code/augeas/tests: lens-fai_diskconfig.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-fonts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-fonts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-fstab.sh.log
+Only in /home/lutter/code/augeas/tests: lens-fstab.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-fuse.sh.log
+Only in /home/lutter/code/augeas/tests: lens-fuse.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-gdm.sh.log
+Only in /home/lutter/code/augeas/tests: lens-gdm.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-group.sh.log
+Only in /home/lutter/code/augeas/tests: lens-group.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-grub.sh.log
+Only in /home/lutter/code/augeas/tests: lens-grub.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-gshadow.sh.log
+Only in /home/lutter/code/augeas/tests: lens-gshadow.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-gtkbookmarks.sh.log
+Only in /home/lutter/code/augeas/tests: lens-gtkbookmarks.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-hocon_lite.sh
+Only in /home/lutter/code/augeas/tests: lens-hocon_lite.sh.log
+Only in /home/lutter/code/augeas/tests: lens-host_conf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-host_conf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-hostname.sh.log
+Only in /home/lutter/code/augeas/tests: lens-hostname.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-hosts_access.sh.log
+Only in /home/lutter/code/augeas/tests: lens-hosts_access.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-hosts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-hosts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-htpasswd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-htpasswd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-httpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-httpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-inetd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-inetd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-inifile.sh.log
+Only in /home/lutter/code/augeas/tests: lens-inifile.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-inittab.sh.log
+Only in /home/lutter/code/augeas/tests: lens-inittab.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-inputrc.sh.log
+Only in /home/lutter/code/augeas/tests: lens-inputrc.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-interfaces.sh.log
+Only in /home/lutter/code/augeas/tests: lens-interfaces.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-iproute2.sh.log
+Only in /home/lutter/code/augeas/tests: lens-iproute2.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-iptables.sh.log
+Only in /home/lutter/code/augeas/tests: lens-iptables.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-iscsid.sh.log
+Only in /home/lutter/code/augeas/tests: lens-iscsid.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-jaas.sh.log
+Only in /home/lutter/code/augeas/tests: lens-jaas.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-jettyrealm.sh.log
+Only in /home/lutter/code/augeas/tests: lens-jettyrealm.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-jmxaccess.sh.log
+Only in /home/lutter/code/augeas/tests: lens-jmxaccess.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-jmxpassword.sh.log
+Only in /home/lutter/code/augeas/tests: lens-jmxpassword.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-json.sh.log
+Only in /home/lutter/code/augeas/tests: lens-json.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-kdump.sh.log
+Only in /home/lutter/code/augeas/tests: lens-kdump.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-keepalived.sh.log
+Only in /home/lutter/code/augeas/tests: lens-keepalived.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-known_hosts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-known_hosts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-koji.sh.log
+Only in /home/lutter/code/augeas/tests: lens-koji.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-krb5.sh.log
+Only in /home/lutter/code/augeas/tests: lens-krb5.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ldap.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ldap.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ldif.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ldif.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ldso.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ldso.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-lightdm.sh.log
+Only in /home/lutter/code/augeas/tests: lens-lightdm.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-limits.sh.log
+Only in /home/lutter/code/augeas/tests: lens-limits.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-login_defs.sh.log
+Only in /home/lutter/code/augeas/tests: lens-login_defs.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-logrotate.sh.log
+Only in /home/lutter/code/augeas/tests: lens-logrotate.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-logwatch.sh.log
+Only in /home/lutter/code/augeas/tests: lens-logwatch.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-lokkit.sh.log
+Only in /home/lutter/code/augeas/tests: lens-lokkit.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-lvm.sh.log
+Only in /home/lutter/code/augeas/tests: lens-lvm.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mailscanner_rules.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mailscanner_rules.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mailscanner.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mailscanner.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mcollective.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mcollective.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mdadm_conf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mdadm_conf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-memcached.sh.log
+Only in /home/lutter/code/augeas/tests: lens-memcached.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mke2fs.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mke2fs.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-modprobe.sh.log
+Only in /home/lutter/code/augeas/tests: lens-modprobe.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-modules_conf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-modules_conf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-modules.sh.log
+Only in /home/lutter/code/augeas/tests: lens-modules.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mongodbserver.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mongodbserver.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-monit.sh.log
+Only in /home/lutter/code/augeas/tests: lens-monit.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-multipath.sh.log
+Only in /home/lutter/code/augeas/tests: lens-multipath.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-mysql.sh.log
+Only in /home/lutter/code/augeas/tests: lens-mysql.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-nagioscfg.sh.log
+Only in /home/lutter/code/augeas/tests: lens-nagioscfg.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-nagiosobjects.sh.log
+Only in /home/lutter/code/augeas/tests: lens-nagiosobjects.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-netmasks.sh.log
+Only in /home/lutter/code/augeas/tests: lens-netmasks.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-networkmanager.sh.log
+Only in /home/lutter/code/augeas/tests: lens-networkmanager.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-networks.sh.log
+Only in /home/lutter/code/augeas/tests: lens-networks.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-nginx.sh.log
+Only in /home/lutter/code/augeas/tests: lens-nginx.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-nrpe.sh.log
+Only in /home/lutter/code/augeas/tests: lens-nrpe.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-nsswitch.sh.log
+Only in /home/lutter/code/augeas/tests: lens-nsswitch.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ntpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ntpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ntp.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ntp.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-odbc.sh.log
+Only in /home/lutter/code/augeas/tests: lens-odbc.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-openshift_config.sh.log
+Only in /home/lutter/code/augeas/tests: lens-openshift_config.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-openshift_http.sh.log
+Only in /home/lutter/code/augeas/tests: lens-openshift_http.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-openshift_quickstarts.sh.log
+Only in /home/lutter/code/augeas/tests: lens-openshift_quickstarts.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-openvpn.sh.log
+Only in /home/lutter/code/augeas/tests: lens-openvpn.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pagekite.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pagekite.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pamconf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pamconf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pam.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pam.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-passwd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-passwd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pbuilder.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pbuilder.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pgbouncer.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pgbouncer.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pg_hba.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pg_hba.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-php.sh.log
+Only in /home/lutter/code/augeas/tests: lens-php.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-phpvars.sh.log
+Only in /home/lutter/code/augeas/tests: lens-phpvars.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix_access.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_access.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix_main.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_main.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix_master.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_master.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix-sasl-smtpd.sh
+Only in /home/lutter/code/augeas/tests: lens-postfix_sasl_smtpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_sasl_smtpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix_transport.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_transport.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postfix_virtual.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postfix_virtual.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-postgresql.sh.log
+Only in /home/lutter/code/augeas/tests: lens-postgresql.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-properties.sh.log
+Only in /home/lutter/code/augeas/tests: lens-properties.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-protocols.sh.log
+Only in /home/lutter/code/augeas/tests: lens-protocols.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-puppet_auth.sh.log
+Only in /home/lutter/code/augeas/tests: lens-puppet_auth.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-puppetfileserver.sh.log
+Only in /home/lutter/code/augeas/tests: lens-puppetfileserver.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-puppetfile.sh.log
+Only in /home/lutter/code/augeas/tests: lens-puppetfile.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-puppet.sh.log
+Only in /home/lutter/code/augeas/tests: lens-puppet.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pylonspaste.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pylonspaste.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-pythonpaste.sh.log
+Only in /home/lutter/code/augeas/tests: lens-pythonpaste.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-qpid.sh.log
+Only in /home/lutter/code/augeas/tests: lens-qpid.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-quote.sh.log
+Only in /home/lutter/code/augeas/tests: lens-quote.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-rabbitmq.sh.log
+Only in /home/lutter/code/augeas/tests: lens-rabbitmq.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-redis.sh.log
+Only in /home/lutter/code/augeas/tests: lens-redis.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-region.sh
+Only in /home/lutter/code/augeas/tests: lens-region.sh.log
+Only in /home/lutter/code/augeas/tests: lens-region.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-reprepro_uploaders.sh.log
+Only in /home/lutter/code/augeas/tests: lens-reprepro_uploaders.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-resolv.sh.log
+Only in /home/lutter/code/augeas/tests: lens-resolv.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-rmt.sh.log
+Only in /home/lutter/code/augeas/tests: lens-rmt.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-rsyncd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-rsyncd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-rsyslog.sh.log
+Only in /home/lutter/code/augeas/tests: lens-rsyslog.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-rx.sh.log
+Only in /home/lutter/code/augeas/tests: lens-rx.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-samba.sh.log
+Only in /home/lutter/code/augeas/tests: lens-samba.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-schroot.sh.log
+Only in /home/lutter/code/augeas/tests: lens-schroot.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-securetty.sh.log
+Only in /home/lutter/code/augeas/tests: lens-securetty.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-services.sh.log
+Only in /home/lutter/code/augeas/tests: lens-services.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-shadow.sh.log
+Only in /home/lutter/code/augeas/tests: lens-shadow.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-shells.sh.log
+Only in /home/lutter/code/augeas/tests: lens-shells.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-shellvars_array.sh
+Only in /home/lutter/code/augeas/tests: lens-shellvars_list.sh.log
+Only in /home/lutter/code/augeas/tests: lens-shellvars_list.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-shellvars.sh.log
+Only in /home/lutter/code/augeas/tests: lens-shellvars.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-simplelines.sh.log
+Only in /home/lutter/code/augeas/tests: lens-simplelines.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-simplevars.sh.log
+Only in /home/lutter/code/augeas/tests: lens-simplevars.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sip_conf.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sip_conf.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-slapd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-slapd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-smbusers.sh.log
+Only in /home/lutter/code/augeas/tests: lens-smbusers.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-solaris_system.sh.log
+Only in /home/lutter/code/augeas/tests: lens-solaris_system.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-soma.sh.log
+Only in /home/lutter/code/augeas/tests: lens-soma.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-spacevars.sh.log
+Only in /home/lutter/code/augeas/tests: lens-spacevars.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-spacing.sh
+Only in /home/lutter/code/augeas/tests: lens-spacing.sh.log
+Only in /home/lutter/code/augeas/tests: lens-spacing.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-splunk.sh.log
+Only in /home/lutter/code/augeas/tests: lens-splunk.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-squid.sh.log
+Only in /home/lutter/code/augeas/tests: lens-squid.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sshd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sshd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-ssh.sh.log
+Only in /home/lutter/code/augeas/tests: lens-ssh.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sssd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sssd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-stunnel.sh.log
+Only in /home/lutter/code/augeas/tests: lens-stunnel.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-subversion.sh.log
+Only in /home/lutter/code/augeas/tests: lens-subversion.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sudoers.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sudoers.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sysconfig_route.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sysconfig_route.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sysconfig.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sysconfig.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-sysctl.sh.log
+Only in /home/lutter/code/augeas/tests: lens-sysctl.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-syslog.sh.log
+Only in /home/lutter/code/augeas/tests: lens-syslog.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-systemd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-systemd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-system.sh
+Only in /home/lutter/code/augeas/tests: lens-thttpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-thttpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-tuned.sh.log
+Only in /home/lutter/code/augeas/tests: lens-tuned.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-up2date.sh.log
+Only in /home/lutter/code/augeas/tests: lens-up2date.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-updatedb.sh.log
+Only in /home/lutter/code/augeas/tests: lens-updatedb.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-util.sh.log
+Only in /home/lutter/code/augeas/tests: lens-util.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-vfstab.sh.log
+Only in /home/lutter/code/augeas/tests: lens-vfstab.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-vmware_config.sh.log
+Only in /home/lutter/code/augeas/tests: lens-vmware_config.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-vsftpd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-vsftpd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-webmin.sh.log
+Only in /home/lutter/code/augeas/tests: lens-webmin.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-wine.sh.log
+Only in /home/lutter/code/augeas/tests: lens-wine.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xendconfsxp.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xendconfsxp.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xinetd.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xinetd.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xml.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xml.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xorg.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xorg.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xymon_alerting.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xymon_alerting.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-xymon.sh.log
+Only in /home/lutter/code/augeas/tests: lens-xymon.sh.trs
+Only in /home/lutter/code/augeas/tests: lens-yum.sh.log
+Only in /home/lutter/code/augeas/tests: lens-yum.sh.trs
+Only in /home/lutter/code/augeas/tests: .libs
+Only in /home/lutter/code/augeas/tests: Makefile
+diff -ru augeas-1.4.0/tests/Makefile.in /home/lutter/code/augeas/tests/Makefile.in
+--- augeas-1.4.0/tests/Makefile.in	2015-06-01 17:23:21.000000000 -0700
++++ /home/lutter/code/augeas/tests/Makefile.in	2015-06-12 10:18:43.309582899 -0700
+@@ -1,7 +1,7 @@
+-# Makefile.in generated by automake 1.14.1 from Makefile.am.
++# Makefile.in generated by automake 1.15 from Makefile.am.
+ # @configure_input@
+ 
+-# Copyright (C) 1994-2013 Free Software Foundation, Inc.
++# Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ 
+ # This Makefile.in is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -25,7 +25,17 @@
+ 
+ 
+ VPATH = @srcdir@
+-am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
++am__is_gnu_make = { \
++  if test -z '$(MAKELEVEL)'; then \
++    false; \
++  elif test -n '$(MAKE_HOST)'; then \
++    true; \
++  elif test -n '$(MAKE_VERSION)' && test -n '$(CURDIR)'; then \
++    true; \
++  else \
++    false; \
++  fi; \
++}
+ am__make_running_with_option = \
+   case $${target_option-} in \
+       ?) ;; \
+@@ -91,9 +101,6 @@
+ check_PROGRAMS = fatest$(EXEEXT) test-xpath$(EXEEXT) \
+ 	test-load$(EXEEXT) test-save$(EXEEXT) test-api$(EXEEXT) \
+ 	test-run$(EXEEXT)
+-DIST_COMMON = $(top_srcdir)/Makefile.inc $(srcdir)/Makefile.in \
+-	$(srcdir)/Makefile.am $(top_srcdir)/build/ac-aux/depcomp \
+-	$(top_srcdir)/build/ac-aux/test-driver
+ subdir = tests
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/gnulib/m4/00gnulib.m4 \
+@@ -231,6 +238,7 @@
+ 	$(top_srcdir)/configure.ac
+ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
+ 	$(ACLOCAL_M4)
++DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
+ mkinstalldirs = $(install_sh) -d
+ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+@@ -543,6 +551,9 @@
+ TEST_LOG_DRIVER = $(SHELL) $(top_srcdir)/build/ac-aux/test-driver
+ TEST_LOG_COMPILE = $(TEST_LOG_COMPILER) $(AM_TEST_LOG_FLAGS) \
+ 	$(TEST_LOG_FLAGS)
++am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/Makefile.inc \
++	$(top_srcdir)/build/ac-aux/depcomp \
++	$(top_srcdir)/build/ac-aux/test-driver
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ pkglibexecdir = @pkglibexecdir@
+ ACLOCAL = @ACLOCAL@
+@@ -1643,7 +1654,6 @@
+ 	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu tests/Makefile'; \
+ 	$(am__cd) $(top_srcdir) && \
+ 	  $(AUTOMAKE) --gnu tests/Makefile
+-.PRECIOUS: Makefile
+ Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
+ 	@case '$?' in \
+ 	  *config.status*) \
+@@ -1652,7 +1662,7 @@
+ 	    echo ' cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)'; \
+ 	    cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe);; \
+ 	esac;
+-$(top_srcdir)/Makefile.inc:
++$(top_srcdir)/Makefile.inc $(am__empty):
+ 
+ $(top_builddir)/config.status: $(top_srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+ 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
+@@ -1848,7 +1858,7 @@
+ 	if test -n "$$am__remaking_logs"; then \
+ 	  echo "fatal: making $(TEST_SUITE_LOG): possible infinite" \
+ 	       "recursion detected" >&2; \
+-	else \
++	elif test -n "$$redo_logs"; then \
+ 	  am__remaking_logs=yes $(MAKE) $(AM_MAKEFLAGS) $$redo_logs; \
+ 	fi; \
+ 	if $(am__make_dryrun); then :; else \
+@@ -3707,6 +3717,8 @@
+ 	pdf pdf-am ps ps-am recheck tags tags-am uninstall \
+ 	uninstall-am
+ 
++.PRECIOUS: Makefile
++
+ valgrind:
+ 	make check \
+ 	  VALGRIND="$(VALGRIND)" \
+Only in /home/lutter/code/augeas/tests: memory.o
+Only in /home/lutter/code/augeas/tests/modules: fail_bad_re.aug~
+Only in /home/lutter/code/augeas/tests/modules: fail_jmt_ambig_seq.aug~
+Only in /home/lutter/code/augeas/tests/modules: pass_erlang_bug.aug~
+Only in /home/lutter/code/augeas/tests/modules: README
+Only in /home/lutter/code/augeas/tests: test-api
+Only in /home/lutter/code/augeas/tests: test-api.log
+Only in /home/lutter/code/augeas/tests: test-api.o
+Only in /home/lutter/code/augeas/tests: test-api.trs
+Only in /home/lutter/code/augeas/tests: test-augtool-empty-line.sh.log
+Only in /home/lutter/code/augeas/tests: test-augtool-empty-line.sh.trs
+Only in /home/lutter/code/augeas/tests: test-augtool-modify-root.sh.log
+Only in /home/lutter/code/augeas/tests: test-augtool-modify-root.sh.trs
+Only in /home/lutter/code/augeas/tests: test-augtool.sh.log
+Only in /home/lutter/code/augeas/tests: test-augtool.sh.trs
+Only in /home/lutter/code/augeas/tests: test-bug-1.sh.log
+Only in /home/lutter/code/augeas/tests: test-bug-1.sh.trs
+Only in /home/lutter/code/augeas/tests: test-events-saved.sh.log
+Only in /home/lutter/code/augeas/tests: test-events-saved.sh.trs
+Only in /home/lutter/code/augeas/tests: test-get.sh.log
+Only in /home/lutter/code/augeas/tests: test-get.sh.trs
+Only in /home/lutter/code/augeas/tests: test-idempotent.sh.log
+Only in /home/lutter/code/augeas/tests: test-idempotent.sh.trs
+Only in /home/lutter/code/augeas/tests: test-interpreter.sh.log
+Only in /home/lutter/code/augeas/tests: test-interpreter.sh.trs
+Only in /home/lutter/code/augeas/tests: test-load
+Only in /home/lutter/code/augeas/tests: test-load.log
+Only in /home/lutter/code/augeas/tests: test-load.o
+Only in /home/lutter/code/augeas/tests: test-load.trs
+Only in /home/lutter/code/augeas/tests: test-preserve.sh.log
+Only in /home/lutter/code/augeas/tests: test-preserve.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-mount-augnew.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-mount-augnew.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-mount-augsave.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-mount-augsave.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-mount.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-mount.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augnew.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augnew.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augsave.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augsave.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augtemp.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-symlink-augtemp.sh.trs
+Only in /home/lutter/code/augeas/tests: test-put-symlink.sh.log
+Only in /home/lutter/code/augeas/tests: test-put-symlink.sh.trs
+Only in /home/lutter/code/augeas/tests: test-run
+Only in /home/lutter/code/augeas/tests: test-run.log
+Only in /home/lutter/code/augeas/tests: test-run.o
+Only in /home/lutter/code/augeas/tests: test-run.trs
+Only in /home/lutter/code/augeas/tests: test-save
+Only in /home/lutter/code/augeas/tests: test-save-empty.sh.log
+Only in /home/lutter/code/augeas/tests: test-save-empty.sh.trs
+Only in /home/lutter/code/augeas/tests: test-save.log
+Only in /home/lutter/code/augeas/tests: test-save-mode.sh.log
+Only in /home/lutter/code/augeas/tests: test-save-mode.sh.trs
+Only in /home/lutter/code/augeas/tests: test-save.o
+Only in /home/lutter/code/augeas/tests: test-save.trs
+Only in /home/lutter/code/augeas/tests: test-suite.log
+Only in /home/lutter/code/augeas/tests: test-unlink-error.sh.log
+Only in /home/lutter/code/augeas/tests: test-unlink-error.sh.trs
+Only in /home/lutter/code/augeas/tests: test-valgrind.sh
+Only in /home/lutter/code/augeas/tests: test-xpath
+Only in /home/lutter/code/augeas/tests: test-xpath.log
+Only in /home/lutter/code/augeas/tests: test-xpath.o
+Only in /home/lutter/code/augeas/tests: test-xpath.trs
+Only in /home/lutter/code/augeas/: .travis.yml


### PR DESCRIPTION
Previously osx would not build augeas 1.4.0 due to missing functions
from libedit (which is used instead of readline on osx). This commit
addresses that by applying a patch to define those functions if they are
not available. The patch is safe to apply everywhere. The patch is based
on https://github.com/hercules-team/augeas/pull/257.
