### PR TITLE
(PUP-5225) Use cert bundle for el4

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -113,7 +113,7 @@ component "openssl" do |pkg, settings, platform|
     when /sles-12-.*$/
       pkg.link '/etc/ssl/ca-bundle.pem', ca_certfile
     when /el-4-.*$/
-      pkg.link '/usr/share/ssl/certs/ca-bundle.crt', ca_certfile
+      # Do nothing here. We have a minimal root cert bundle.
     else
       pkg.link '/etc/pki/tls/certs/ca-bundle.crt', ca_certfile
     end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -83,7 +83,7 @@ project "puppet-agent" do |proj|
     proj.component "cfpropertylist"
   end
 
-  if platform.is_solaris? || platform.is_osx?
+  if platform.is_solaris? || platform.is_osx? || platform.name =~ /^el-4/
     proj.component "ca-cert"
   end
 


### PR DESCRIPTION
EL4 has a particularly old cert bundle with its version of openssl,
which doesn't include our forge root cert. Because of this, here we add
the ca-cert component for el4 and use our own minimal root cert bundle,
which include that cert.
