### PR TITLE
PA-96 update methods in platform rubies away from the deprecated vcloud_name method

### DIFF
--- a/configs/platforms/cisco-wrlinux-5-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-5-x86_64.rb
@@ -6,7 +6,6 @@ platform "cisco-wrlinux-5-x86_64" do |plat|
   # such as autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/5/pl-build-tools-cisco-wrlinux-5.repo"
   plat.install_build_dependencies_with "yum install -y"
-
-  plat.vcloud_name "cisco-wrlinux-5-x86_64"
+  plat.vmpooler_template "cisco-wrlinux-5-x86_64"
 
 end

--- a/configs/platforms/cisco-wrlinux-7-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-7-x86_64.rb
@@ -6,5 +6,5 @@ platform "cisco-wrlinux-7-x86_64" do |plat|
   # such as autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/7/pl-build-tools-cisco-wrlinux-7.repo"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "cisco-wrlinux-7-x86_64"
+  plat.vmpooler_template "cisco-wrlinux-7-x86_64"
 end

--- a/configs/platforms/cumulus-2.2-amd64.rb
+++ b/configs/platforms/cumulus-2.2-amd64.rb
@@ -22,5 +22,5 @@ apt-get install -qy --no-install-recommends build-essential make quilt pkg-confi
 )
 
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-7-x86_64"
+  plat.vmpooler_template "debian-7-x86_64"
 end

--- a/configs/platforms/debian-6-amd64.rb
+++ b/configs/platforms/debian-6-amd64.rb
@@ -7,5 +7,5 @@ platform "debian-6-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-6-x86_64"
+  plat.vmpooler_template "debian-6-x86_64"
 end

--- a/configs/platforms/debian-6-i386.rb
+++ b/configs/platforms/debian-6-i386.rb
@@ -7,5 +7,5 @@ platform "debian-6-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-6-i386"
+  plat.vmpooler_template "debian-6-i386"
 end

--- a/configs/platforms/debian-7-amd64.rb
+++ b/configs/platforms/debian-7-amd64.rb
@@ -7,5 +7,5 @@ platform "debian-7-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-7-x86_64"
+  plat.vmpooler_template "debian-7-x86_64"
 end

--- a/configs/platforms/debian-7-i386.rb
+++ b/configs/platforms/debian-7-i386.rb
@@ -7,5 +7,5 @@ platform "debian-7-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-wheezy.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-7-i386"
+  plat.vmpooler_template "debian-7-i386"
 end

--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -7,5 +7,5 @@ platform "debian-8-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-jessie.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-8-x86_64"
+  plat.vmpooler_template "debian-8-x86_64"
 end

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -7,5 +7,5 @@ platform "debian-8-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-jessie.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "debian-8-i386"
+  plat.vmpooler_template "debian-8-i386"
 end

--- a/configs/platforms/el-4-i386.rb
+++ b/configs/platforms/el-4-i386.rb
@@ -6,5 +6,5 @@ platform "el-4-i386" do |plat|
 
   plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils pl-tar; yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "centos-4-i386"
+  plat.vmpooler_template "centos-4-i386"
 end

--- a/configs/platforms/el-4-x86_64.rb
+++ b/configs/platforms/el-4-x86_64.rb
@@ -6,5 +6,5 @@ platform "el-4-x86_64" do |plat|
 
   plat.provision_with "echo '[build-tools]\nname=build-tools\ngpgcheck=0\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/4/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/4/$basearch' > /etc/yum.repos.d/pl-build-tools.repo;yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils pl-tar; yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "centos-4-x86_64"
+  plat.vmpooler_template "centos-4-x86_64"
 end

--- a/configs/platforms/el-5-i386.rb
+++ b/configs/platforms/el-5-i386.rb
@@ -5,5 +5,5 @@ platform "el-5-i386" do |plat|
 
   plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/5/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck "
-  plat.vcloud_name "centos-5-i386"
+  plat.vmpooler_template "centos-5-i386"
 end

--- a/configs/platforms/el-5-x86_64.rb
+++ b/configs/platforms/el-5-x86_64.rb
@@ -5,5 +5,5 @@ platform "el-5-x86_64" do |plat|
 
   plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/5/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
-  plat.vcloud_name "centos-5-x86_64"
+  plat.vmpooler_template "centos-5-x86_64"
 end

--- a/configs/platforms/el-6-i386.rb
+++ b/configs/platforms/el-6-i386.rb
@@ -5,5 +5,5 @@ platform "el-6-i386" do |plat|
 
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vcloud_name "centos-6-i386"
+  plat.vmpooler_template "centos-6-i386"
 end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -5,5 +5,5 @@ platform "el-6-x86_64" do |plat|
 
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vcloud_name "centos-6-x86_64"
+  plat.vmpooler_template "centos-6-x86_64"
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -5,5 +5,5 @@ platform "el-7-x86_64" do |plat|
 
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vcloud_name "centos-7-x86_64"
+  plat.vmpooler_template "centos-7-x86_64"
 end

