### PR TITLE
(PA-102) Restore public git URIs

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:puppetlabs/facter.git", "ref": "1aa380a82ec35b7f8e7e58fab627e74f93aaeff3"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "1aa380a82ec35b7f8e7e58fab627e74f93aaeff3"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:puppetlabs/hiera.git", "ref": "196e896cd9fc132a0fe02269ffe8f5de70231412"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "196e896cd9fc132a0fe02269ffe8f5de70231412"}


### PR DESCRIPTION
A new staging pipeline was created and auto-promoted ssh-based git URIs
for facter and hiera. Our Windows VMs cannot use ssh-based git URIs, so
builds were failing.

This commit restores the facter and hiera repo URI to use
git://github.com URIs.
