### PR TITLE
(maint) Pin Windows Ruby + PFTW packaging repos on stable

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/stable"
+  "ref": "origin/4.2.2"
 }

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "origin/2.1.x-x86",
-    "x64": "origin/2.1.x-x64"
+    "x86": "origin/2.1.7.0-x86",
+    "x64": "origin/2.1.7.0-x64"
   }
 }


### PR DESCRIPTION
- Previously we relied on tracking the HEAD of the stable branch of
  puppet_for_the_win for packaging, and similarly tracked the HEAD of
  the 2.1.x(86|64) repos for vendored Ruby on Windows.
  
  This is problematic, because it could mean that a package
  produced by the puppet-agent pipeline carries a puppet-agent SHA
  believed to be unique, but with respect to Windows, only
  represents a point in time.  The same puppet-agent SHA could be
  rebuilt and produce a different package based on the state of the
  branches for vendored Ruby and Windows packaging.
  
  Let's correct that, since it's a VERY BAD THING (tm)
