### PR TITLE
(RE-5667) update plugindir path for puppet-agent mcollective

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -48,10 +48,12 @@ component "marionette-collective" do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{settings[:host_ruby]} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{File.join(settings[:sysconfdir], 'mcollective')} --sitelibdir=#{settings[:ruby_vendordir]} --quick --sbindir=#{settings[:bindir]}"]
+    ["#{settings[:host_ruby]} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{File.join(settings[:sysconfdir], 'mcollective')} --sitelibdir=#{settings[:ruby_vendordir]} --quick --sbindir=#{settings[:bindir]} --plugindir=#{File.join('/opt/puppetlabs', 'mcollective', 'plugins')}"]
   end
 
   pkg.directory File.join(settings[:sysconfdir], "mcollective")
+  pkg.directory File.join('/opt/puppetlabs', 'mcollective')
+  pkg.directory File.join('/opt/puppetlabs', 'mcollective', 'plugins')
 
   # Bring in the client.cfg and server.cfg from ext/aio.
   pkg.install_file "ext/aio/common/client.cfg.dist", File.join(settings[:sysconfdir], 'mcollective', 'client.cfg')


### PR DESCRIPTION
The build/install for the mco component currently uses the default
plugindir path ( /usr/libexec/mcollective ).  This commit moves the path
within the puppet-agent project and now matches what's distributed in
mco sample configs. It also addresses a build issue on El Capitan now
that /usr is protected :

```
/opt/puppetlabs/puppet/lib/ruby/2.1.0/fileutils.rb:250:in `mkdir': Operation not permitted @ dir_s_mkdir - /usr/libexec/mcollective (Errno::EPERM)
```