--- a/configs/platforms/eos-4-i386.rb
+++ b/configs/platforms/eos-4-i386.rb
@@ -8,5 +8,5 @@ platform "eos-4-i386" do |plat|
   plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils zip"
 
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
-  plat.vcloud_name "fedora-14-i386"
+  plat.vmpooler_template "fedora-14-i386"
 end

--- a/configs/platforms/fedora-f21-i386.rb
+++ b/configs/platforms/fedora-f21-i386.rb
@@ -6,5 +6,5 @@ platform "fedora-f21-i386" do |plat|
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/i386/pl-build-tools-release-21-11.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-21-i386"
+  plat.vmpooler_template "fedora-21-i386"
 end

--- a/configs/platforms/fedora-f21-x86_64.rb
+++ b/configs/platforms/fedora-f21-x86_64.rb
@@ -6,5 +6,5 @@ platform "fedora-f21-x86_64" do |plat|
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/fedora/21/x86_64/pl-build-tools-release-21-11.noarch.rpm"
   plat.install_build_dependencies_with "yum install -y"
-  plat.vcloud_name "fedora-21-x86_64"
+  plat.vmpooler_template "fedora-21-x86_64"
 end

--- a/configs/platforms/fedora-f22-i386.rb
+++ b/configs/platforms/fedora-f22-i386.rb
@@ -6,5 +6,5 @@ platform "fedora-f22-i386" do |plat|
   plat.provision_with "dnf install -y autoconf automake rsync gcc make rpmdevtools rpm-libs"
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-fedora-22.noarch.rpm"
   plat.install_build_dependencies_with "dnf install -y"
-  plat.vcloud_name "fedora-22-i386"
+  plat.vmpooler_template "fedora-22-i386"
 end

--- a/configs/platforms/fedora-f22-x86_64.rb
+++ b/configs/platforms/fedora-f22-x86_64.rb
@@ -6,5 +6,5 @@ platform "fedora-f22-x86_64" do |plat|
   plat.provision_with "dnf install -y autoconf automake rsync gcc make rpmdevtools rpm-libs"
   plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-fedora-22.noarch.rpm"
   plat.install_build_dependencies_with "dnf install -y"
-  plat.vcloud_name "fedora-22-x86_64"
+  plat.vmpooler_template "fedora-22-x86_64"
 end

--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -6,5 +6,5 @@ platform "osx-10.10-x86_64" do |plat|
   plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.1"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
-  plat.vcloud_name "osx-1010-x86_64"
+  plat.vmpooler_template "osx-1010-x86_64"
 end

--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -5,5 +5,5 @@ platform "osx-10.11-x86_64" do |plat|
 
   plat.provision_with 'cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
-  plat.vcloud_name "osx-1011-x86_64"
+  plat.vmpooler_template "osx-1011-x86_64"
 end

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -6,5 +6,5 @@ platform "osx-10.9-x86_64" do |plat|
   plat.provision_with 'softwareupdate -i "Command Line Tools (OS X Mavericks)-6.2"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
-  plat.vcloud_name "osx-109-x86_64"
+  plat.vmpooler_template "osx-109-x86_64"
 end

--- a/configs/platforms/sles-10-i386.rb
+++ b/configs/platforms/sles-10-i386.rb
@@ -6,5 +6,5 @@ platform "sles-10-i386" do |plat|
   plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/10/i386/pl-build-tools-sles-10-i386.repo"
   plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vcloud_name "sles-10-i386"
+  plat.vmpooler_template "sles-10-i386"
 end

--- a/configs/platforms/sles-10-x86_64.rb
+++ b/configs/platforms/sles-10-x86_64.rb
@@ -6,5 +6,5 @@ platform "sles-10-x86_64" do |plat|
   plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/10/x86_64/pl-build-tools-sles-10-x86_64.repo"
   plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vcloud_name "sles-10-x86_64"
+  plat.vmpooler_template "sles-10-x86_64"
 end

--- a/configs/platforms/sles-11-i386.rb
+++ b/configs/platforms/sles-11-i386.rb
@@ -6,5 +6,5 @@ platform "sles-11-i386" do |plat|
   plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/i386/pl-build-tools-sles-11-i386.repo"
   plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vcloud_name "sles-11-i386"
+  plat.vmpooler_template "sles-11-i386"
 end

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -7,5 +7,5 @@ platform "sles-11-x86_64" do |plat|
   plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
   plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vcloud_name "sles-11-x86_64"
