### PR TITLE
(RE-5092) Add dmidecode to puppet-agent

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,0 +1,22 @@
+component 'dmidecode' do |pkg, settings, platform|
+  pkg.version '2.12'
+  pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
+  pkg.url "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
+
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.173.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.175.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.176.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.177.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.181.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.182.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end
+

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -48,6 +48,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby-augeas"
   proj.component "openssl"
   proj.component "virt-what"
+  proj.component "dmidecode"
 
   # We only build ruby-selinux for EL 5-7
   if proj.get_platform.name =~ /^el-(5|6|7)-.*/

--- a/resources/patches/dmidecode/README
+++ b/resources/patches/dmidecode/README
@@ -1,0 +1,5 @@
+
+Patches for DMI Decode.
+Downloaded from: http://www.nongnu.org/dmidecode/
+
+Recommended patches: dmidecode.c 1.173, 1.175, 1.176, 1.177, 1.181, 1.182, 1.195.

--- a/resources/patches/dmidecode/dmidecode-1.173.patch
+++ b/resources/patches/dmidecode/dmidecode-1.173.patch
@@ -1,0 +1,11 @@
+--- a/dmidecode.c	2013/04/23 14:39:38	1.172
++++ b/dmidecode.c	2013/04/23 15:06:23	1.173
+@@ -2236,7 +2236,7 @@
+ 	if (code == 0)
+ 		printf(" Unknown");
+ 	else
+-		printf(" %.3f V", (float)(i16)code / 1000);
++		printf(" %.3f V", (float)code / 1000);
+ }
+ 
+ static const char *dmi_memory_device_form_factor(u8 code)

--- a/resources/patches/dmidecode/dmidecode-1.175.patch
+++ b/resources/patches/dmidecode/dmidecode-1.175.patch
@@ -1,0 +1,36 @@
+--- a/dmidecode.c	2013/04/24 13:35:22	1.174
++++ b/dmidecode.c	2013/04/24 18:11:56	1.175
+@@ -712,7 +712,6 @@
+ 		{ 0x3D, "Opteron 6200" },
+ 		{ 0x3E, "Opteron 4200" },
+ 		{ 0x3F, "FX" },
+-
+ 		{ 0x40, "MIPS" },
+ 		{ 0x41, "MIPS R4000" },
+ 		{ 0x42, "MIPS R4200" },
+@@ -729,7 +728,6 @@
+ 		{ 0x4D, "Opteron 6300" },
+ 		{ 0x4E, "Opteron 3300" },
+ 		{ 0x4F, "FirePro" },
+-
+ 		{ 0x50, "SPARC" },
+ 		{ 0x51, "SuperSPARC" },
+ 		{ 0x52, "MicroSPARC II" },
+@@ -1176,7 +1174,7 @@
+ 		"Socket LGA1356-3" /* 0x2C */
+ 	};
+ 
+-	if (code >= 0x01 && code <= 0x2A)
++	if (code >= 0x01 && code <= 0x2C)
+ 		return upgrade[code - 0x01];
+ 	return out_of_spec;
+ }
+@@ -2338,7 +2336,7 @@
+ 	{
+ 		int i;
+ 
+-		for (i = 1; i <= 14; i++)
++		for (i = 1; i <= 15; i++)
+ 			if (code & (1 << i))
+ 				printf(" %s", detail[i - 1]);
+ 	}

