### PR TITLE
(PA-131) Add leatherman as its own component

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -16,6 +16,7 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires "ruby"
   pkg.build_requires 'openssl'
+  pkg.build_requires 'leatherman'
 
   if platform.is_linux?
     # Running facter (as part of testing) expects virt-what is available

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,0 +1,1 @@
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "origin/master"}

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -1,0 +1,93 @@
+component "leatherman" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/leatherman.json')
+
+  if platform.is_osx?
+    pkg.build_requires "cmake"
+    pkg.build_requres "boost"
+  elsif platform.name =~ /huaweios/
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-gcc-4.8.2-1.huaweios6.ppce500mc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-cmake-3.2.3-1.huaweios6.ppce500mc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-boost-1.58.0-1.huaweios6.ppce500mc.rpm"
+  elsif platform.name =~ /solaris-10/
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-boost-1.58.0-1.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-cmake-3.2.3-2.i386.pkg.gz"
+  elsif platform.name =~ /solaris-11/
+    pkg.build_requires "pl-gcc-#{platform.architecture}"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost-#{platform.architecture}"
+  elsif platform.is_aix?
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
+  else
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+  end
+
+  # curl is only used for compute clusters (GCE, EC2); so rpm, deb, and Windows
+  use_curl = 'FALSE'
+  if platform.is_linux?
+    pkg.build_requires "curl"
+    use_curl = 'TRUE'
+  end
+
+  pkg.build_requires "ruby"
+
+  ruby = "#{settings[:host_ruby]} -rrbconfig"
+
+  # cmake on OSX is provided by brew
+  # a toolchain is not currently required for OSX since we're building with clang.
+  if platform.is_osx?
+    toolchain = ""
+    cmake = "/usr/local/bin/cmake"
+  elsif platform.is_solaris?
+    if platform.architecture == 'sparc'
+      ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
+    end
+
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+    cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
+
+    # FACT-1156: If we build with -O3, solaris segfaults due to something in std::vector
+    special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
+  else
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
+    cmake = "/opt/pl-build-tools/bin/cmake"
+  end
+
+  pkg.configure do
+    ["#{cmake} \
+        #{toolchain} \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+        -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+        -DLEATHERMAN_SHARED=TRUE \
+        #{special_flags} \
+        -DBOOST_STATIC=ON \
+        -DLEATHERMAN_USE_CURL=#{use_curl} \
+        ."]
+  end
+
+  # Make test will explode horribly in a cross-compile situation
+  # Tests will be skipped on AIX until they are expected to pass
+  if platform.architecture == 'sparc' || platform.is_aix?
+    test = ":"
+  else
+    test = "#{platform[:make]} test ARGS=-V"
+  end
+
+  pkg.build do
+    # Until a `check` target exists, run tests are part of the build.
+    [
+      "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
+      "env LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{test}"
+    ]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -89,6 +89,7 @@ project "puppet-agent" do |proj|
   end
 
   # First our stuff
+  proj.component "leatherman"
   proj.component "puppet"
   proj.component "facter"
   proj.component "hiera"


### PR DESCRIPTION
This enables us to un-vendor leatherman from all of our individual
projects. Until those projects are ready to consume an external
leatherman install, this will go unused. We can't remove the vendoring
until we have this in place in P-A, though.