### PR TITLE
(RE-5775) Configure curl with puppet-agent's vendored ca-bundle

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -8,7 +8,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.configure do
     ["LDFLAGS='#{settings[:ldflags]}' \
      ./configure --prefix=#{settings[:prefix]} \
-     --with-ssl=#{settings[:prefix]} --enable-threaded-resolver --disable-ldap --disable-ldaps"]
+     --with-ssl=#{settings[:prefix]} --enable-threaded-resolver --disable-ldap --disable-ldaps --with-ca-bundle=#{settings[:prefix]}/ssl/cert.pem"]
   end
 
   pkg.build do


### PR DESCRIPTION
Prior to this commit, puppet-agent's vendored curl used the
system openssl's ca-bundle.

Here we update our vendored curl to use the puppet-agent's
vendored ca-bundle.
