### PR TITLE
(maint) Add ca-certs component to solaris

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -80,6 +80,9 @@ project "puppet-agent" do |proj|
   # Components only applicable on OSX
   if proj.get_platform.is_osx?
    proj.component "cfpropertylist"
+  end
+
+  if proj.get_platform.is_solaris? || proj.get_platform.is_osx?
    proj.component "ca-cert"
   end
 


### PR DESCRIPTION
Solaris suffers from the same ca-cert deficiencies that osx does, so
this commit applies the same ca-cert component to the solaris build to
ensure that the puppet-agent can connect to the forge successfully.
