### PR TITLE
(RE-6075) Exclude puppet-agent.csh on cisco-wrlinux-7

### DIFF
--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -3,5 +3,7 @@ component "shellpath" do |pkg, settings, platform|
   pkg.add_source "file://resources/files/puppet-agent.sh", sum: "f5987a68adf3844ca15ba53813ad6f63"
   pkg.add_source "file://resources/files/puppet-agent.csh", sum: "62b360a7d15b486377ef6c7c6d05e881"
   pkg.install_configfile("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh")
-  pkg.install_configfile("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
+  if platform.name !~ /cisco-wrlinux-7/
+    pkg.install_configfile("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
+  end
 end


### PR DESCRIPTION
The cisco-wrlinux-7 platform executes all scripts in /etc/profile.d

The platform does not have csh and the puppet-agent.csh script causes issues.  This change excludes the script from this platform.

Login:

```
-sh: /etc/profile.d/puppet-agent.csh: line 2: syntax error near unexpected token `('
-sh: /etc/profile.d/puppet-agent.csh: line 2: `set path = ($path /opt/puppetlabs/bin)'
```

/etc/profile

```
if [ -d /etc/profile.d ]; then
  for i in /etc/profile.d/* ; do
    . $i
  done
  unset i
fi
```
