### PR TITLE
(PA-95) Update cert bundle to 1.0.7

### DIFF
--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
   "url": "git@github.com:puppetlabs/puppet-ca-bundle.git",
-  "ref": "1.0.4"
+  "ref": "1.0.7"
 }


### PR DESCRIPTION
In the previous update to the cert bundle,
we hit an issue with strict parsing of .pem
files by IBM java in SLES. This update includes
a fix for that issue, and includes the full
Mozilla CA cert bundle.
