### PR TITLE
(maint) Update net-ssh gem to 2.9.2

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,6 +1,6 @@
 component "rubygem-net-ssh" do |pkg, settings, platform|
-  pkg.version "2.1.4"
-  pkg.md5sum "797c9a7a9e25c781cbf6b77a0054bb2e"
+  pkg.version "2.9.2"
+  pkg.md5sum "ac7574a89e2b422468d98f5387ceb41e"
   pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-rubygem-net-ssh'


### PR DESCRIPTION
The version of net-ssh we've been shipping was released in April 2011.
This upgrade is also needed so we can eventually add support for
including the net-netconf gem for HuaweiOS.
