### PR TITLE
(maint) Dependency tweaks for HuaweiOS

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -15,7 +15,7 @@ component 'augeas' do |pkg, settings, platform|
     pkg.requires 'libxml2'
 
     pkg.build_requires 'readline-devel'
-    if platform.is_nxos? or platform.is_cisco_wrlinux?
+    if platform.is_nxos? or platform.is_cisco_wrlinux? or platform.is_huaweios?
       pkg.requires 'libreadline6'
     else
       pkg.requires 'readline'

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -9,7 +9,7 @@ component "virt-what" do |pkg, settings, platform|
   unless platform.is_deb?
     requires "util-linux"
   end
-  unless ( platform.name =~ /^el-4-.*$/ or platform.name =~ /^sles-(10|11)-.*$/ or platform.is_nxos? or platform.is_cisco_wrlinux? or platform.is_eos? )
+  unless ( platform.name =~ /^el-4-.*$/ or platform.name =~ /^sles-(10|11)-.*$/ or platform.is_nxos? or platform.is_cisco_wrlinux? or platform.is_eos? or platform.is_huaweios? )
     requires "dmidecode"
   end
   if platform.name =~ /^sles-(10|11)-.*$/


### PR DESCRIPTION
HuaweiOS doesn't have dmidecode available, and uses libreadline6 as the
name of its readline package.
