### PR TITLE
(PA-42) Move to git.install 2.6.2

### DIFF
--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -37,7 +37,7 @@ if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
 Install-Choco 7zip.commandline 9.20.0.20150210
 
 Install-Choco cmake 3.2.2
-Install-Choco git.install 1.9.5.20150320
+Install-Choco git.install 2.6.2.20151028
 Install-Choco Wix35 $Wix35_VERSION
 
 # For MinGW, we expect specific project defaults


### PR DESCRIPTION
Version 2.6.2 provides a 64-bit version of git, and the install script
uses more reliable methods of updating PATH. Use it in builds.
