### PR TITLE
(PE-10723) Create /opt/puppetlabs/facter/facts.d

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -125,4 +125,5 @@ component "facter" do |pkg, settings, platform|
   end
 
   pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter"
+  pkg.directory File.join('/opt/puppetlabs', 'facter', 'facts.d')
 end


### PR DESCRIPTION
Prior to this commit, the external facts directory was not created on an
initial puppet-agent install. This commit adds that directory in. This
allows for more clarity for users on where external facts should live.
