### PR TITLE
(PUP-5215) Update Ruby to include an updated openssl 

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.6.1-x86",
-    "x64": "refs/tags/2.1.6.1-x64"
+    "x86": "refs/tags/2.1.6.2-x86",
+    "x64": "refs/tags/2.1.6.2-x64"
   }
 }


### PR DESCRIPTION
This commit updates the ruby build we are including in the puppet-agent
package. This new build is against an updated build of OpenSSL 1.0.0s
