### PR TITLE
(RE-4867) Update license in puppet-agent project

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -18,7 +18,7 @@ project "puppet-agent" do |proj|
   proj.description "The Puppet Agent package contains all of the elements needed to run puppet, including ruby, facter, hiera and mcollective."
   proj.version_from_git
   proj.write_version_file File.join(proj.prefix, 'VERSION')
-  proj.license "ASL 2.0"
+  proj.license "See components"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
   proj.target_repo "PC1"


### PR DESCRIPTION
While the vanagon configs for puppet-agent are licensed under the ASL 2
license, the package itself cannot be because the componenents of the
package are of various licenses. This commit updates the licensing to
reflect that variety.
