### PR TITLE
(RE-5684) Check for equality instead of assigning

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -70,7 +70,7 @@ project "puppet-agent" do |proj|
   proj.component "facter"
   proj.component "hiera"
   proj.component "marionette-collective"
-  unless (platform.is_solaris? &&  platform.architecture != 'i386' && platform.os_version = "11" ) || platform.is_aix?
+  unless (platform.is_solaris? &&  platform.architecture != 'i386' && platform.os_version == "11" ) || platform.is_aix?
     proj.component "cpp-pcp-client"
     proj.component "pxp-agent"
   end


### PR DESCRIPTION
A conditional in the puppet-agent project config contained an errant
assignment instead of equality check, which confuses solaris 10 sparc
builds by assigning the os_version to be 11. This causes an odd mismatch
of behaviors. This commit updates it to use the correct equality test.