+  plat.vmpooler_template "sles-11-x86_64"
 end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -6,5 +6,5 @@ platform "sles-12-x86_64" do |plat|
   plat.zypper_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/12/x86_64/pl-build-tools-sles-12-x86_64.repo"
   plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make rpm-build"
   plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
-  plat.vcloud_name "sles-12-x86_64"
+  plat.vmpooler_template "sles-12-x86_64"
 end

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -2,7 +2,7 @@ platform "solaris-10-i386" do |plat|
   plat.servicedir "/var/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
-  plat.vcloud_name "solaris-10-x86_64"
+  plat.vmpooler_template "solaris-10-x86_64"
 
   base_pkgs = ['arc', 'gnu-idn', 'gpch', 'gtar', 'hea', 'libm', 'wgetu', 'xcu4']
   base_url = 'http://pl-build-tools.delivery.puppetlabs.net/solaris/10/depends'

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -2,7 +2,7 @@ platform "solaris-10-sparc" do |plat|
   plat.servicedir "/var/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
-  plat.vcloud_name "solaris-10-x86_64"
+  plat.vmpooler_template "solaris-10-x86_64"
   plat.tar "/usr/sfw/bin/gtar"
   plat.patch "/usr/bin/gpatch"
   plat.num_cores "/usr/bin/kstat cpu_info | /opt/csw/bin/ggrep -E '[[:space:]]+core_id[[:space:]]' | wc -l"

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -2,7 +2,7 @@ platform "solaris-11-i386" do |plat|
   plat.servicedir "/lib/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
-  plat.vcloud_name "solaris-11-x86_64"
+  plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -2,7 +2,7 @@ platform "solaris-11-sparc" do |plat|
   plat.servicedir "/lib/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
-  plat.vcloud_name "solaris-11-x86_64"
+  plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
 end

--- a/configs/platforms/ubuntu-10.04-amd64.rb
+++ b/configs/platforms/ubuntu-10.04-amd64.rb
@@ -7,5 +7,5 @@ platform "ubuntu-10.04-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1004-x86_64"
+  plat.vmpooler_template "ubuntu-1004-x86_64"
 end

--- a/configs/platforms/ubuntu-10.04-i386.rb
+++ b/configs/platforms/ubuntu-10.04-i386.rb
@@ -7,5 +7,5 @@ platform "ubuntu-10.04-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-lucid.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1004-i386"
+  plat.vmpooler_template "ubuntu-1004-i386"
 end

--- a/configs/platforms/ubuntu-12.04-amd64.rb
+++ b/configs/platforms/ubuntu-12.04-amd64.rb
@@ -7,5 +7,5 @@ platform "ubuntu-12.04-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1204-x86_64"
+  plat.vmpooler_template "ubuntu-1204-x86_64"
 end

--- a/configs/platforms/ubuntu-12.04-i386.rb
+++ b/configs/platforms/ubuntu-12.04-i386.rb
@@ -7,5 +7,5 @@ platform "ubuntu-12.04-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-precise.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1204-i386"
+  plat.vmpooler_template "ubuntu-1204-i386"
 end

--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -7,5 +7,5 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1404-x86_64"
+  plat.vmpooler_template "ubuntu-1404-x86_64"
 end

--- a/configs/platforms/ubuntu-14.04-i386.rb
+++ b/configs/platforms/ubuntu-14.04-i386.rb
@@ -7,5 +7,5 @@ platform "ubuntu-14.04-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1404-i386"
+  plat.vmpooler_template "ubuntu-1404-i386"
 end

--- a/configs/platforms/ubuntu-15.04-amd64.rb
+++ b/configs/platforms/ubuntu-15.04-amd64.rb
@@ -7,6 +7,6 @@ platform "ubuntu-15.04-amd64" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-vivid.list", "http://pl-build-tools.delivery.puppetlabs.net/debian/keyring.gpg"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1504-x86_64"
+  plat.vmpooler_template "ubuntu-1504-x86_64"
 end
 

--- a/configs/platforms/ubuntu-15.04-i386.rb
+++ b/configs/platforms/ubuntu-15.04-i386.rb
@@ -7,6 +7,6 @@ platform "ubuntu-15.04-i386" do |plat|
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-vivid.list", "http://pl-build-tools.delivery.puppetlabs.net/debian/keyring.gpg"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vcloud_name "ubuntu-1504-i386"
+  plat.vmpooler_template "ubuntu-1504-i386"
 end
 


### PR DESCRIPTION
vcloud_name is a deprecated method in vanagon, this will update the platform rubies in PA to use vmpooler_template instead.
