### PR TITLE
(RE-5759) Switch puppet-agent projects to using win32 threads

### DIFF
--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -23,7 +23,7 @@ $toolsDir="${sourceDir}\deps"
 
 $mingwVerNum = "4.8.3"
 $mingwVerChoco = $mingwVerNum
-$mingwThreads = "posix"
+$mingwThreads = "win32"
 if ($arch -eq 64) {
   $mingwExceptions = "seh"
   $mingwArch = "x86_64"

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -40,15 +40,15 @@ Install-Choco git.install 1.9.5.20150320
 Install-Choco Wix35 $Wix35_VERSION
 
 # For MinGW, we expect specific project defaults
-# - posix threads, given no more Windows Server 2003 support (which required win32)
+# - win32 threads - reverting back from posix threads
 # - seh exceptions on 64-bit, to work around an obscure bug loading Ruby in Facter
 # These are the defaults on our myget feed.
 if ($arch -eq 64) {
   Install-Choco ruby 2.1.6
-  Install-Choco mingw-w64-posix $mingwVerChoco
+  Install-Choco mingw-w64 $mingwVerChoco
 } else {
   Install-Choco ruby 2.1.6 @('-x86')
-  Install-Choco mingw-w32-posix $mingwVerChoco @('-x86')
+  Install-Choco mingw-w32 $mingwVerChoco @('-x86')
 }
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 if ($arch -eq 32) {


### PR DESCRIPTION
This reverts the following commit:
(RE-5313) Build Windows with mingw posix threads (6d04f5cfac292caa4b7c8d49785029aab9d4d284)

Dev team have made changes to use boost::thread instead of std::thread which means we can switch back to win32 builds from posix.
