### PR TITLE
(maint) Move vanagon to 0.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.3')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.4')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'


### PR DESCRIPTION
Moving to vanagon 0.3.4 allows puppet-agent to pick up a few bugfixes,
mostly around rpm file naming.
