### PR TITLE
(PE-10636) Create hieradata dir in correct path

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -17,5 +17,5 @@ component "hiera" do |pkg, settings, platform|
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera"
 
-  pkg.directory File.join(settings[:puppet_codedir], 'hieradata')
+  pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'hieradata')
 end


### PR DESCRIPTION
Currently, we are creating `/etc/puppetlabs/code/hieradata`, which
doesn't actually correspond to anythig. In our hiera.yaml file that we
put down, we create reference the hieradata directory at
`/etc/puppetlabs/code/environments/%{environment}/hieradata`. We are
fairly confident that we can create the "production" environment, and
the hieradata directory there. This commit changes
`/etc/puppetlabs/code/hieradata` to
`/etc/puppetlabs/code/environments/production/hieradata` to be
consistent with what we look for by default accoring to `hiera.yaml`.
