### PR TITLE
(RE-5643) Update md5 for puppet-agent.sh

### DIFF
--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -1,6 +1,6 @@
 component "shellpath" do |pkg, settings, platform|
   pkg.version "2015-09-18"
-  pkg.add_source "file://resources/files/puppet-agent.sh", sum: "490e3e4424318edab303e97eaba76f48"
+  pkg.add_source "file://resources/files/puppet-agent.sh", sum: "f5987a68adf3844ca15ba53813ad6f63"
   pkg.add_source "file://resources/files/puppet-agent.csh", sum: "62b360a7d15b486377ef6c7c6d05e881"
   pkg.install_configfile("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh")
   pkg.install_configfile("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")


### PR DESCRIPTION
In a previous commit, we updated the puppet-agent.sh.
Here we update the md5sum to match the updated file.
