### PR TITLE
(maint) Use an alternate rubygems source if specified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def vanagon_location_for(place)
   if place =~ /^(git[:@][^#]*)#(.*)/


### PR DESCRIPTION
Now that vanagon is a gem, we should be using our internal mirror when
desired for builds. This commit borrows the environment variable that
puppet uses in its Gemfile to achieve this.
