### PR TITLE
(maint) Add rsync to Debian 7 dependencies

### DIFF
--- a/configs/platforms/debian-7-amd64.rb
+++ b/configs/platforms/debian-7-amd64.rb
@@ -5,7 +5,7 @@ platform "debian-7-amd64" do |plat|
   plat.codename "wheezy"
 
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-7-x86_64"
 end

--- a/configs/platforms/debian-7-i386.rb
+++ b/configs/platforms/debian-7-i386.rb
@@ -5,7 +5,7 @@ platform "debian-7-i386" do |plat|
   plat.codename "wheezy"
 
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vcloud_name "debian-7-i386"
 end


### PR DESCRIPTION
rsync is required for vanagon. Package was missing in Debian 7 definition (although present in Debian 8 definitions.

It's possible the image in pooler already had rsync installed, but it's required for clean installs.

buildtools update puppetlabs/pl-build-tools-vanagon#71
