### PR TITLE
Merge stable to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.2.0
+    - rvm: 2.1.7
       env: "CHECK='rubocop -D'"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.3.18')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.4.1')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -38,21 +38,23 @@ component "marionette-collective" do |pkg, settings, platform|
       puppet_bin = "/opt/puppetlabs/bin/puppet"
       rpm_statedir = "%{_localstatedir}/lib/rpm-state/#{pkg.get_name}"
       service_statefile = "#{rpm_statedir}/service.pp"
-      pkg.add_preinstall_action <<-HERE.undent
-        if [ $1 -gt 1 ]; then
+      pkg.add_preinstall_action ["upgrade"],
+        [<<-HERE.undent
           install --owner root --mode 0700 --directory #{rpm_statedir} || :
           if [ -x #{puppet_bin} ] ; then
             #{puppet_bin} resource service mcollective > #{service_statefile} || :
           fi
-        fi
-      HERE
+          HERE
+        ]
 
-      pkg.add_postinstall_action <<-HERE.undent
-        if [ -f #{service_statefile} ] ; then
-          #{puppet_bin} apply #{service_statefile} > /dev/null 2>&1 || :
-          rm -rf #{rpm_statedir} || :
-        fi
-      HERE
+      pkg.add_postinstall_action ["upgrade"],
+        [<<-HERE.undent
+          if [ -f #{service_statefile} ] ; then
+            #{puppet_bin} apply #{service_statefile} > /dev/null 2>&1 || :
+            rm -rf #{rpm_statedir} || :
+          fi
+          HERE
+        ]
     end
 
     pkg.install_file "ext/aio/redhat/mcollective-sysv.logrotate", "/etc/logrotate.d/mcollective"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -69,7 +69,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "launchd"
     pkg.install_service "ext/osx/pxp-agent.plist", nil, "com.puppetlabs.pxp-agent"
   when "smf"
-    pkg.install_service "ext/solaris/smf/pxp-agent.xml"
+    pkg.install_service "ext/solaris/smf/pxp-agent.xml", service_type: "network"
   when "aix"
     pkg.install_service "resources/aix/pxp-agent.service", nil, "pxp-agent"
   else

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.7.0-x86",
-    "x64": "refs/tags/2.1.7.0-x64"
+    "x86": "refs/tags/2.1.7.1-x86",
+    "x64": "refs/tags/2.1.7.1-x64"
   }
 }

--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -3,7 +3,7 @@ platform "osx-10.10-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "yosemite"
 
-  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10)-6.4"'
+  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.1"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vcloud_name "osx-1010-x86_64"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -21,6 +21,7 @@ foss_platforms:
   - fedora-f22-x86_64
   - osx-10.9-x86_64
   - osx-10.10-x86_64
+  - osx-10.11-x86_64
   - ubuntu-12.04-amd64
   - ubuntu-12.04-i386
   - ubuntu-14.04-amd64

--- a/resources/aix/mcollective.service
+++ b/resources/aix/mcollective.service
@@ -1,1 +1,1 @@
-/opt/puppetlabs/puppet/bin/ruby -s mcollective -u root -a '/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg'
+/opt/puppetlabs/puppet/bin/ruby -s mcollective -u root -a '/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --no-daemonize'

--- a/resources/aix/pxp-agent.service
+++ b/resources/aix/pxp-agent.service
@@ -1,1 +1,1 @@
-'/opt/puppetlabs/puppet/bin/pxp-agent --foreground' -s pxp-agent -u root
+'/opt/puppetlabs/puppet/bin/pxp-agent' -a '--foreground' -s pxp-agent -u root


### PR DESCRIPTION
Merges stable to master, restoring all component json files, except for windows_ruby.json, since we do want to use the most recent tags `ruby 2.1.7.1-{x86,x64}`.

/cc @Iristyle @shrug @geoffnichols 
