### PR TITLE
(RE-5788) Choco install fails should kill builds

### DIFF
--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -23,10 +23,10 @@ Write-Host "arch=$arch, cores=$cores, buildsource=$buildsource"
 Function Install-Choco ($pkg, $ver, $opts = "") {
     Write-Host "Installing $pkg $ver from https://www.myget.org/F/puppetlabs"
     try {
-        choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts
+        Invoke-External { choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts }
     } catch {
         Write-Host "Error: $_, trying again."
-        choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts
+        Invoke-External { choco install -y $pkg -version $ver -source https://www.myget.org/F/puppetlabs -debug $opts }
     }
 }
 


### PR DESCRIPTION
- Previous retry method was not correct, as a non-zero exit code does
  not throw.  So verify the exit code and throw if Chocolatey fails
  to install, so that a retry can be attempted.
  
  The catch allows us to retry an install once, and fail hard if the
  second attempt to install a package dies.
  
  Unfortunately, the original attempts to capture all non-zero exit
  codes missed this call to Chocolatey in ea3f563
