### PR TITLE
(RE-5346) Fix up pxp/pcp for AIX

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -1,10 +1,18 @@
 component "cpp-pcp-client" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/cpp-pcp-client.json')
 
-  pkg.build_requires "openssl"
-  pkg.build_requires "pl-gcc"
-  pkg.build_requires "pl-cmake"
-  pkg.build_requires "pl-boost"
+  if platform.is_aix?
+    pkg.build_requires "openssl"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
+  else
+    pkg.build_requires "openssl"
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+  end
 
   pkg.configure do
     ["PATH=#{settings[:bindir]}:$$PATH \

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -3,9 +3,15 @@ component "pxp-agent" do |pkg, settings, platform|
 
   pkg.build_requires "facter"
   pkg.build_requires "openssl"
-  pkg.build_requires "pl-gcc"
-  pkg.build_requires "pl-cmake"
-  pkg.build_requires "pl-boost"
+  if platform.is_aix?
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
+  else
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+  end
 
  pkg.configure do
     ["PATH=#{settings[:bindir]}:$$PATH \

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -70,7 +70,7 @@ project "puppet-agent" do |proj|
   proj.component "facter"
   proj.component "hiera"
   proj.component "marionette-collective"
-  if platform.is_rpm? || platform.is_deb?
+  if platform.is_linux?
     proj.component "cpp-pcp-client"
     proj.component "pxp-agent"
   end


### PR DESCRIPTION
This commit makes it so you can build puppet-agent on master for AIX.
This does not mean that pcp/pxp work for AIX, because there are some
code issues there, however this at least gets us to the stage where we
can run builds of puppet-agent without blowing up.
