### PR TITLE
(PCP-6) Add systemd-specfic logrotate config for pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -49,13 +49,10 @@ component "pxp-agent" do |pkg, settings, platform|
   pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool')
   pkg.directory File.join(settings[:logdir], 'pxp-agent')
 
-  if platform.is_linux?
-    pkg.install_configfile "ext/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"
-  end
-
   case platform.servicetype
   when "systemd"
     pkg.install_service "ext/systemd/pxp-agent.service", "ext/redhat/pxp-agent.sysconfig"
+    pkg.install_configfile "ext/systemd/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"
   when "sysv"
     if platform.is_deb?
       pkg.install_service "ext/debian/pxp-agent.init", "ext/debian/pxp-agent.default"
@@ -64,6 +61,7 @@ component "pxp-agent" do |pkg, settings, platform|
     elsif platform.is_rpm?
       pkg.install_service "ext/redhat/pxp-agent.init", "ext/redhat/pxp-agent.sysconfig"
     end
+    pkg.install_configfile "ext/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"
   when "launchd"
     pkg.install_service "ext/osx/pxp-agent.plist", nil, "com.puppetlabs.pxp-agent"
   when "smf"


### PR DESCRIPTION
This commit adds a systemd-specfic logrotate config for
for pxp-agent.
