### PR TITLE
(PA-69) Use puppet-win32-ruby branches for testing

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.7.0-x86",
-    "x64": "refs/tags/2.1.7.0-x64"
+    "x86": "15f21c66bd503bc62769f3ababe8e2b9cd9f6999",
+    "x64": "74627d32deaec9b15b310b78d0f09903ac2ff6e5"
   }
 }


### PR DESCRIPTION
Use HEAD of the puppet-win32-ruby 2.1.x branches to
validate rubygems fixes are working as intended.

After that validation is completed, PA-69 addresses
creating new puppet-win32-ruby tags and updating
puppet-agent to use the tags.
