### PR TITLE
(PUP-5064) Pin specific Windows packaging version

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/master"
+  "ref": "origin/b515d41c89ade27d8b68d02ccbf24cf7ebed5a71"
 }


### PR DESCRIPTION
 - Previously the Windows packaging was tracking the master branch.
   However, use a specific version here.