### PR TITLE
(PA-54) Use tags for updated components

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "8d2c0797d95ad74a1c9b5ec5a3a92c694df2dd0b"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.1.2"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "196e896cd9fc132a0fe02269ffe8f5de70231412"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.0.5"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "74f5c0041da64f5633b605b7d7b18afcfdc4eabd"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.3.0"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:puppetlabs/pxp-agent.git", "ref": "e4304678ce992318ebfc7fb71bdd3ba4bfaa22f6"}
+{"url": "git@github.com:puppetlabs/pxp-agent.git", "ref": "refs/tags/1.0.0"}


### PR DESCRIPTION
We tagged facter, hiera, pxp-agent, and puppet. Update the component
configs to use those tags instead of SHAs.
