### PR TITLE
(maint) Move vanagon to 0.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.4')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.5')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'


### PR DESCRIPTION
This commit moves vanagon to 0.3.5 to include bugfixes
for upgrades on SLES and install failures on Arista
EOS.
