### PR TITLE
(maint) Limit chown in ruby-augeas to solaris platforms

### DIFF
--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -22,8 +22,11 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.install do
     [
       "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) DESTDIR=/ install",
-      "chown root:root #{settings[:ruby_vendordir]}/augeas.rb",
     ]
   end
+
+  pkg.install do
+    "chown root:root #{settings[:ruby_vendordir]}/augeas.rb"
+  end if platform.is_solaris?
 
 end


### PR DESCRIPTION
Previously a chown was applied to all platforms during the install of
the ruby-augeas component. This was to satisfy solaris packaging needs,
and seemed safe everywhere. However the root group doesn't exist on
platforms such as OSX, so this commit limits the application of the
chown to just solaris where it is needed.
