### PR TITLE
(PE-12686) Fix bug in aix package dependency

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -83,12 +83,10 @@ component "puppet" do |pkg, settings, platform|
     if platform.os_version == "11"
       pkg.requires 'archiver/gnu-tar'
     end
-  elsif platform.is_aix?
+  else
     # PMT doesn't work on AIX, don't add a useless dependency
     # We will need to revisit when we update PMT support
-    next
-  else
-    pkg.requires 'tar'
+    pkg.requires 'tar' unless platform.is_aix?
   end
 
   pkg.install do


### PR DESCRIPTION
In a previous commit, we introduced logic to conditionally
apply a package dependency on platforms other than aix.

This fixes a bug in that logic that is causing the entire
package component to be skipped on aix
