### PR TITLE
(CPR-224) Add ruby-selinux component on fedora platforms

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -109,7 +109,7 @@ project "puppet-agent" do |proj|
   end
 
   # We only build ruby-selinux for EL 5-7
-  if platform.name =~ /^el-(5|6|7)-.*/
+  if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
     proj.component "ruby-selinux"
   end
 


### PR DESCRIPTION
Previously the ruby-selinux compoment was only included on el5 through
el7, which left fedora out in the cold rainy world on its own. This
commit invites fedora into the cozy warm house we've built.
