### PR TITLE
(maint) Windows log external command execution

### DIFF
--- a/bin/build-helpers.ps1
+++ b/bin/build-helpers.ps1
@@ -8,6 +8,7 @@ function Invoke-External
   )
 
   $Global:LASTEXITCODE = 0
+  Write-Output "Executing external command:`n$cmd"
   & $cmd
   if ($LASTEXITCODE -ne 0) { throw ("Terminating.  Last command failed with exit code $LASTEXITCODE") }
 }


### PR DESCRIPTION
- Useful for debugging / sanity purposes
