### PR TITLE
(PE-11625) Patch augeas services lens for sles-10

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -6,6 +6,9 @@ component 'augeas' do |pkg, settings, platform|
   pkg.replaces 'pe-augeas'
   pkg.apply_patch 'resources/patches/augeas/osx-stub-needed-readline-functions.patch'
   pkg.apply_patch 'resources/patches/augeas/sudoers-negated-command-alias.patch'
+  if platform.is_sles? && platform.os_version == '10'
+    pkg.apply_patch 'resources/patches/augeas/augeas-1.2.0-fix-services-sles10.patch'
+  end
 
   if platform.is_rpm?
     pkg.build_requires 'libxml2-devel'

--- a/resources/patches/augeas/augeas-1.2.0-fix-services-sles10.patch
+++ b/resources/patches/augeas/augeas-1.2.0-fix-services-sles10.patch
@@ -1,0 +1,43 @@
+From f750f694d883976895c5a01cdcf8cdfc1458b04f Mon Sep 17 00:00:00 2001
+From: Rob Braden <bradejr@puppetlabs.com>
+Date: Thu, 18 Sep 2014 15:18:15 -0700
+Subject: [PATCH] Permit a missing protocol, as exists in SLES for the
+ supfilesrv service
+
+---
+ lenses/services.aug            | 2 +-
+ lenses/tests/test_services.aug | 6 ++++++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/lenses/services.aug b/lenses/services.aug
+index 338737d..82d3354 100644
+--- a/lenses/services.aug
++++ b/lenses/services.aug
+@@ -79,7 +79,7 @@ let alias = [ label "alias" . store word_re ]
+  *)
+ let record = [ label "service-name" . store word_re
+                  . sep_spc . (port | port_range)
+-                 . del "/" "/" . protocol . ( sep_spc . alias )*
++                 . (del "/" "/" . protocol)? . ( sep_spc . alias )*
+                  . comment_or_eol ]
+
+ (* View: lns
+diff --git a/lenses/tests/test_services.aug b/lenses/tests/test_services.aug
+index aef5143..3274bff 100644
+--- a/lenses/tests/test_services.aug
++++ b/lenses/tests/test_services.aug
+@@ -72,6 +72,12 @@ z39.50		210/tcp		z3950 wais	# NISO Z39.50 database \n"
+   test Services.lns put "tcpmux          1/tcp # some comment\n"
+     after rm "/service-name/#comment" = "tcpmux          1/tcp\n"
+
++  (* From SLES, an invalid line with no protocol *)
++  test Services.record get "supfilesrv  871    # NOT OFFICIAL ASSIGNED\n" =
++    { "service-name" = "supfilesrv"
++        { "port"     = "871" }
++        { "#comment" = "NOT OFFICIAL ASSIGNED" } }
++
+   (* On AIX, port ranges are valid *)
+   test Services.lns get "x11                      6000-6063/tcp  # X Window System\n" =
+     { "service-name" = "x11"
+--
+2.1.0


### PR DESCRIPTION
SLES 10 out of the box has an entry in /etc/services with
no protocol listed, which is non-conforming with the standard
for entries in the file.

This pulls in a patch from pe-augeas, originally from
https://github.com/domcleal/augeas/commit/ea86153468eb7989592a4eb1b7b6d8b0794f709c
as documented at http://www.redhat.com/archives/augeas-devel/2011-June/msg00041.html
