### PR TITLE
(PCP-85) Install modules to /opt/puppetlabs/pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -30,6 +30,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
+          -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           -DBOOST_STATIC=ON \
           ."
     ]

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,6 +1,7 @@
 project "puppet-agent" do |proj|
   # Project level settings our components will care about
-  proj.setting(:prefix, "/opt/puppetlabs/puppet")
+  proj.setting(:install_root, "/opt/puppetlabs")
+  proj.setting(:prefix, File.join(proj.install_root, "puppet"))
   proj.setting(:sysconfdir, "/etc/puppetlabs")
   proj.setting(:puppet_configdir, File.join(proj.sysconfdir, 'puppet'))
   proj.setting(:puppet_codedir, "/etc/puppetlabs/code")
@@ -115,7 +116,7 @@ project "puppet-agent" do |proj|
     proj.component "ruby-selinux"
   end
 
-  proj.directory "/opt/puppetlabs"
+  proj.directory proj.install_root
   proj.directory proj.prefix
   proj.directory proj.sysconfdir
   proj.directory proj.logdir


### PR DESCRIPTION
Without this change core modules are installed to
/opt/puppetlabs/puppet/pxp-agent/modules, which contradicts
https://github.com/puppetlabs/puppet-specifications/blob/master/file_paths.md

Configure installing to /opt/puppetlabs/pxp-agent/modules instead.
