### PR TITLE
(PCP-76) Create /etc/puppetlabs/pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -43,6 +43,9 @@ component "pxp-agent" do |pkg, settings, platform|
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
+  pkg.directory File.join(settings[:sysconfdir], 'pxp-agent')
+  pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
+
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/systemd/pxp-agent.service", "ext/redhat/pxp-agent.sysconfig"


### PR DESCRIPTION
Prior to this commit, pxp-agent's configuration
directories were not created on initial install
of puppet-agent. This commit adds pxp-agent's
configuration directories.
