### PR TITLE
(RE-5621) Bump pinned vanagon version to 0.3.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.15')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.16')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
Prior to this commit, puppet-agent builds for
Ubuntu 15.04 and Debian 8 fail due to an issue
in vanagon 0.3.15.

This commit bumps the pinned vanagon version to
0.3.16, which has fixed the issue.
