### PR TITLE
(PUP-5215, RE-5359) Bump to RUby 2.1.7, OpenSSL 1.0.2d, and include s…

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.6.1-x86",
-    "x64": "refs/tags/2.1.6.1-x64"
+    "x86": "refs/tags/2.1.7.0-x86",
+    "x64": "refs/tags/2.1.7.0-x64"
   }
 }


### PR DESCRIPTION
…afer openssl default cert dir
