### PR TITLE
(PA-46) Install smf services to the network subsystem

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -69,7 +69,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "launchd"
     pkg.install_service "ext/osx/pxp-agent.plist", nil, "com.puppetlabs.pxp-agent"
   when "smf"
-    pkg.install_service "ext/solaris/smf/pxp-agent.xml"
+    pkg.install_service "ext/solaris/smf/pxp-agent.xml", service_type: "network"
   when "aix"
     pkg.install_service "resources/aix/pxp-agent.service", nil, "pxp-agent"
   else


### PR DESCRIPTION
Previously the smf services in pxp-agent did not specify a subtype
and were installed at top level. This works on solaris 10, but on
solaris 11 services must be installed in a subdirectory. This commit
moves them under network, which is an appropriate place for them.
