### PR TITLE
(PE-10944) Augeas sudoers lens doesn't allow negated command aliases

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -5,6 +5,7 @@ component 'augeas' do |pkg, settings, platform|
 
   pkg.replaces 'pe-augeas'
   pkg.apply_patch 'resources/patches/augeas/osx-stub-needed-readline-functions.patch'
+  pkg.apply_patch 'resources/patches/augeas/sudoers-negated-command-alias.patch'
 
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'

--- a/resources/patches/augeas/sudoers-negated-command-alias.patch
+++ b/resources/patches/augeas/sudoers-negated-command-alias.patch
@@ -1,0 +1,198 @@
+From 17134e3df37313645c56cd984bc9ab2ba60fbf68 Mon Sep 17 00:00:00 2001
+From: Geoff Williams <geoff.williams@puppetlabs.com>
+Date: Fri, 10 Jul 2015 19:59:38 +1000
+Subject: [PATCH 1/2] Support for negated command alias - fixes
+ https://github.com/hercules-team/augeas/issues/262
+
+---
+ lenses/sudoers.aug            |  2 +-
+ lenses/tests/test_sudoers.aug | 13 +++++++++++++
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/lenses/sudoers.aug b/lenses/sudoers.aug
+index 7567772..2c880c5 100644
+--- a/lenses/sudoers.aug
++++ b/lenses/sudoers.aug
+@@ -88,7 +88,7 @@ let sep_dquote   = Util.del_str "\""
+ (* Variable: sto_to_com_cmnd
+ sto_to_com_cmnd does not begin or end with a space *)
+ let sto_to_com_cmnd =
+-      let alias = Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
++      let alias = /!?/ . Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
+    in let non_alias = /(!?[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\])|[^,=:#() \t\n\\]/
+    in store (alias | non_alias)
+ 
+diff --git a/lenses/tests/test_sudoers.aug b/lenses/tests/test_sudoers.aug
+index c9f9fff..d1f47c9 100644
+--- a/lenses/tests/test_sudoers.aug
++++ b/lenses/tests/test_sudoers.aug
+@@ -326,3 +326,16 @@ test Sudoers.spec get "group+user somehost = ALL\n" =
+       { "command" = "ALL" }
+     }
+   }
++
++(* Test: Sudoers.spec
++     https://github.com/hercules-team/augeas/issues/262:  Sudoers lens doesn't suppot `!` for command aliases *)
++test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !BANNED\n" = 
++  { "spec"
++    { "user" = "%opssudoers" }
++    { "host_group"
++      { "host" = "ALL" }
++      { "command" = "ALL"
++        { "runas_user" = "ALL" } }
++      { "command" = "!BANNED" }
++    }
++  }
+
+From e206c78d1135ce51e217882fe75aab7fa302e60d Mon Sep 17 00:00:00 2001
+From: Geoff Williams <geoff.williams@puppetlabs.com>
+Date: Tue, 14 Jul 2015 12:37:52 +1000
+Subject: [PATCH 2/2] fix typo in testcase; shorten reference to bug report;
+ build a proper tree for negated commands and command alias; update testcase
+ to reflect this and add a test for building a negated command for
+ completeness
+
+---
+ lenses/sudoers.aug            | 69 ++++++++++++++++++++++---------------------
+ lenses/tests/test_sudoers.aug | 24 ++++++++++++---
+ 2 files changed, 55 insertions(+), 38 deletions(-)
+
+diff --git a/lenses/sudoers.aug b/lenses/sudoers.aug
+index 2c880c5..35e7ca8 100644
+--- a/lenses/sudoers.aug
++++ b/lenses/sudoers.aug
+@@ -82,15 +82,46 @@ let sep_col  = sep_cont_opt_build ":"
+ (* Variable: sep_dquote *)
+ let sep_dquote   = Util.del_str "\""
+ 
++(************************************************************************
++ * View: default_type
++ *   Type definition for <defaults>
++ *
++ *   Definition:
++ *     > Default_Type ::= 'Defaults' |
++ *     >                  'Defaults' '@' Host_List |
++ *     >                  'Defaults' ':' User_List |
++ *     >                  'Defaults' '!' Cmnd_List |
++ *     >                  'Defaults' '>' Runas_List
++ *************************************************************************)
++let default_type     =
++  let value = store /[@:!>][^ \t\n\\]+/ in
++  [ label "type" . value ]
++
++(************************************************************************
++ * View: del_negate
++ *   Delete an even number of '!' signs
++ *************************************************************************)
++let del_negate = del /(!!)*/ ""
++
++(************************************************************************
++ * View: negate_node
++ *   Negation of boolean values for <defaults>. Accept one optional '!'
++ *   and produce a 'negate' node if there is one.
++ *************************************************************************)
++let negate_node = [ del "!" "!" . label "negate" ]
++
++let negate_or_value (key:lens) (value:lens) =
++  [ del_negate . (negate_node . key | key . value) ]
+ 
+ (* Group: Stores *)
+ 
+ (* Variable: sto_to_com_cmnd
+ sto_to_com_cmnd does not begin or end with a space *)
+-let sto_to_com_cmnd =
+-      let alias = /!?/ . Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
+-   in let non_alias = /(!?[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\])|[^,=:#() \t\n\\]/
+-   in store (alias | non_alias)
++
++let sto_to_com_cmnd = del_negate . negate_node? . (
++      let alias = Rx.word - /(NO)?(PASSWD|EXEC|SETENV)/
++     in let non_alias = /[\/a-z]([^,:#()\n\\]|\\\\[=:,\\])*[^,=:#() \t\n\\]|[^,=:#() \t\n\\]/
++   in store (alias | non_alias))
+ 
+ (* Variable: sto_to_com
+ 
+@@ -255,36 +286,6 @@ let alias = user_alias | runas_alias | host_alias | cmnd_alias
+  * Group:                          DEFAULTS
+  *************************************************************************)
+ 
+-(************************************************************************
+- * View: default_type
+- *   Type definition for <defaults>
+- *
+- *   Definition:
+- *     > Default_Type ::= 'Defaults' |
+- *     >                  'Defaults' '@' Host_List |
+- *     >                  'Defaults' ':' User_List |
+- *     >                  'Defaults' '!' Cmnd_List |
+- *     >                  'Defaults' '>' Runas_List
+- *************************************************************************)
+-let default_type     =
+-  let value = store /[@:!>][^ \t\n\\]+/ in
+-  [ label "type" . value ]
+-
+-(************************************************************************
+- * View: del_negate
+- *   Delete an even number of '!' signs
+- *************************************************************************)
+-let del_negate = del /(!!)*/ ""
+-
+-(************************************************************************
+- * View: negate_node
+- *   Negation of boolean values for <defaults>. Accept one optional '!'
+- *   and produce a 'negate' node if there is one.
+- *************************************************************************)
+-let negate_node = [ del "!" "!" . label "negate" ]
+-
+-let negate_or_value (key:lens) (value:lens) =
+-  [ del_negate . (negate_node . key | key . value) ]
+ 
+ (************************************************************************
+  * View: parameter_flag
+diff --git a/lenses/tests/test_sudoers.aug b/lenses/tests/test_sudoers.aug
+index d1f47c9..0ce5758 100644
+--- a/lenses/tests/test_sudoers.aug
++++ b/lenses/tests/test_sudoers.aug
+@@ -183,7 +183,8 @@ www-data +biglab=(rpinson)NOEXEC: ICAL \
+ 	  { "host_group"
+ 	      { "host" = "ALPHA" }
+ 	      { "command" = "/usr/bin/su [!-]*" }
+-	      { "command" = "!/usr/bin/su *root*" } } }
++	      { "command" = "/usr/bin/su *root*" 
++                  { "negate" } } } }
+       {}
+       { "spec"
+           { "user"    = "@my\ admin\ group" }
+@@ -328,14 +329,29 @@ test Sudoers.spec get "group+user somehost = ALL\n" =
+   }
+ 
+ (* Test: Sudoers.spec
+-     https://github.com/hercules-team/augeas/issues/262:  Sudoers lens doesn't suppot `!` for command aliases *)
+-test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !BANNED\n" = 
++     GH #262:  Sudoers lens doesn't support `!` for command aliases *)
++test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !!!BANNED\n" = 
+   { "spec"
+     { "user" = "%opssudoers" }
+     { "host_group"
+       { "host" = "ALL" }
+       { "command" = "ALL"
+         { "runas_user" = "ALL" } }
+-      { "command" = "!BANNED" }
++      { "command" = "BANNED"
++        { "negate" } }
++    }
++  }
++
++(* Test: Sudoers.spec
++     Handle multiple `!` properly in commands *)
++test Sudoers.spec get "%opssudoers ALL=(ALL) ALL, !!!/bin/mount\n" =
++  { "spec"
++    { "user" = "%opssudoers" }
++    { "host_group"
++      { "host" = "ALL" }
++      { "command" = "ALL"
++        { "runas_user" = "ALL" } }
++      { "command" = "/bin/mount"
++        { "negate" } }
+     }
+   }


### PR DESCRIPTION
Prior to this commit, when negated command aliases are
present in /etc/sudoers, customers are unable to use
Puppet to manage the file.

This commit adds a patch based on Geoff Williams' PR
at https://github.com/hercules-team/augeas/pull/263.
