### PR TITLE
(RE-4958) Add missing directories to packaging lists

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -129,5 +129,6 @@ component "facter" do |pkg, settings, platform|
   end
 
   pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter"
+  pkg.directory File.join('/opt/puppetlabs', 'facter')
   pkg.directory File.join('/opt/puppetlabs', 'facter', 'facts.d')
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -59,6 +59,7 @@ project "puppet-agent" do |proj|
     proj.component "ruby-selinux"
   end
 
+  proj.directory "/opt/puppetlabs"
   proj.directory proj.prefix
   proj.directory proj.sysconfdir
   proj.directory proj.logdir


### PR DESCRIPTION
Found that these were missing from being included in the RPM
package once we started explicitly delcaring directories.
