### PR TITLE
(maint) Compile facter with the correct java_home

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -39,12 +39,18 @@ component "facter" do |pkg, settings, platform|
   case platform.name
   when /el-(6|7)/
     pkg.build_requires 'java-1.8.0-openjdk-devel'
-  when /debian-(7|8)/
+  when /debian-(7|8)-amd64/
     pkg.build_requires 'openjdk-7-jdk'
     java_home = "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64"
-  when /ubuntu-(12\.04|14\.\d{2})/
+  when /debian-(7|8)-i386/
+    pkg.build_requires 'openjdk-7-jdk'
+    java_home = "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-i386"
+  when /ubuntu-(12\.04|14\.\d{2})-amd64/
     pkg.build_requires 'openjdk-7-jdk'
     java_home = "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64"
+  when /ubuntu-(12\.04|14\.\d{2})-i386/
+    pkg.build_requires 'openjdk-7-jdk'
+    java_home = "JAVA_HOME=/usr/lib/jvm/java-7-openjdk-i386"
   when /fedora-f20/
     pkg.build_requires 'java-1.7.0-openjdk-devel'
   when /fedora-f21/


### PR DESCRIPTION
Prior to this commit, we were pointing 32bit debian and ubuntu builds to
the java-home that corresponded to 64bit builds. Because of this, facter
could not find java, and was not building facter with jruby support,
which means that it wouldn't work with puppetserver. This commit fixes
that by pointing to the correct architecture where java will be found.
