### PR TITLE
(RE-5755) Explicitly set user/group in puppet-ca-bundle

### DIFF
--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -3,6 +3,6 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.build_requires "openssl"
 
   pkg.install do
-    "#{platform[:make]} install OPENSSL=#{settings[:bindir]}/openssl USER=0 GROUP=0"
+    "#{platform[:make]} install OPENSSL=#{settings[:bindir]}/openssl USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
   end
 end


### PR DESCRIPTION
Did you know that if you force push to the [left side of a closed PR](https://github.com/puppetlabs/puppet-agent/pull/334), you can't reopen it?
Today I learned something.

---

Setting these two values explicitly works around a shortcoming in
the Solaris 10 implementation of `id`. This will probably be
removed later on, if/when we're able to get /usr/xpg4/bin/id
installed on builder images. Alternatively, it'll be cleaned up
to be a little less totally hardcoded.
