### PR TITLE
(RE-5153) Add Puppet Execution Protocol agent

### DIFF
--- a/configs/components/cpp-pxp-client.json
+++ b/configs/components/cpp-pxp-client.json
@@ -1,0 +1,2 @@
+{"url": "git@github.com:puppetlabs/cthun-client.git", "ref": "master"}
+

--- a/configs/components/cpp-pxp-client.rb
+++ b/configs/components/cpp-pxp-client.rb
@@ -1,0 +1,28 @@
+component "cpp-pxp-client" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/cpp-pxp-client.json')
+
+  pkg.build_requires "openssl"
+  pkg.build_requires "pl-gcc"
+  pkg.build_requires "pl-cmake"
+  pkg.build_requires "pl-boost"
+
+  pkg.configure do
+    ["PATH=#{settings[:bindir]}:$$PATH \
+          /opt/pl-build-tools/bin/cmake \
+          -DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+          -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+          -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
+          -DBOOST_STATIC=ON \
+          ."]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,0 +1,2 @@
+{"url": "git@github.com:puppetlabs/cthun-agent.git", "ref": "master"}
+

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -1,0 +1,29 @@
+component "pxp-agent" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/pxp-agent.json')
+
+  pkg.build_requires "facter"
+  pkg.build_requires "openssl"
+  pkg.build_requires "pl-gcc"
+  pkg.build_requires "pl-cmake"
+  pkg.build_requires "pl-boost"
+
+ pkg.configure do
+    ["PATH=#{settings[:bindir]}:$$PATH \
+          /opt/pl-build-tools/bin/cmake \
+          -DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+          -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+          -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
+          -DBOOST_STATIC=ON \
+          ."]
+  end
+
+  pkg.build do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -33,6 +33,10 @@ project "puppet-agent" do |proj|
   proj.component "facter"
   proj.component "hiera"
   proj.component "marionette-collective"
+  if proj.get_platform.is_rpm? || proj.get_platform.is_deb?
+    proj.component "cpp-pxp-client"
+    proj.component "pxp-agent"
+  end
 
   # Then the dependencies
   proj.component "augeas"


### PR DESCRIPTION
This commit adds initial support for the Puppet Execution Protocol agent (pxp-agent) as a component
to the AIO puppet-agent for rpm- and deb-based platforms. (Solaris 
and OSX are excluded for the moment, as puppet-agent for these 
platforms is still WIP.)

These configs are based on the initial work at
https://github.com/puppetlabs/cthun-agent-vanagon.

:warning:  This will need attention after the cthun projects are renamed. 
