### PR TITLE
(PE-11030) Use XCFLAGS instead of CFLAGS for ruby

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -19,7 +19,7 @@ component "ruby" do |pkg, settings, platform|
   pkg.build_requires "openssl"
 
   env = "PATH=/opt/pl-build-tools/bin:$$PATH"
-  env += " CFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}'" if platform.is_linux?
+  env += " XCFLAGS='#{settings[:cflags]}' LDFLAGS='#{settings[:ldflags]}'" if platform.is_linux?
 
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"


### PR DESCRIPTION
If CFLAGS are exported for ruby's configure, it will override all of the
CFLAGS in use, including optimization flags. Using XCFLAGS will add
flags to the default CFLAGS instead. This commit fixes a regression
introduced by overriding CFLAGS for ruby by using XCFLAGS instead.
