### PR TITLE
(PA-98) Solaris SPARC linking

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -22,7 +22,7 @@ component "libxml2" do |pkg, settings, platform|
   end
 
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --without-python"]
+    ["./configure --prefix=#{settings[:prefix]} --without-python #{settings[:host]}"]
   end
 
   pkg.build do

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -26,7 +26,7 @@ component "libxslt" do |pkg, settings, platform|
   end
 
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]}"]
+    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]} #{settings[:host]}"]
   end
 
   pkg.build do


### PR DESCRIPTION
Passing host in to configure for libxml2 and libxslt should let it know
that it's being cross-compiled. This should fix the issue with wrong ELF
machine type when linking augeas.
