### PR TITLE
(PA-25) Export RUBYLIB for pure ruby gem installs

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -11,6 +11,12 @@ component "ruby-stomp" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
   pkg.install do
     ["#{settings[:gem_install]} stomp-1.3.3.gem"]
   end

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -11,6 +11,12 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
   pkg.install do
     ["#{settings[:gem_install]} deep_merge-#{pkg.get_version}.gem"]
   end

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -9,6 +9,12 @@ component "rubygem-hocon" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
   pkg.install do
     ["#{settings[:gem_install]} hocon-#{pkg.get_version}.gem"]
   end

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -11,6 +11,12 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
   pkg.install do
     ["#{settings[:gem_install]} net-ssh-#{pkg.get_version}.gem"]
   end


### PR DESCRIPTION
Previously, pure ruby gem installs would explode on the cross compiled
ruby because puppet and hiera weren't in the load path, which triggered
a neverending attempt to find them in the gem and ruby load paths,
eventually overflowing the stack.
This commit addresses that problem by explicitly setting RUBYLIB to
include our vendor_ruby directory, which has puppet and hiera. This
allows hiera/version and puppet/version to be safely required and avoids
the aforementioned stack overflow. This will work as long as our version
libraries don't attempt to load any native code, such as facter.
