### PR TITLE
(maint) Fix SCP Windows intermediates

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -126,7 +126,7 @@ archive_dest = "/home/Administrator/archive"
 facter_zipname = "facter"
 pxp_zipname = "pxp-agent"
 # Format everything to prepare to archive it
-Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{facter_zipname}/lib ; cp -r /home/Administrator/facter/release/bin /home/Administrator/facter/lib/inc #{archive_dest}/#{facter_zipname} ; cp /home/Administrator/facter/release/lib/facter.rb #{archive_dest}/#{facter_zipname}/lib \"")
+Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{facter_zipname}/lib ; cp -r /home/Administrator/facter/release/bin #{archive_dest}/#{facter_zipname} ; cp /home/Administrator/facter/release/lib/facter.rb #{archive_dest}/#{facter_zipname}/lib \"")
 fail "Copying source files for packaging failed" unless $?.success?
 # repeat for pxp-agent
 Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{pxp_zipname}/modules ; cp -r /home/Administrator/cpp-pcp-client/release/bin #{archive_dest}/#{pxp_zipname} ; cp -r /home/Administrator/pxp-agent/release/bin #{archive_dest}/#{pxp_zipname}; cp -r /home/Administrator/pxp-agent/modules/pxp-module-puppet #{archive_dest}/#{pxp_zipname}/modules \"")


### PR DESCRIPTION
- The path to the intermediate Facter and pxp-agent
  builds are not in the 'archive' path.
