### PR TITLE
(PCP-101) add missing pxp-agent default paths

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -46,6 +46,8 @@ component "pxp-agent" do |pkg, settings, platform|
 
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent')
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
+  pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool')
+  pkg.directory File.join(settings[:logdir], 'pxp-agent')
 
   if platform.is_linux?
     pkg.install_configfile "ext/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"


### PR DESCRIPTION
Here we add more empty directories for pxp-agent, a spooldir where job output
will go, and a logdir where logfiles will live.
