### PR TITLE
(CPR-190) Register puppet and hiera as gems in the AIO

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -19,6 +19,8 @@ component "hiera" do |pkg, settings, platform|
     "#{ruby} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version}.gemspec"
+
   pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -71,6 +71,9 @@ component "puppet" do |pkg, settings, platform|
     ]
   end
 
+
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version}.gemspec"
+
   pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
   pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
 


### PR DESCRIPTION
Previously if you wanted to install gems that depended on puppet or
hiera, you had to force them since the gem system included with the AIO
didn't see puppet/hiera as installed. This commit fixes that that
installing the gemspecs for these projects.

Note: mcollective has never had a gemspec, so it is not registred.
Note2: Facter is no longer a ruby project, so is not registered.

```
[root@turq77jknoh13ul ~]# rpm -Uvh
puppet-agent-1.2.3.311.gb740bfa-1.el7.x86_64.rpm
Preparing...                          #################################
[100%]
Updating / installing...
   1:puppet-agent-1.2.3.311.gb740bfa-1#################################
   [100%]
[root@turq77jknoh13ul ~]# /opt/puppetlabs/puppet/bin/gem list

   *** LOCAL GEMS ***

   bigdecimal (1.2.4)
   deep_merge (1.0.1)
   hiera (3.0.3)
   hocon (0.9.3)
   io-console (0.4.3)
   json (1.8.1)
   minitest (4.7.5)
   net-ssh (2.1.4)
   psych (2.0.5)
   puppet (4.2.1)
   rake (10.1.0)
   rdoc (4.1.0)
   stomp (1.3.3)
   test-unit (2.1.6.0)
```
