### PR TITLE
(PA-63) AIX pxp-agent's '--foreground' should be an argument

### DIFF
--- a/resources/aix/pxp-agent.service
+++ b/resources/aix/pxp-agent.service
@@ -1,1 +1,1 @@
-'/opt/puppetlabs/puppet/bin/pxp-agent --foreground' -s pxp-agent -u root
+'/opt/puppetlabs/puppet/bin/pxp-agent' -a '--foreground' -s pxp-agent -u root


### PR DESCRIPTION
Prior to this commit, the pxp-agent service does not start
successfully on AIX.

This commit adjusts the AIX service config for pxp-agent so that
'--foreground' will be configured as a mkssys "argument", which
allows the service to start successfully.
