### PR TITLE
(RE-5639) Add NSSM component to Windows builds

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -34,6 +34,7 @@ CPPPCPCLIENT = JSON.parse(File.read('configs/components/cpp-pcp-client.json'))
 PXPAGENT     = JSON.parse(File.read('configs/components/pxp-agent.json'))
 HIERA        = JSON.parse(File.read('configs/components/hiera.json'))
 MCO          = JSON.parse(File.read('configs/components/marionette-collective.json'))
+NSSM         = JSON.parse(File.read('configs/components/nssm.json'))
 WINDOWS      = JSON.parse(File.read('configs/components/windows_puppet.json'))
 WINDOWS_RUBY = JSON.parse(File.read('configs/components/windows_ruby.json'))
 
@@ -161,6 +162,10 @@ CONFIG = {
     'sys' => {
       :ref  => WINDOWS_RUBY['ref'][ARCH],
       :repo => WINDOWS_RUBY['url']
+    },
+    'nssm' => {
+      :archive => NSSM['archive'],
+      :path    => NSSM['path']
     },
   }
 }

--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,0 +1,4 @@
+{
+  "archive": "nssm-2.24.zip",
+  "path": "http://buildsources.delivery.puppetlabs.net/windows/nssm/"
+}


### PR DESCRIPTION
(RE-5639) Add NSSM as a component to puppet-agent

First PR for this change.
Note - this also rolls up the changes for the RE-5313, so it will probably make more sense when RE-5313 is pushed up.
