### PR TITLE
(RE-5144) Add OpenSSL license file to AIO puppet-agent

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -67,6 +67,8 @@ component "openssl" do |pkg, settings, platform|
     ["#{env} #{platform[:make]} INSTALL_PREFIX=/ install"]
   end
 
+  pkg.install_file "LICENSE", "#{settings[:prefix]}/share/doc/openssl-#{pkg.get_version}/LICENSE"
+
   if platform.is_deb?
     pkg.link '/etc/ssl/certs/ca-certificates.crt', ca_certfile
   elsif platform.is_rpm?


### PR DESCRIPTION
Prior to this commit, the puppet-agent does not include
the OpenSSL license file. By the terms of the OpenSSL
license, it looks like we need to include it.

This commit updates the puppet-agent openssl component
to include the OpenSSL license file.
