### PR TITLE
(RE-5610) Use -bbigtoc to build cpp-pcp-client

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -4,12 +4,15 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
   pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
 
+  platform_flags = ''
   pkg.build_requires "openssl"
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
+    # This should be moved to the toolchain file
+    platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
@@ -26,6 +29,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     [
       "#{cmake} \
       #{toolchain} \
+      #{platform_flags} \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \


### PR DESCRIPTION
libcpp-pcp-client links a lot of symbols, creating a TOC too large for
the default 64KB on AIX. Using static linking was tried as a solution,
but causes issues with our EL4 toolchain. This is the expedient
solution.
