### PR TITLE
(PA-47) Use puppet_for_the_win 4.3.0 tag

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/master"
+  "ref": "refs/tags/4.3.0"
 }


### PR DESCRIPTION
- This correlates to the Puppet version shipping with puppet-agent
  1.3.0
