### PR TITLE
(RE-5921) Fix Git PATH

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -70,7 +70,7 @@ end
 
 # Set up the environment so I don't keep crying
 ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no Administrator@#{hostname}"
-ssh_env = "export PATH=\'/cygdrive/c/Program Files (x86)/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
+ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
 
 result = Kernel.system("set -vx;#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")
 fail "Unable to connect to the host. Is is possible that you aren't on VPN or connected to the internal PL network?" unless result

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -50,7 +50,7 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 if ($arch -eq 32) {
   $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
 }
-$env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\Git\cmd"
+$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
 Write-Host "Updated Path to $env:PATH"
 
 # SSL root pointer.

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -55,7 +55,7 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 if ($arch -eq 32) {
   $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
 }
-$env:PATH += [Environment]::GetFolderPath('ProgramFilesX86') + "\Git\cmd"
+$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
 Write-Host "Updated Path to $env:PATH"
 
 cd $toolsDir


### PR DESCRIPTION
Git used to be located in "Program Files (x86)" as it was a 32-bit
executable. The bump to Git 2.6.2.20151028 changed to a 64-bit
executable that installs to "Program Files". Correct PATH for the new
location.
