### PR TITLE
(RE-5313) Add pxp-agent to the Windows Build

### DIFF
--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -1,0 +1,48 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+param (
+[int] $arch=64,
+[int] $cores=2,
+[string] $cpppcpclientRef='origin/master'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+. $scriptDirectory\windows-env.ps1
+
+Write-Host "arch=$arch, cores=$cores"
+
+cd $sourceDir
+
+Write-Host "Starting cpp-pcp-client build"
+
+cd cpp-pcp-client
+git checkout $cpppcpclientRef
+mkdir -Force release
+cd release
+
+## Build pxp_agent
+$args = @(
+  '-G',
+  "MinGW Makefiles",
+  "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
+  "-DBOOST_STATIC=ON",
+  "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client`"",
+  "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`""
+  "-DCURL_STATIC=ON",
+  ".."
+)
+cmake $args
+mingw32-make -j $cores
+mingw32-make install
+
+Write-Host "cpp-pcp-client Build completed."
+## Write out the version that was just built.
+#git describe --long | Out-File -FilePath 'bin/VERSION' -Encoding ASCII -Force
+
+## Test the results.
+Write-Host "Starting Tests"
+mingw32-make test ARGS=-V

--- a/bin/build-facter.ps1
+++ b/bin/build-facter.ps1
@@ -1,0 +1,47 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+param (
+[int] $arch=64,
+[int] $cores=2,
+[string] $facterRef='origin/master'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+. $scriptDirectory\windows-env.ps1
+
+Write-Host "Arch=$arch, Cores=$cores"
+
+Write-Host "Starting facter build"
+
+## facter already downloaded - cd and start the build
+
+cd facter
+git checkout $facterRef
+mkdir -Force release
+cd release
+
+## Build Facter
+$args = @(
+  '-G',
+  "MinGW Makefiles",
+  "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
+  "-DBOOST_STATIC=ON",
+  "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg`"",
+  "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\deps`""
+  "-DCURL_STATIC=ON",
+  ".."
+)
+cmake $args
+mingw32-make -j $cores
+Write-Host "facter Build completed."
+
+## Write out the version that was just built.
+git describe --long | Out-File -FilePath 'bin/VERSION' -Encoding ASCII -Force
+
+## Test the results.
+Write-Host "Starting Tests"
+mingw32-make test ARGS=-V

--- a/bin/build-pxp-agent.ps1
+++ b/bin/build-pxp-agent.ps1
@@ -1,0 +1,50 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+param (
+[int] $arch=64,
+[int] $cores=2,
+[string] $pxpagentRef='origin/master'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+. $scriptDirectory\windows-env.ps1
+
+Write-Host "arch=$arch, cores=$cores"
+
+cd $sourceDir
+
+Write-Host "Starting pxp-agent build"
+
+cd pxp-agent
+git checkout $pxpagentRef
+mkdir -Force release
+cd release
+
+$env:PATH += ";" + $toolsDir + "\pcp-client\bin"
+Write-Host "Updated Path to $env:PATH"
+
+## Build pxp_agent
+$args = @(
+  '-G',
+  "MinGW Makefiles",
+  "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
+  "-DBOOST_STATIC=ON",
+  "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
+  "-DCMAKE_INSTALL_PREFIX=`"$sourceDir`""
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\pcp-client`"",
+  "-DCURL_STATIC=ON",
+  ".."
+)
+cmake $args
+mingw32-make -j $cores
+Write-Host "pxp-agent Build completed."
+
+## Write out the version that was just built.
+git describe --long | Out-File -FilePath 'bin/VERSION' -Encoding ASCII -Force
+
+## Test the results.
+Write-Host "Starting Tests"
+mingw32-make test ARGS=-V

--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'yaml'
 require 'json'
 require 'fileutils'
@@ -28,6 +29,8 @@ script_arch          = "#{ARCH =='x64' ? '64' : '32'}"
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))
 FACTER       = JSON.parse(File.read('configs/components/facter.json'))
+PXPAGENT     = JSON.parse(File.read('configs/components/pxp-agent.json'))
+CPPPCPCLIENT = JSON.parse(File.read('configs/components/cpp-pcp-client.json'))
 HIERA        = JSON.parse(File.read('configs/components/hiera.json'))
 MCO          = JSON.parse(File.read('configs/components/marionette-collective.json'))
 WINDOWS      = JSON.parse(File.read('configs/components/windows_puppet.json'))
@@ -35,59 +38,103 @@ WINDOWS_RUBY = JSON.parse(File.read('configs/components/windows_ruby.json'))
 
 ssh_key = ENV['VANAGON_SSH_KEY'] ? "-i #{ENV['VANAGON_SSH_KEY']}" : ''
 
-#chocolatey versions
-CHOCO_WIX35_VERSION = '3.5.2519.20130612'
+VMPOOL_TOKEN_OPTS = ENV['VMPOOL_TOKEN'] ? "-H X-AUTH-TOKEN:#{ENV['VMPOOL_TOKEN']}" : ""
 
 # Retrieve a vm
 vm_type = 'win-2012-x86_64'
-curl_output=`curl -d --url http://vmpooler.delivery.puppetlabs.net/vm/#{vm_type}`
+curl_output=`curl -d --url http://vmpooler.delivery.puppetlabs.net/vm/#{vm_type} #{VMPOOL_TOKEN_OPTS}`
 host_json = JSON.parse(curl_output)
 hostname = host_json[vm_type]['hostname'] + '.' + host_json['domain']
 puts "Acquired #{vm_type} VM from pooler at #{hostname}"
+ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no Administrator@#{hostname}"
+rsync_command = "rsync -e 'ssh #{ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -Hl --protocol 29 --verbose --recursive --no-perms --no-owner --no-group"
 
 # Set up the environment so I don't keep crying
-ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no Administrator@#{hostname}"
 ssh_env = "export PATH=\'/cygdrive/c/Program Files (x86)/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
+# rsync to windows requires protocol=29 and ssh command without the -tt option to work.
+# "#{rsync_command} #{source} #{target}:#{dest}"
 
 result = Kernel.system("#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")
 fail "Unable to connect to the host. Is is possible that you aren't on VPN or connected to the internal PL network?" unless result
 
-
-### Build Facter
-#
-#
-
 Kernel.system("#{ssh_command} 'source .bash_profile ; echo $PATH'")
 
-# We use the facter ref for downloading a script from Github, and for checking out
-# the correct ref when building. The URL doesn't support refs/tags/<tag>, so if
-# using an explicit tag strip `refs/tags`. We still use the full ref for git checkout.
-if match = FACTER['ref'].match(/^refs\/tags\/(.*)$/)
-    FACTER_ref = match.captures[0]
-else
-    FACTER_ref = FACTER['ref']
-end
+# Get local work directory for repo fetches.
+workdir = Dir.mktmpdir
+puts "Created Temp Directory #{workdir}"
+# Clone the two repositories including submodules
+result= Kernel.system("set -vx;cd #{workdir}; git clone #{FACTER['url']}")
+fail "It seems there were some issues cloning the facter repo" unless result
+result= Kernel.system("set -vx;cd #{workdir}/facter; git checkout #{FACTER['ref']}; git submodule update --init --recursive")
+fail "It seems there were some issues cloning the facter repo" unless result
 
-# Download and execute the facter build script
-# this script lives in the puppetlabs/facter repo
-facter_build_script = ENV['FACTER_BUILD_SCRIPT'] ||
-  "https://raw.githubusercontent.com/puppetlabs/facter/#{FACTER_ref}/contrib/facter.ps1"
-puts "Downloading Facter build script from #{facter_build_script}"
-result = Kernel.system("#{ssh_command} \"curl -O #{facter_build_script} && powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./facter.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE} -facterRef #{FACTER['ref']} -facterFork #{FACTER['url']}\"")
-fail "It looks like the facter build script #{facter_build_script} failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+result= Kernel.system("set -vx;cd #{workdir}; git clone #{PXPAGENT['url']}")
+fail "It seems there were some issues cloning the pxp-agent repo" unless result
+result= Kernel.system("set -vx;cd #{workdir}/pxp-agent; git checkout #{PXPAGENT['ref']}; git submodule update --init --recursive")
+fail "It seems there were some issues cloning the pxp-agent repo" unless result
+
+result= Kernel.system("set -vx;cd #{workdir}; git clone #{CPPPCPCLIENT['url']}")
+fail "It seems there were some issues cloning the cpc-client repo" unless result
+result= Kernel.system("set -vx;cd #{workdir}/cpp-pcp-client; git checkout #{CPPPCPCLIENT['ref']}; git submodule update --init --recursive")
+fail "It seems there were some issues cloning the cpc-client repo" unless result
+
+# Clone puppet_for_the_win
+result= Kernel.system("set -vx;cd #{workdir}; git clone #{WINDOWS['url']} puppet_for_the_win")
+fail "It seems there were some issues cloning the puppet_for_the_win repo" unless result
+result= Kernel.system("set -vx;cd #{workdir}/puppet_for_the_win; git checkout #{WINDOWS['ref']}")
+fail "It seems there were some issues cloning the puppet_for_the_win repo" unless result
+
+# Push the repos over to the build pooler machine.
+puts "#{rsync_command} #{workdir} 'Administrator@#{hostname}:~/pxp-agent'"
+Kernel.system("#{rsync_command} '#{workdir}/' 'Administrator@#{hostname}:~/'")
+
+# Copy all .ps1 files to destination directory for execution there.
+Kernel.system("#{rsync_command} 'bin/' 'Administrator@#{hostname}:~/'")
+
+# Ready the Windows Build Environment, followed by the facter and pxp-agent build scripts
+
+puts "Build-Windows.rb... Setting up windows toolset - windows-toolset.ps1"
+result = Kernel.system("#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./windows-toolset.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE}\"")
+fail "It looks like the Windows-toolset build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+puts "Build-Windows.rb... Windows Setup Completed!!"
+
+puts "Build-Windows.rb... building cpp-pcp-client"
+result = Kernel.system("#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./build-cpp-pcp-client.ps1 -arch #{script_arch} -cpppcpclientRef #{CPPPCPCLIENT['ref']}\"")
+fail "It looks like the cpp-pcp-client build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+puts "Build-Windows.rb... cpp-pcp-client build Completed!!"
+
+puts "Build-Windows.rb... building pxp-agent"
+result = Kernel.system("#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./build-pxp-agent.ps1 -arch #{script_arch} -pxpagentRef #{PXPAGENT['ref']}\"")
+fail "It looks like the pxp-agent build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+puts "Build-Windows.rb... pxp-agent build Completed!!"
+
+puts "Build-Windows.rb... building facter"
+result = Kernel.system("#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./build-facter.ps1 -arch #{script_arch} -facterRef #{FACTER['ref']}\"")
+fail "It looks like the facter build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
+puts "Build-Windows.rb... facter build Completed!!"
 
 # Move all necessary dll's into facter bindir
-Kernel.system("#{ssh_command} \"cp /cygdrive/c/tools/mingw#{script_arch}/bin/libgcc_s_#{ARCH == 'x64' ? 'seh' : 'sjlj'}-1.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libstdc++-6.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libwinpthread-1.dll /home/Administrator/facter/release/bin/\"")
+Kernel.system("set -vx;#{ssh_command} \"cp /cygdrive/c/tools/mingw#{script_arch}/bin/libgcc_s_#{ARCH == 'x64' ? 'seh' : 'sjlj'}-1.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libstdc++-6.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libwinpthread-1.dll /home/Administrator/facter/release/bin/\"")
+# Repeat for pxp-agent (CTH-357)
+Kernel.system("set -vx;#{ssh_command} \"cp /cygdrive/c/tools/mingw#{script_arch}/bin/libgcc_s_#{ARCH == 'x64' ? 'seh' : 'sjlj'}-1.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libstdc++-6.dll /cygdrive/c/tools/mingw#{script_arch}/bin/libwinpthread-1.dll /home/Administrator/pxp-agent/release/bin/\"")
 
+archive_dest = "/home/Administrator/archive"
+facter_zipname = "facter"
+pxp_zipname = "pxp-agent"
 # Format everything to prepare to archive it
-Kernel.system("#{ssh_command} \"source .bash_profile ; mkdir -p /home/Administrator/archive/lib ; cp -r /home/Administrator/facter/release/bin /home/Administrator/facter/lib/inc /home/Administrator/archive/ ; cp /home/Administrator/facter/release/lib/facter.rb /home/Administrator/archive/lib/ \"")
+Kernel.system("set -vx;#{ssh_command} \"mkdir -p #{archive_dest}/#{facter_zipname}/lib  \"")
+Kernel.system("set -vx;#{ssh_command} \"cp /home/Administrator/facter/release/lib/facter.rb #{archive_dest}/#{facter_zipname}/lib \"")
+Kernel.system("set -vx;#{ssh_command} \"cp -r /home/Administrator/facter/release/bin /home/Administrator/facter/lib/inc #{archive_dest}/#{facter_zipname} \"")
+
+Kernel.system("set -vx;#{ssh_command} \"mkdir -p #{archive_dest}/#{pxp_zipname}/lib  \"")
+Kernel.system("set -vx;#{ssh_command} \"cp -r /home/Administrator/pxp-agent/release/bin /home/Administrator/pxp-agent/lib/inc #{archive_dest}/#{pxp_zipname} \"")
+Kernel.system("set -vx;#{ssh_command} \"cp -r /home/Administrator/cpp-pcp-client/release/bin /home/Administrator/cpp-pcp-client/lib/inc #{archive_dest}/#{pxp_zipname} \"")
 
 # Zip up the built archives
-Kernel.system("#{ssh_command} \"source .bash_profile ; 7za.exe a -r -tzip facter.zip 'C:\\cygwin64\\home\\Administrator\\archive\\*'\"")
-
+Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; 7za.exe a -r -tzip #{facter_zipname}.zip 'C:\\cygwin64\\home\\Administrator\\archive\\#{facter_zipname}\\*'\"")
+Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; 7za.exe a -r -tzip #{pxp_zipname}.zip    'C:\\cygwin64\\home\\Administrator\\archive\\#{pxp_zipname}\\*'\"")
 
 ### Build puppet-agent.msi
-
 
 CONFIG = {
   :repos => {
@@ -103,6 +150,10 @@ CONFIG = {
       :archive => 'facter.zip',
       :path    => 'file:///home/Administrator'
     },
+    'pxp-agent' => {
+      :archive => 'pxp-agent.zip',
+      :path    => 'file:///home/Administrator'
+    },
     'mcollective' => {
       :ref  => MCO['ref'],
       :repo => MCO['url']
@@ -115,30 +166,22 @@ CONFIG = {
 }
 File.open("winconfig.yaml", 'w') { |f| f.write(YAML.dump(CONFIG)) }
 
-# Install Wix35 with chocolatey
-wix_install = "choco install -y Wix35 -source https://www.myget.org/F/puppetlabs -version #{CHOCO_WIX35_VERSION}"
-Kernel.system("#{ssh_command} \"source .bash_profile ; if (! #{wix_install}); then #{wix_install}; fi\"")
-
-# Clone puppet_for_the_win
-result = Kernel.system("#{ssh_command} \"source .bash_profile ; git clone #{WINDOWS['url']} puppet_for_the_win; cd puppet_for_the_win && git checkout #{WINDOWS['ref']}\"")
-fail "It seems there were some issues cloning the puppet_for_the_win repo" unless result
-
 # Send the config file over so we know what to build with
 Kernel.system("scp #{ssh_key} winconfig.yaml Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/")
 
 # Build the MSI with automation in puppet_for_the_win
-result = Kernel.system("#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} c:/tools/ruby21/bin/rake clobber windows:build config=winconfig.yaml\"")
+result = Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} c:/tools/ruby21/bin/rake clobber windows:build config=winconfig.yaml\"")
 fail "It seems there were some issues building the puppet-agent msi" unless result
 
 # Fetch back the built installer
 FileUtils.mkdir_p("output/windows")
 msi_file = "puppet-agent-#{AGENT_VERSION_STRING}-#{ARCH}.msi"
-Kernel.system("scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/pkg/#{msi_file} output/windows/")
+Kernel.system("set -vx;scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/pkg/#{msi_file} output/windows/")
 
 # delete a vm only if we successfully brought back the msi
 msi_path = "output/windows/#{msi_file}"
 if File.exists?(msi_path)
   FileUtils.ln("./#{msi_path}", "output/windows/puppet-agent-#{ARCH}.msi")
-  Kernel.system("curl -X DELETE --url \"http://vmpooler.delivery.puppetlabs.net/vm/#{hostname}\"")
+  Kernel.system("set -vx;curl -X DELETE --url \"http://vmpooler.delivery.puppetlabs.net/vm/#{hostname}\"")
   FileUtils.rm 'winconfig.yaml'
 end

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -1,0 +1,62 @@
+
+$ErrorActionPreference = 'Stop'
+
+# Ensure TEMP directory is set and exists. Git.install can fail otherwise.
+if ($env:TEMP -eq $null) {
+  $env:TEMP = Join-Path $env:SystemDrive 'temp'
+  Write-Host "TEMP is null, setting to $env:TEMP"
+}
+if (!(Test-Path $env:TEMP)) {
+  mkdir -Path $env:TEMP
+  Write-Host "Created Temp Directory $env:TEMP"
+}
+
+if ($env:Path -eq $null) {
+    Write-Host "Path is null?"
+}
+
+# Starting from a base Windows Server 2008r2 or 2012r2 installation, install required tools, setup the PATH, and download and build software.
+# This script can be run directly from the web using "iex ((new-object net.webclient).DownloadString('<url_to_raw>'))"
+
+### Configuration
+## Setup the working directory
+$sourceDir=$pwd
+
+$toolsDir="${sourceDir}\deps"
+
+$mingwVerNum = "4.8.3"
+$mingwVerChoco = $mingwVerNum
+$mingwThreads = "posix"
+if ($arch -eq 64) {
+  $mingwExceptions = "seh"
+  $mingwArch = "x86_64"
+} else {
+  $mingwExceptions = "sjlj"
+  $mingwArch = "i686"
+}
+$mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
+
+$opensslPkg = "openssl-1.0.0s-x64-windows"
+
+$boostVer = "boost_1_57_0"
+$boostPkg = "${boostVer}-${mingwVer}"
+
+$yamlCppVer = "yaml-cpp-0.5.1"
+$yamlPkg = "${yamlCppVer}-${mingwVer}"
+
+$curlVer = "curl-7.42.1"
+$curlPkg = "${curlVer}-${mingwVer}"
+
+$Wix35_VERSION = '3.5.2519.20130612'
+
+$cppInst = "cpp-pcp-client"
+
+$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+if ($arch -eq 32) {
+  $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
+}
+$env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\Git\cmd"
+Write-Host "Updated Path to $env:PATH"
+
+# SSL root pointer.
+$env:OPENSSL_ROOT_DIR = $toolsDir + "\" + $opensslPkg

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -1,0 +1,151 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+# $buildSource => Choose whether to download pre-built libraries or build from source
+param (
+[int] $arch=64,
+[int] $cores=2,
+[bool] $buildSource=$FALSE
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+. $scriptDirectory\windows-env.ps1
+
+mkdir -Force $toolsDir
+
+Write-Host "arch=$arch, cores=$cores, buildsource=$buildsource"
+
+### Setup, build, and install
+## Install Chocolatey, then use it to install required tools.
+Function Install-Choco ($pkg, $ver, $opts = "") {
+    Write-Host "Installing $pkg $ver from https://www.myget.org/F/puppetlabs"
+    try {
+        choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts
+    } catch {
+        Write-Host "Error: $_, trying again."
+        choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts
+    }
+}
+
+if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+Install-Choco 7zip.commandline 9.20.0.20150210
+
+Install-Choco cmake 3.2.2
+Install-Choco git.install 1.9.5.20150320
+Install-Choco python 3.4.2.20150210
+# Use native chocolatey to install gow as we don't have it in the PL repo.
+choco install -y gow -version 0.8.0
+Install-Choco Wix35 $Wix35_VERSION
+
+# For MinGW, we expect specific project defaults
+# - win32 threads, for Windows Server 2003 support
+# - seh exceptions on 64-bit, to work around an obscure bug loading Ruby in Facter
+# These are the defaults on our myget feed.
+if ($arch -eq 64) {
+  Install-Choco ruby 2.1.6
+  Install-Choco mingw-w64-posix $mingwVerChoco
+} else {
+  Install-Choco ruby 2.1.6 @('-x86')
+  Install-Choco mingw-w32-posix $mingwVerChoco @('-x86')
+}
+$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+if ($arch -eq 32) {
+  $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
+}
+$env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\Git\cmd"
+Write-Host "Updated Path to $env:PATH"
+
+cd $toolsDir
+
+if ($buildSource) {
+  ## Download, build, and install Boost
+  Write-Host "Downloading http://downloads.sourceforge.net/boost/$boostVer.7z"
+  (New-Object net.webclient).DownloadFile("http://downloads.sourceforge.net/boost/$boostVer.7z", "$toolsDir\$boostVer.7z")
+  & 7za x "${boostVer}.7z" | FIND /V "ing "
+  cd $boostVer
+
+  .\bootstrap mingw
+  $args = @(
+    'toolset=gcc',
+    "--build-type=minimal",
+    "install",
+    "--with-program_options",
+    "--with-system",
+    "--with-filesystem",
+    "--with-date_time",
+    "--with-thread",
+    "--with-regex",
+    "--with-random",
+    "--with-log",
+    "--with-locale",
+    "--with-chrono",
+    "--prefix=`"$toolsDir\$boostPkg`"",
+    "boost.locale.iconv=off"
+    "-j$cores"
+  )
+  .\b2 $args
+  cd $toolsDir
+
+  ## Download, build, and install yaml-cpp
+  Write-Host "Downloading https://yaml-cpp.googlecode.com/files/${yamlCppVer}.tar.gz"
+  (New-Object net.webclient).DownloadFile("https://yaml-cpp.googlecode.com/files/${yamlCppVer}.tar.gz", "$toolsDir\${yamlCppVer}.tar.gz")
+  & 7za x "${yamlCppVer}.tar.gz"
+  & 7za x "${yamlCppVer}.tar" | FIND /V "ing "
+  cd $yamlCppVer
+  mkdir build
+  cd build
+
+  $args = @(
+    '-G',
+    "MinGW Makefiles",
+    "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
+    "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\$yamlPkg`"",
+    ".."
+  )
+  cmake $args
+  mingw32-make install -j $cores
+  cd $toolsDir
+
+  Write-Host "Downloading http://curl.haxx.se/download/${curlVer}.zip"
+  (New-Object net.webclient).DownloadFile("http://curl.haxx.se/download/${curlVer}.zip", "$toolsDir\${curlVer}.zip")
+  & 7za x "${curlVer}.zip" | FIND /V "ing "
+  cd $curlVer
+
+  mingw32-make mingw32
+  mkdir -Path $toolsDir\$curlPkg\include
+  cp -r include\curl $toolsDir\$curlPkg\include
+  mkdir -Path $toolsDir\$curlPkg\lib
+  cp lib\libcurl.a $toolsDir\$curlPkg\lib
+  cd $toolsDir
+} else {
+  ## Download and unpack Boost from a pre-built package in S3
+  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${boostPkg}.7z"
+  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${boostPkg}.7z", "$toolsDir\${boostPkg}.7z")
+  & 7za x "${boostPkg}.7z" | FIND /V "ing "
+
+  ## Download and unpack yaml-cpp from a pre-built package in S3
+  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${yamlPkg}.7z"
+  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${yamlPkg}.7z", "$toolsDir\${yamlPkg}.7z")
+  & 7za x "${yamlPkg}.7z" | FIND /V "ing "
+
+  ## Download and unpack curl from a pre-built package in S3
+  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${curlPkg}.7z"
+  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${curlPkg}.7z", "$toolsDir\${curlPkg}.7z")
+  & 7za x "${curlPkg}.7z" | FIND /V "ing "
+}
+cd $toolsDir
+
+# Download openssl
+Write-Host "Downloading http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma"
+(New-Object net.webclient).DownloadFile("http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma", "$toolsDir\${opensslPkg}.tar.lzma")
+& 7za x "$toolsDir\${opensslPkg}.tar.lzma"
+mkdir $toolsDir\${opensslPkg}
+cd $toolsDir\${opensslPkg}
+& 7za x "$toolsDir\${opensslPkg}.tar"
+
+cd $toolsDir


### PR DESCRIPTION
Initial push of pxp-agent code to branch for testing
This compiles the pxp-agent code and prepares a pcp.zip archive for
inclusion in the .msi.

Some additional changes are needed in puppet_for_the_win to use this
additional zip archive.

Note - all the powershell scripts are moved to the puppet-agent/bin directory - may not be the best choice of directory, but it does model the Vanagon approach where all the build scripts reside in puppet-agent.
Therefore, the facter.ps1 script is no longer needed in the facter repo.

However, until AppVeyor setup is resolved, this script should remain there.
We also need to setup AppVeyor for pxp-agent and cpp-pcp-client (suggest we do this as separate JIRA task).
