### PR TITLE
(CTH-277) Update Github URL for cpp-pcp-client

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,2 +1,2 @@
-{"url": "git@github.com:puppetlabs/cthun-client.git", "ref": "master"}
+{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "master"}
 


### PR DESCRIPTION
The Github repo has been renamed from cthun-client
to cpp-pcp-client.

Here we update the URL to match.
