### PR TITLE
(maint) Disable install doc

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -26,7 +26,7 @@ component "ruby" do |pkg, settings, platform|
         --prefix=#{settings[:prefix]} \
         --with-opt-dir=#{settings[:prefix]} \
         --enable-shared \
-        --disable-install-rdoc"]
+        --disable-install-doc"]
   end
 
   pkg.build do


### PR DESCRIPTION
Prior to this commit we were disabling the documentation
generation/installation for the rdoc components, but not for the C API.
We should probably have all docs, or none. Since this ruby is really
designed to be a bundled ruby with Puppet and not general purpose, I
think it makes the most sense to just disable all documentation.
