### PR TITLE
DONT MERGE ME (RE-5610) Enable bigtoc for cpp-pcp-client

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -10,6 +10,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.environment "CMAKE_SHARED_LINKER_FLAGS" => "#{settings[:ldflags]} -bbigtoc"
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""


### PR DESCRIPTION
We are getting intermittent failures from building cpp-pcp-client due to
TOC overflows on AIX. This LDFLAG bigtoc allows for a larger TOC at a
cost of a small bit of performance.
