### PR TITLE
(PA-102, PA-104) Windows SSH UserKnownHostsFile=/dev/null

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -69,7 +69,7 @@ def clone_and_rynsc_private_repo(fork, ref, hostname, ssh_key)
 end
 
 # Set up the environment so I don't keep crying
-ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no Administrator@#{hostname}"
+ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null Administrator@#{hostname}"
 ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
 
 result = Kernel.system("set -vx;#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")


### PR DESCRIPTION
- Previously, when previously accessed vmpooler hostnames collided
  with newly allocated ones, builds could fail since the keys are
  different.
  
  Prevent that failure by setting UserKnownHostsFile to /dev/null
