### PR TITLE
(PCP-92) Add logrotate config to puppet-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -47,6 +47,10 @@ component "pxp-agent" do |pkg, settings, platform|
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent')
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
 
+  if platform.is_linux?
+    pkg.install_configfile "ext/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"
+  end
+
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/systemd/pxp-agent.service", "ext/redhat/pxp-agent.sysconfig"


### PR DESCRIPTION
This commit adds pxp-agent's logrotate config to puppet-agent.
