### PR TITLE
(PA-95) Bump ca-cert bundle to 1.0.6 with more complete set of CA certs

### DIFF
--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
   "url": "git@github.com:puppetlabs/puppet-ca-bundle.git",
-  "ref": "1.0.4"
+  "ref": "1.0.6"
 }


### PR DESCRIPTION
This adds a more comprehensive set of CA certificates to puppet-agent's bundle.
