### PR TITLE
(maint) Windows builds track versions.txt

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -196,6 +196,7 @@ fail "It seems there were some issues building the puppet-agent msi" unless resu
 # Fetch back the built installer
 msi_file = "puppet-agent-#{AGENT_VERSION_STRING}-#{ARCH}.msi"
 Kernel.system("set -vx;scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/pkg/#{msi_file} output/windows/")
+Kernel.system("set -vx;scp #{ssh_key} Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/stagedir/misc/versions.txt output/windows/versions-#{ARCH}.txt")
 
 # delete a vm only if we successfully brought back the msi
 msi_path = "output/windows/#{msi_file}"


### PR DESCRIPTION
- It can be particularly useful to know the contents of an MSI prior
  to downloading / installing the MSI.
  
  This is especially useful here since puppet_for_the_win tracks
  the HEAD of a branch, and therefore the puppet-agent SHA might
  not uniquely identify the contents of an MSI based on what's
  in the packaging repository at a moment in time.
