### PR TITLE
(maint) Add net-netconf and dependent gems for HuaweiOS

### DIFF
--- a/configs/components/rubygem-mini_portile.rb
+++ b/configs/components/rubygem-mini_portile.rb
@@ -1,0 +1,15 @@
+component "rubygem-mini_portile" do |pkg, settings, platform|
+  pkg.version "0.6.2"
+  pkg.md5sum "281cc0d974d3810d1195ad4a863ba5b6"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/mini_portile-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} mini_portile-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -1,0 +1,16 @@
+component "rubygem-net-netconf" do |pkg, settings, platform|
+  pkg.version "0.4.3"
+  pkg.md5sum "fa173b0965766a427d8692f6b31c85a4"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/net-netconf-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-nokogiri"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} net-netconf-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -1,0 +1,16 @@
+component "rubygem-net-scp" do |pkg, settings, platform|
+  pkg.version "1.2.1"
+  pkg.md5sum "abeec1cab9696e02069e74bd3eac8a1b"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/net-scp-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-net-ssh"
+
+  # Because we are cross-compiling, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} net-scp-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,0 +1,16 @@
+component "rubygem-nokogiri" do |pkg, settings, platform|
+  pkg.version "1.6.6.2"
+  pkg.md5sum "fc9f91534bf93d57b84f625b55732a7c"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-mini_portile"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} nokogiri-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -84,6 +84,14 @@ project "puppet-agent" do |proj|
   proj.component "ruby-augeas"
   proj.component "openssl"
 
+  # HuaweiOS needs these gems included since it can't build native extensions
+  if platform.is_huaweios?
+    proj.component "rubygem-net-netconf"
+    proj.component "rubygem-net-scp"
+    proj.component "rubygem-nokogiri"
+    proj.component "rubygem-mini_portile"
+  end
+
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"


### PR DESCRIPTION
Huawei module development is dependent upon the net-netconf gem,
which requires nokogiri. nokigiri requires native extensions to
be built, so we're embeddeding these gems into the agent itself.
