### PR TITLE
(PCP-96) Windows pxp-agent reqs module batch files

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -129,7 +129,7 @@ pxp_zipname = "pxp-agent"
 Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{facter_zipname}/lib ; cp -r /home/Administrator/facter/release/bin #{archive_dest}/#{facter_zipname} ; cp /home/Administrator/facter/release/lib/facter.rb #{archive_dest}/#{facter_zipname}/lib \"")
 fail "Copying source files for packaging failed" unless $?.success?
 # repeat for pxp-agent
-Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{pxp_zipname}/modules ; cp -r /home/Administrator/cpp-pcp-client/release/bin #{archive_dest}/#{pxp_zipname} ; cp -r /home/Administrator/pxp-agent/release/bin #{archive_dest}/#{pxp_zipname}; cp -r /home/Administrator/pxp-agent/modules/pxp-module-puppet #{archive_dest}/#{pxp_zipname}/modules \"")
+Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; mkdir -p #{archive_dest}/#{pxp_zipname}/modules ; cp -r /home/Administrator/cpp-pcp-client/release/bin #{archive_dest}/#{pxp_zipname} ; cp -r /home/Administrator/pxp-agent/release/bin #{archive_dest}/#{pxp_zipname}; cp -r /home/Administrator/pxp-agent/modules/pxp-module-puppet* #{archive_dest}/#{pxp_zipname}/modules \"")
 fail "Copying source files for packaging failed" unless $?.success?
 
 # Zip up the built archives


### PR DESCRIPTION
- Prior to the changes as part of PCP-96, we were only copying the
  file `pxp-module-puppet` to the zip file used as part of building the
  MSI package.  However, PCP-96 removed some configuration settings
  such as `interpreter` and `puppet_bin` that were specific to the
  module, but now requires that batch files be introduced to properly
  ensure that the Ruby interpreter launches the module.
  
  This change now ensures that `pxp-module-puppet.bat` is included with
  the zip file in addition to `pxp-module-puppet`
  
  Paired-with: Rob Reynolds rob@puppetlabs.com
