### PR TITLE
(RE-4879) Generate x86_64 code for 64 bit systems

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -12,7 +12,12 @@ component "openssl" do |pkg, settings, platform|
     target = 'darwin64-x86_64-cc'
     ldflags = ''
   else
-    target = 'linux-elf'
+    if platform.architecture =~ /86$/
+      target = 'linux-elf'
+      sslflags = '386'
+    elsif platform.architecture =~ /64$/
+      target = 'linux-x86_64'
+    end
     ldflags = "#{settings[:ldflags]} -Wl,-z,relro"
   end
 
@@ -32,8 +37,9 @@ component "openssl" do |pkg, settings, platform|
       --libdir=lib \
       --openssldir=#{settings[:prefix]}/ssl \
       shared \
+      no-asm \
       #{target} \
-      no-asm 386 \
+      #{sslflags} \
       no-camellia \
       enable-seed \
       enable-tlsext \


### PR DESCRIPTION
Previously, openssl unconditionally passed 386 to the configure, which
attempts to create i386 compatible code (bad things happened otherwise
on 486+ processors). This flag is not desireable on 64-bit builds. It
seems to successfully build, but then causes strange problems, for
example in the pkcs12 routines. This commit updates the configure to use
linux-x86_64 for 64-bit builds, and to only pass 386 to the configure to
x86 builds.
