### PR TITLE
(RE-5673) Xcode 6.4 CLT for 10.10 no longer available

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -3,7 +3,7 @@ platform "osx-10.10-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "yosemite"
 
-  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10)-6.4"'
+  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.1"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-1010-x86_64"


### PR DESCRIPTION
During provisioning we update the CLT on OSX.  Apple has removed 6.4
for OSX 10.10 and has made 7.1 available.  This commit updates the
provisioning process to install 7.1.
