### PR TITLE
Bump puppet, facter, hiera, mcollective for puppet-agent 1.2.4

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/facter",
-  "ref": "refs/tags/3.0.2"
+  "ref": "refs/tags/3.1.0"
 }

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/hiera",
-  "ref": "refs/tags/3.0.2"
+  "ref": "refs/tags/3.0.3"
 }

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/marionette-collective",
-  "ref": "refs/tags/2.8.4"
+  "ref": "refs/tags/2.8.5"
 }

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.com/puppetlabs/puppet.git",
-  "ref": "refs/tags/4.2.1"
+  "ref": "refs/tags/4.2.2"
 }


### PR DESCRIPTION
windows_ruby is staying at 2.1.6.1-x86/x64, and windows_puppet was
already bumped to 4.2.2.
