### PR TITLE
Bump vanagon to 0.3.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.7')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.8')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'


### PR DESCRIPTION
Update vanagon to 0.3.8 to add support for
the OSX installer plugin, some debian fixes and
some RPM 5/Cisco Wind-River Linux fixes.
