### PR TITLE
(WIP) Unvendor leatherman from cfacter

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "3ef918b655def6d9d6bfec514749da349b70bba5"}
+{"url": "git://github.com/branan/facter.git", "ref": "03f6a864a6e572529f0230eff58e2aacd823d0ce"}

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -15,6 +15,7 @@ component "facter" do |pkg, settings, platform|
   pkg.replaces 'pe-facter'
 
   pkg.build_requires "ruby"
+  pkg.build_requires "leatherman"
 
   # Running facter (as part of testing) expects virt-what is available
   pkg.build_requires 'virt-what'

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,0 +1,1 @@
+{"url": "git://github.com/branan/leatherman.git", "ref": "c8cf9f80c0b9a449da25baa6975b3d34495c3fb6"}

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -1,0 +1,45 @@
+component 'leatherman' do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/leatherman.json')
+
+   # OSX uses clang and system openssl.  cmake comes from brew.
+  if platform.is_osx?
+    pkg.build_requires "cmake"
+    pkg.build_requires "boost"
+    pkg.build_requires "yaml-cpp --with-static-lib"
+  else
+    pkg.build_requires "openssl"
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+    pkg.build_requires "pl-yaml-cpp"
+  end
+
+  # cmake on OSX is provided by brew
+  # a toolchain is not currently required for OSX since we're building with clang.
+  if platform.is_osx?
+    toolchain=""
+    cmake="/usr/local/bin/cmake"
+  else
+    toolchain="-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
+    cmake="/opt/pl-build-tools/bin/cmake"
+  end
+
+  pkg.configure do
+    ["PATH=#{settings[:bindir]}:$$PATH \
+        #{cmake} \
+        #{toolchain} \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+        -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+        -DBOOST_STATIC=ON \
+        ."]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -35,6 +35,7 @@ project "puppet-agent" do |proj|
   proj.component "marionette-collective"
 
   # Then the dependencies
+  proj.component "leatherman"
   proj.component "augeas"
   proj.component "cfpropertylist" if proj.get_platform.is_osx?
   # Curl is only needed for compute clusters (GCE, EC2); so rpm, deb, and Windows


### PR DESCRIPTION
This switches us to building leatherman as part of the puppet-agent
build, rather than as a submodule of Facter.

DO NOT MERGE YET

This is currently pointed to my fork of leatherman and facter. Before we're ready here, we need to:

1) Be ready to tag leatherman
2) Sort out the travis/appveyor plan with a separate leatherman
