### PR TITLE
(maint) Use pl-tar on el4

### DIFF
--- a/configs/platforms/el-4-i386.rb
+++ b/configs/platforms/el-4-i386.rb
@@ -2,8 +2,9 @@ platform "el-4-i386" do |plat|
   plat.servicedir "/etc/rc.d/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
+  plat.tar "/opt/pl-build-tools/bin/tar"
 
-  plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils;yum update -y pkgconfig"
+  plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils pl-tar; yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
   plat.vcloud_name "centos-4-i386"
 end

--- a/configs/platforms/el-4-x86_64.rb
+++ b/configs/platforms/el-4-x86_64.rb
@@ -2,8 +2,9 @@ platform "el-4-x86_64" do |plat|
   plat.servicedir "/etc/rc.d/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
+  plat.tar "/opt/pl-build-tools/bin/tar"
 
-  plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils;yum update -y pkgconfig"
+  plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils pl-tar; yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
   plat.vcloud_name "centos-4-x86_64"
 end


### PR DESCRIPTION
EL4 has a very old version of tar that doesn't handle hardlinks very
well. When packaging for el4, using a more modern version is desireable.
This commit updates the el4 platform configs to install and use pl-tar,
as was done for our build-tools stack.
