### PR TITLE
(PA-25) Register puppet, facter and hiera as gems

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -176,6 +176,8 @@ component "facter" do |pkg, settings, platform|
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+
   pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter"
   pkg.directory File.join('/opt/puppetlabs', 'facter')
   pkg.directory File.join('/opt/puppetlabs', 'facter', 'facts.d')

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -13,6 +13,8 @@ component "hiera" do |pkg, settings, platform|
     "#{settings[:host_ruby]} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+
   pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -93,6 +93,9 @@ component "puppet" do |pkg, settings, platform|
     ]
   end
 
+
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+
   pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
   pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
 


### PR DESCRIPTION
Previously if you wanted to install gems that depended on puppet, facter or
hiera, you had to force them since the gem system included with the AIO
didn't see puppet/hiera/facter as installed. This commit fixes that that
installing the gemspecs for these projects.

Note: mcollective has never had a gemspec, so it is not registered.

[root@rm7rmn9e1onkqck ~]# ls -l /opt/puppetlabs/puppet/lib/ruby/
2.1.0/       gems/        site_ruby/   vendor_ruby/
[root@rm7rmn9e1onkqck ~]# ls -l /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/specifications/{pup,fact,hi}*.gemspec
-rw-r--r--. 1 root root  603 Oct 23 17:19 /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/specifications/facter.gemspec
-rw-r--r--. 1 root root 1389 Oct 23 17:12 /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/specifications/hiera.gemspec
-rw-r--r--. 1 root root 2037 Oct 23 17:12 /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/specifications/puppet.gemspec
[root@rm7rmn9e1onkqck ~]# /opt/puppetlabs/puppet/bin/gem list

**\* LOCAL GEMS ***

bigdecimal (1.2.4)
deep_merge (1.0.1)
facter (3.1.1)
hiera (3.0.4)
hocon (0.9.3)
io-console (0.4.3)
json (1.8.1)
minitest (4.7.5)
net-ssh (2.9.2)
psych (2.0.5)
puppet (4.2.3)
rake (10.1.0)
rdoc (4.1.0)
stomp (1.3.3)
test-unit (2.1.7.0)
