### PR TITLE
(maint) Fix Solaris i386 build's FACTER_RUBY

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -114,7 +114,9 @@ component "facter" do |pkg, settings, platform|
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
   elsif platform.is_solaris?
-    ruby = "/opt/csw/bin/ruby -r#{settings[:datadir]}/doc/rbconfig.rb"
+    if platform.architecture == 'sparc'
+      ruby = "/opt/csw/bin/ruby -r#{settings[:datadir]}/doc/rbconfig.rb"
+    end
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.10/bin/cmake"
 
@@ -145,7 +147,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   # Make test will explode horribly in a cross-compile situation
-  if platform.architecture == "sparc"
+  if platform.architecture == 'sparc'
     test = ":"
   else
     test = "#{platform[:make]} test ARGS=-V"


### PR DESCRIPTION
Facter relies on FACTER_RUBY being defined to match the AIO's libruby
path. For cross-compiles - such as sparc - we need another Ruby
installed to provide that info, but that Ruby isn't present on Solaris
i386 builds and results in setting the wrong FACTER_RUBY.

Only use `/opt/csw/bin/ruby` on Sparc, as that's the only system it's
needed on.
