### PR TITLE
Revert "(PUP-5215) Update Ruby to include an updated openssl"

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.6.2-x86",
-    "x64": "refs/tags/2.1.6.2-x64"
+    "x86": "refs/tags/2.1.6.1-x86",
+    "x64": "refs/tags/2.1.6.1-x64"
   }
 }


### PR DESCRIPTION
This reverts commit 226bfeb21f188d8ff44d20e18c082c70af3ba69d.

This work was only partially completed, with x64 openssl not remediated.
This commit rolls the tag back until it is complete.
