### PR TITLE
[DO NOT MERGE](PA-23) Block Windows Server 2003 on 1.3.0

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "refs/tags/4.2.2"
+  "ref": "refs/tags/4.3.0"
 }


### PR DESCRIPTION
Move puppet_for_the_win to the release tag that will ensure
that the 1.3.0 release (Puppet 4.3.0) will block Windows Server
2003 from installing Puppet.

This is blocked on 
- [ ] A `4.3.0` tag in the `puppet_for_the_win` repository

Supersedes #344. Code for checking this same thing was merged into master from #398.
