### PR TITLE
(PA-67) Execute mcollectived with '--no-daemonize' option in AIX

### DIFF
--- a/resources/aix/mcollective.service
+++ b/resources/aix/mcollective.service
@@ -1,1 +1,1 @@
-/opt/puppetlabs/puppet/bin/ruby -s mcollective -u root -a '/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg'
+/opt/puppetlabs/puppet/bin/ruby -s mcollective -u root -a '/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --no-daemonize'


### PR DESCRIPTION
In AIX, the subsystem manager deals with daemonization of processes.
The Mcollective service command args used by `startsrc` should run
with the --no-daemonize option, as puppet does.
