### PR TITLE
(RE-5260) Remove supplemental file for solaris smf in pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -58,7 +58,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "launchd"
     pkg.install_service "ext/osx/pxp-agent.plist", nil, "com.puppetlabs.pxp-agent"
   when "smf"
-    pkg.install_service "ext/solaris/smf/pxp-agent.xml", "ext/solaris/smf/pxp-agent"
+    pkg.install_service "ext/solaris/smf/pxp-agent.xml"
   when "aix"
     pkg.install_service "resources/aix/pxp-agent.service", nil, "pxp-agent"
   else


### PR DESCRIPTION
When the smf service was added for pxp-agent, a supplemental service
file was indicated, but no such file exists in the pxp-agent source, so
this commit removes it from the install service for the smf service in
pxp-agent.
