### PR TITLE
(RE-5921) Update git.install to  2.6.2.20151028

### DIFF
--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -37,7 +37,7 @@ if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
 Install-Choco 7zip.commandline 9.20.0.20150210
 
 Install-Choco cmake 3.2.2
-Install-Choco git.install 1.9.5.20150320
+Install-Choco git.install 2.6.2.20151028
 Install-Choco Wix35 $Wix35_VERSION
 
 # For MinGW, we expect specific project defaults


### PR DESCRIPTION
This corrects a hard build error due to the git.install 1.9.5.20150320
failing - causing the puppet-agent build to fail.

_URGENT_ fix

Supersedes #393 
