### PR TITLE
Revert "(RE-5358) Update Ruby to 2.1.7"

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,6 +1,6 @@
 component "ruby" do |pkg, settings, platform|
-  pkg.version "2.1.7"
-  pkg.md5sum "2e143b8e19b056df46479ae4412550c9"
+  pkg.version "2.1.6"
+  pkg.md5sum "6e5564364be085c45576787b48eeb75f"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby'
@@ -11,16 +11,17 @@ component "ruby" do |pkg, settings, platform|
   pkg.replaces 'pe-rubygem-gem2rpm'
 
   pkg.apply_patch "resources/patches/ruby/libyaml_cve-2014-9130.patch"
+  pkg.apply_patch "resources/patches/ruby/CVE-2015-4020.patch"
 
   # Cross-compiles require a hand-built rbconfig from the target system
   if platform.is_solaris?
     rbconfig_info = {
       'sparc-sun-solaris2.10' => {
-        :sum => "94ccda4d66ada8d301dce0cdd111ea5a",
+        :sum => "e3ce52e22c49b7a32eb290b6253b0cbc",
         :target_double => 'sparc-solaris2.10',
       },
       'i386-pc-solaris2.10' => {
-        :sum => "d4d75e7afccbb235fc079f558473c7f9",
+        :sum => "5a34dbec6d4b8dbe1a01dedfc60441aa",
         :target_double => 'i386-solaris2.10',
       },
     }

--- a/resources/files/rbconfig-i386-pc-solaris2.10.rb
+++ b/resources/files/rbconfig-i386-pc-solaris2.10.rb
@@ -1,10 +1,10 @@
 
-# This file was created by PuppetAgent for Solaris 10 i386.  Any
+# This file was created by mkconfig.rb when ruby was built.  Any
 # changes made to this file will be lost the next time ruby is built.
 
 module RbConfig
-  RUBY_VERSION == "2.1.7" or
-    raise "ruby lib version (2.1.7) doesn't match executable version (#{RUBY_VERSION})"
+  RUBY_VERSION == "2.1.6" or
+    raise "ruby lib version (2.1.6) doesn't match executable version (#{RUBY_VERSION})"
 
   TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.1.0/i386-solaris2.10")
   DESTDIR = '' unless defined? DESTDIR
@@ -13,7 +13,7 @@ module RbConfig
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "1"
   CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "400"
+  CONFIG["PATCHLEVEL"] = "336"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/rbconfig-sparc-sun-solaris2.10.rb
+++ b/resources/files/rbconfig-sparc-sun-solaris2.10.rb
@@ -1,10 +1,10 @@
 
-# This file was created by PuppetAgent for Solaris 10 i386.  Any
+# This file was created by mkconfig.rb when ruby was built.  Any
 # changes made to this file will be lost the next time ruby is built.
 
 module RbConfig
-  RUBY_VERSION == "2.1.7" or
-    raise "ruby lib version (2.1.7) doesn't match executable version (#{RUBY_VERSION})"
+  RUBY_VERSION == "2.1.6" or
+    raise "ruby lib version (2.1.6) doesn't match executable version (#{RUBY_VERSION})"
 
   TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.1.0/sparc-solaris2.10")
   DESTDIR = '' unless defined? DESTDIR
@@ -13,7 +13,7 @@ module RbConfig
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "1"
   CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "400"
+  CONFIG["PATCHLEVEL"] = "336"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/patches/ruby/CVE-2015-4020.patch
+++ b/resources/patches/ruby/CVE-2015-4020.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/rubygems.rb b/lib/rubygems.rb
+index ea18930..73d063e 100644
+--- a/lib/rubygems.rb
++++ b/lib/rubygems.rb
+@@ -8,7 +8,7 @@
+ require 'rbconfig'
+ 
+ module Gem
+-  VERSION = '2.2.3'
++  VERSION = '2.2.5'
+ end
+ 
+ # Must be first since it unloads the prelude from 1.9.2
+diff --git a/lib/rubygems/remote_fetcher.rb b/lib/rubygems/remote_fetcher.rb
+index 58991ca..ed2e171 100644
+--- a/lib/rubygems/remote_fetcher.rb
++++ b/lib/rubygems/remote_fetcher.rb
+@@ -90,7 +90,13 @@ class Gem::RemoteFetcher
+     rescue Resolv::ResolvError
+       uri
+     else
+-      URI.parse "#{uri.scheme}://#{res.target}#{uri.path}"
++      target = res.target.to_s.strip
++
++      if /\.#{Regexp.quote(host)}\z/ =~ target
++        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
++      end
++
++      uri
+     end
+   end
+ 


### PR DESCRIPTION
This reverts commit 0e2edb6d11eed705276b1d27a4f01756d5997d11.

Ruby 2.1.7 doesn't build out of the box on el4 or sles10, so this commit
pulls it out until we can get 2.1.7 building on those platforms.