--- a/resources/patches/dmidecode/dmidecode-1.176.patch
+++ b/resources/patches/dmidecode/dmidecode-1.176.patch
@@ -1,0 +1,11 @@
+--- a/dmidecode.c	2013/04/24 18:11:56	1.175
++++ b/dmidecode.c	2013/04/26 19:05:48	1.176
+@@ -69,7 +69,7 @@
+ #define out_of_spec "<OUT OF SPEC>"
+ static const char *bad_index = "<BAD INDEX>";
+ 
+-#define SUPPORTED_SMBIOS_VER 0x0207
++#define SUPPORTED_SMBIOS_VER 0x0208
+ 
+ /*
+  * Type-independant Stuff

--- a/resources/patches/dmidecode/dmidecode-1.177.patch
+++ b/resources/patches/dmidecode/dmidecode-1.177.patch
@@ -1,0 +1,35 @@
+--- a/dmidecode.c	2013/04/26 19:05:48	1.176
++++ b/dmidecode.c	2014/01/13 14:54:21	1.177
+@@ -2,7 +2,7 @@
+  * DMI Decode
+  *
+  *   Copyright (C) 2000-2002 Alan Cox <alan@redhat.com>
+- *   Copyright (C) 2002-2010 Jean Delvare <khali@linux-fr.org>
++ *   Copyright (C) 2002-2014 Jean Delvare <jdelvare@suse.de>
+  *
+  *   This program is free software; you can redistribute it and/or modify
+  *   it under the terms of the GNU General Public License as published by
+@@ -1697,6 +1697,10 @@
+ 		"PCI Express 3 x8",
+ 		"PCI Express 3 x16" /* 0xB6 */
+ 	};
++	/*
++	 * Note to developers: when adding entries to these lists, check if
++	 * function dmi_slot_id below needs updating too.
++	 */
+ 
+ 	if (code >= 0x01 && code <= 0x13)
+ 		return type[code - 0x01];
+@@ -1790,6 +1794,12 @@
+ 		case 0xAE: /* PCI Express 2 */
+ 		case 0xAF: /* PCI Express 2 */
+ 		case 0xB0: /* PCI Express 2 */
++		case 0xB1: /* PCI Express 3 */
++		case 0xB2: /* PCI Express 3 */
++		case 0xB3: /* PCI Express 3 */
++		case 0xB4: /* PCI Express 3 */
++		case 0xB5: /* PCI Express 3 */
++		case 0xB6: /* PCI Express 3 */
+ 			printf("%sID: %u\n", prefix, code1);
+ 			break;
+ 		case 0x07: /* PCMCIA */

--- a/resources/patches/dmidecode/dmidecode-1.181.patch
+++ b/resources/patches/dmidecode/dmidecode-1.181.patch
@@ -1,0 +1,17 @@
+--- a/dmidecode.c	2014/03/20 13:47:14	1.180
++++ b/dmidecode.c	2014/07/11 09:24:22	1.181
+@@ -1012,11 +1012,11 @@
+ 		sig = 1;
+ 	else if ((type >= 0x18 && type <= 0x1D) /* AMD */
+ 	      || type == 0x1F /* AMD */
+-	      || (type >= 0x38 && type <= 0x3E) /* AMD */
+-	      || (type >= 0x46 && type <= 0x49) /* AMD */
++	      || (type >= 0x38 && type <= 0x3F) /* AMD */
++	      || (type >= 0x46 && type <= 0x4F) /* AMD */
+ 	      || (type >= 0x83 && type <= 0x8F) /* AMD */
+ 	      || (type >= 0xB6 && type <= 0xB7) /* AMD */
+-	      || (type >= 0xE6 && type <= 0xEF)) /* AMD */
++	      || (type >= 0xE4 && type <= 0xEF)) /* AMD */
+ 		sig = 2;
+ 	else if (type == 0x01 || type == 0x02)
+ 	{

--- a/resources/patches/dmidecode/dmidecode-1.182.patch
+++ b/resources/patches/dmidecode/dmidecode-1.182.patch
@@ -1,0 +1,16 @@
+--- a/dmidecode.c	2014/07/11 09:24:22	1.181
++++ b/dmidecode.c	2014/10/13 10:05:22	1.182
+@@ -2311,10 +2311,11 @@
+ 		"Reserved",
+ 		"Reserved",
+ 		"DDR3",
+-		"FBD2", /* 0x19 */
++		"FBD2",
++		"DDR4" /* 0x1A */
+ 	};
+ 
+-	if (code >= 0x01 && code <= 0x19)
++	if (code >= 0x01 && code <= 0x1A)
+ 		return type[code - 0x01];
+ 	return out_of_spec;
+ }

--- a/resources/patches/dmidecode/dmidecode-1.195.patch
+++ b/resources/patches/dmidecode/dmidecode-1.195.patch
@@ -1,0 +1,11 @@
+--- a/dmidecode.c	2015/05/04 11:24:54	1.194
++++ b/dmidecode.c	2015/05/04 11:28:49	1.195
+@@ -4379,7 +4379,7 @@
+ 
+ 		to_dmi_header(&h, data);
+ 		display = ((opt.type == NULL || opt.type[h.type])
+-			&& !((opt.flags & FLAG_QUIET) && (h.type > 39 && h.type <= 127))
++			&& !((opt.flags & FLAG_QUIET) && (h.type == 126 || h.type == 127))
+ 			&& !opt.string);
+ 
+ 		/*


### PR DESCRIPTION
Adding dmidecode to the puppet-agent build as virt-what has a dependency on it.
Several patches applied as suggested in: http://www.nongnu.org/dmidecode/

Note - the dmidecode package was also downloaded and placed in http://buildsources.delivery.puppetlabs.net/ to support the build.

Tested on all platforms using http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/33/
