### PR TITLE
(FACT-1152) Enable partition fact for el4/el5

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -76,6 +76,9 @@ component "facter" do |pkg, settings, platform|
     if (platform.is_el? and platform.os_version.to_i >= 6) or (platform.is_sles? and platform.os_version.to_i >= 11)
       pkg.build_requires "libblkid-devel"
       skip_blkid = 'OFF'
+    elsif (platform.is_el? and platform.os_version.to_i < 6)
+      pkg.build_requires "e2fsprogs-devel"
+      skip_blkid = 'OFF'
     end
   end
 


### PR DESCRIPTION
On el4 and el5, blkid is provided by a different package than in later
EL systems. It is in the e2fsprogs package (it later moved into
util-linux). This commit enables blkid for el4 and el5 and adds a build
dependency on e2fsprogs-devel for those platforms.
