### PR TITLE
(PCP-69) Don't daemonize pxp-agent service on AIX

### DIFF
--- a/resources/aix/pxp-agent.service
+++ b/resources/aix/pxp-agent.service
@@ -1,1 +1,1 @@
-/opt/puppetlabs/puppet/bin/pxp-agent -s pxp-agent -u root
+'/opt/puppetlabs/puppet/bin/pxp-agent --foreground' -s pxp-agent -u root


### PR DESCRIPTION
By default, pxp-agent now daemonizes if unconfigured, and runs as
a foreground process if invoked with --foreground.

This commit adds the --foreground argument to the pxp-agent service
config for AIX, where daemonization is not needed.
