### PR TITLE
(CPR-145) Add /opt/puppetlabs/bin to $PATH

### DIFF
--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -1,0 +1,7 @@
+component "shellpath" do |pkg, settings, platform|
+  pkg.version "2015-09-18"
+  pkg.add_source "file://resources/files/puppet-agent.sh", sum: "490e3e4424318edab303e97eaba76f48"
+  pkg.add_source "file://resources/files/puppet-agent.csh", sum: "62b360a7d15b486377ef6c7c6d05e881"
+  pkg.install_configfile("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh")
+  pkg.install_configfile("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -84,6 +84,7 @@ project "puppet-agent" do |proj|
   if platform.is_linux?
     proj.component "virt-what"
     proj.component "dmidecode"
+    proj.component "shellpath"
   end
 
   if platform.is_solaris? || platform.name =~ /^el-4/

--- a/resources/files/puppet-agent.csh
+++ b/resources/files/puppet-agent.csh
@@ -1,0 +1,2 @@
+# Add /opt/puppetlabs/bin to the path for csh users
+set path = ($path /opt/puppetlabs/bin)

--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -1,0 +1,5 @@
+# Place /opt/puppetlabs/bin in $PATH if it's not already there.
+
+if ! $(echo $PATH | grep /opt/puppetlabs/bin) ; then
+    export PATH=$PATH:/opt/puppetlabs/bin
+fi


### PR DESCRIPTION
This commit introduces 2 new files to be placed in /etc/profile.d on
linux systems. They add /opt/puppetlabs/bin to your $PATH for bourne and
csh compatible shells.

The files are marked as config files as admins may want to edit or
remove them.

Two downsides:
1. Though it adds things to /etc/profile.d, unless you source
   /etc/profile the current shell won't have it added to the path.
2. Systems that are not Linux still have this problem.
