### PR TITLE
(RE-4287) Enable pxp-agent in AIO builds for AIX and Solaris 11 SPARC

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -71,10 +71,8 @@ project "puppet-agent" do |proj|
   proj.component "facter"
   proj.component "hiera"
   proj.component "marionette-collective"
-  unless (platform.is_solaris? && platform.architecture != 'i386' && platform.os_version == "11")
-    proj.component "cpp-pcp-client"
-    proj.component "pxp-agent"
-  end
+  proj.component "cpp-pcp-client"
+  proj.component "pxp-agent"
 
   # Then the dependencies
   proj.component "augeas"


### PR DESCRIPTION
Prior to this, pxp-agent components were excluded from AIX 
and Solaris 11 SPARC puppet-agent builds. 

This enables pxp-agent component builds for AIX and 
Solaris 11 SPARC.
