### PR TITLE
(RE-5737) Set RPATH for OSX PXP/PCP components

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -13,6 +13,8 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
+    cmake_extra_args = "-DCMAKE_MACOSX_RPATH=ON \
+        -DCMAKE_INSTALL_RPATH=#{settings[:prefix]}/lib"
   elsif platform.is_solaris?
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
@@ -31,6 +33,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DBOOST_STATIC=ON \
+          #{cmake_extra_args} \
           ."
     ]
   end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -14,6 +14,8 @@ component "pxp-agent" do |pkg, settings, platform|
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
+    cmake_extra_args = "-DCMAKE_MACOSX_RPATH=ON \
+        -DCMAKE_INSTALL_RPATH=#{settings[:prefix]}/lib"
   elsif platform.is_solaris?
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
@@ -32,6 +34,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DBOOST_STATIC=ON \
+          #{cmake_extra_args} \
           ."
     ]
   end


### PR DESCRIPTION
Prior to this commit, execution of pxp-agent
on OS X fails with "dyld: Library not loaded:
libcpp-pcp-client.so".

This commit updates the pxp-agent and cpp-
pcp-client components to specify the RPATH
for OSX.
