### PR TITLE
(PA-2) Install dmidecode to bin instead of sbin

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -10,6 +10,7 @@ component 'dmidecode' do |pkg, settings, platform|
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.181.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.182.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
+  pkg.apply_patch "resources/patches/dmidecode/dmidecode-install-to-bin.patch"
 
   pkg.build do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]

--- a/resources/patches/dmidecode/dmidecode-install-to-bin.patch
+++ b/resources/patches/dmidecode/dmidecode-install-to-bin.patch
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 55378bb..b43b218 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,7 +27,7 @@ LDFLAGS =
+ 
+ DESTDIR =
+ prefix  = /usr/local
+-sbindir = $(prefix)/sbin
++bindir  = $(prefix)/bin
+ mandir  = $(prefix)/share/man
+ man8dir = $(mandir)/man8
+ docdir  = $(prefix)/share/doc/dmidecode
+@@ -110,13 +110,13 @@ install : install-bin install-man install-doc
+ uninstall : uninstall-bin uninstall-man uninstall-doc
+ 
+ install-bin : $(PROGRAMS)
+-	$(INSTALL_DIR) $(DESTDIR)$(sbindir)
++	$(INSTALL_DIR) $(DESTDIR)$(bindir)
+ 	for program in $(PROGRAMS) ; do \
+-	$(INSTALL_PROGRAM) $$program $(DESTDIR)$(sbindir) ; done
++	$(INSTALL_PROGRAM) $$program $(DESTDIR)$(bindir) ; done
+ 
+ uninstall-bin :
+ 	for program in $(PROGRAMS) ; do \
+-	$(RM) $(DESTDIR)$(sbindir)/$$program ; done
++	$(RM) $(DESTDIR)$(bindir)/$$program ; done
+ 
+ install-man :
+ 	$(INSTALL_DIR) $(DESTDIR)$(man8dir)


### PR DESCRIPTION
For the puppet-agent private prefix, we want to just have a single
bindir that other puppet-agent binaries can be aware of.
