### PR TITLE
(maint) Update rubocop config excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
     - 'configs/**/*.rb'
   Exclude:
     - 'resources/**/*.rb'
+    - 'ext/**/*'
+    - 'vendor/**/*'
+    - 'bundle/**/*'
 
 
 # MAYBE useful - errors when rescue {} happens.


### PR DESCRIPTION
This commit extends the excludes to add ext which contains ruby files in
local checkouts, and common locations of bundled gems.
