### PR TITLE
(maint) Add signing server for osx

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -7,6 +7,9 @@ gpg_key: '4BD6EC30'
 deb_targets: 'lucid-i386 lucid-amd64 precise-i386 precise-amd64 squeeze-i386 squeeze-amd64 trusty-i386 trusty-amd64 wheezy-i386 wheezy-amd64'
 rpm_targets: 'el-5-i386 el-5-x86_64 el-6-i386 el-6-x86_64 el-7-x86_64 sles-11-i386 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
+osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
+osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
+osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'


### PR DESCRIPTION
Without this, signing osx packages fails because it doesn't know where
to try to sign packages
