### PR TITLE
(PA-97) Fix build errors on OSX

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -10,7 +10,7 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS" => settings[:cflags]
     pkg.environment "LDFLAGS" => settings[:ldflags]
-  else
+  elsif !platform.is_osx?
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
     pkg.environment "LDFLAGS" => settings[:ldflags]

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -14,7 +14,7 @@ component "libxslt" do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
-  else
+  elsif !platform.is_osx?
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
     pkg.environment "LDFLAGS" => settings[:ldflags]


### PR DESCRIPTION
During the addition of libxml and libxslt we missed setting the build
requirements and CFLAGS correctly for OSX. This small patch fixes that
by letting OSX just use its own defaults and not passing in our gcc or
cflags.
