### PR TITLE
(RE-5985) Cleanup package dependencies for Cisco wrlinux

### DIFF
--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -3,7 +3,13 @@ component "shellpath" do |pkg, settings, platform|
   pkg.add_source "file://resources/files/puppet-agent.sh", sum: "f5987a68adf3844ca15ba53813ad6f63"
   pkg.add_source "file://resources/files/puppet-agent.csh", sum: "62b360a7d15b486377ef6c7c6d05e881"
   pkg.install_configfile("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh")
-  if platform.name !~ /cisco-wrlinux-7/
+
+  # The cisco platforms have non-standard packages for /etc/profile.d and also try to run the csh
+  if platform.name =~ /cisco-wrlinux-5/
+    pkg.requires 'platform'
+  elsif platform.name =~ /cisco-wrlinux-7/
+    pkg.requires 'cisco-config'
+  else
     pkg.install_configfile("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
   end
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -70,6 +70,11 @@ project "puppet-agent" do |proj|
     proj.identifier "com.puppetlabs"
   end
 
+  # For some platforms the default doc location for the BOM does not exist or is incorrect - move it to specified directory
+  if platform.name =~ /cisco-wrlinux/
+    proj.bill_of_materials File.join(proj.datadir, "doc")
+  end
+
   # Platform specific
   proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")


### PR DESCRIPTION
puppet-agent rpm for Cisco wrlinux would throw dependency issues when installed via rpm.

```
root@t2txsshdfijcslg:~# rpm -i puppet-agent-1.2.7.385.g8450f42-1.cisco_wrlinux7.x86_64.rpm
error: Failed dependencies:
    /etc/profile.d is needed by puppet-agent-1.2.7.385.g8450f42-1.cisco_wrlinux7.x86_64
    /usr/doc is needed by puppet-agent-1.2.7.385.g8450f42-1.cisco_wrlinux7.x86_64
```

This is due to /etc/profile.d being owned by non-standard packages and /usr/doc is non-existent on the platform.

This commit sets the Cisco specific packages as a dependency to eliminate the /etc/profile.d warning and moves the BOM into the puppet namespace.
