### PR TITLE
Revert "(PA-25) Register puppet, facter and hiera as gems"

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -176,8 +176,6 @@ component "facter" do |pkg, settings, platform|
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
-
   pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter"
   pkg.directory File.join('/opt/puppetlabs', 'facter')
   pkg.directory File.join('/opt/puppetlabs', 'facter', 'facts.d')

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -13,8 +13,6 @@ component "hiera" do |pkg, settings, platform|
     "#{settings[:host_ruby]} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
   end
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
-
   pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -93,9 +93,6 @@ component "puppet" do |pkg, settings, platform|
     ]
   end
 
-
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
-
   pkg.configfile File.join(settings[:puppet_configdir], 'puppet.conf')
   pkg.configfile File.join(settings[:puppet_configdir], 'auth.conf')
 


### PR DESCRIPTION
The facter gemspec work has not landed in facter master yet, so this is breaking builds.

Reverts puppetlabs/puppet-agent#378
