### PR TITLE
(RE-5643) Fix shellpath for sh compatible users

### DIFF
--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -1,5 +1,5 @@
-# Place /opt/puppetlabs/bin in $PATH if it's not already there.
+# Add /opt/puppetlabs/bin to the path for sh compatible users
 
-if ! $(echo $PATH | grep /opt/puppetlabs/bin) ; then
-    export PATH=$PATH:/opt/puppetlabs/bin
+if ! echo $PATH | grep -q /opt/puppetlabs/bin ; then
+  export PATH=$PATH:/opt/puppetlabs/bin
 fi


### PR DESCRIPTION
Previously the attempt to ensure $PATH had /opt/puppetlabs/bin in it was
bailing out since it was execing the items returned from the grep. This
fixes the grep statement.
