### PR TITLE
(PE-12686) Remove dependency on tar rpm for AIX

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -83,6 +83,10 @@ component "puppet" do |pkg, settings, platform|
     if platform.os_version == "11"
       pkg.requires 'archiver/gnu-tar'
     end
+  elsif platform.is_aix?
+    # PMT doesn't work on AIX, don't add a useless dependency
+    # We will need to revisit when we update PMT support
+    next
   else
     pkg.requires 'tar'
   end


### PR DESCRIPTION
Currently the puppet-agent package depends on having a 'tar'
RPM installed. The tar command is used by PMT, however PNT doesn't
currently work on AIX due to the lack of CA certs. It has not really been
tested, and probably needs some updates to work with AIX.

This removes the useless dependency on the tar RPM package. We
may want to revisit when we update PMT support.
