### PR TITLE
ARISTA-43 - EOS AIO fixes

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -121,4 +121,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory File.join(settings[:logdir], 'puppet'), mode: "0750"
 
   pkg.link "#{settings[:bindir]}/puppet", "#{settings[:link_bindir]}/puppet"
+  if platform.is_eos?
+    pkg.link "#{settings[:sysconfdir]}", "#{settings[:link_sysconfdir]}"
+  end
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -5,6 +5,9 @@ project "puppet-agent" do |proj|
 
   if platform.is_osx?
     proj.setting(:sysconfdir, "/private/etc/puppetlabs")
+  elsif platform.is_eos?
+    proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
+    proj.setting(:link_sysconfdir, "/etc/puppetlabs")
   else
     proj.setting(:sysconfdir, "/etc/puppetlabs")
   end


### PR DESCRIPTION
These are the cherry-picked commits from master that are needed to resolve ARISTA-43 - setting the sysconfdir to EOS's persistent storage filesystem area.
