### PR TITLE
(RE-6013, RE-6012, RE-6116, RE-611) Build OpenSSL, Curl, and our ca certs for windows

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -5,17 +5,42 @@ component 'curl' do |pkg, settings, platform|
 
   pkg.build_requires "openssl"
 
+  prefix = settings[:prefix]
+  pem_file = "#{settings[:prefix]}/ssl/cert.pem"
+
+  make = platform[:make]
+
+  if platform.is_windows?
+    pkg.build_requires "pl-zlib-#{platform.architecture}"
+    pkg.build_requires "runtime"
+
+    pkg.environment "PATH" => "#{settings[:gcc_bindir]}:$$PATH"
+    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "CC" => settings[:cc]
+    pkg.environment "CXX" => settings[:cxx]
+
+    prefix = platform.convert_to_windows_path(settings[:prefix])
+    pem_file = platform.convert_to_windows_path("#{settings[:puppet_configdir]}/ssl/cert.pem")
+
+    make = "/usr/bin/make"
+  end
+
   pkg.configure do
     ["LDFLAGS='#{settings[:ldflags]}' \
-     ./configure --prefix=#{settings[:prefix]} \
-     --with-ssl=#{settings[:prefix]} --enable-threaded-resolver --disable-ldap --disable-ldaps --with-ca-bundle=#{settings[:prefix]}/ssl/cert.pem"]
+     ./configure --prefix=#{prefix} \
+        --with-ssl=#{prefix} \
+        --enable-threaded-resolver \
+        --disable-ldap \
+        --disable-ldaps \
+        --with-ca-bundle=#{pem_file} \
+        #{settings[:host]}"]
   end
 
   pkg.build do
-    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
-    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 end

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -4,6 +4,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.url "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"
+  pkg.build_requires "puppet-ca-bundle"
 
   prefix = settings[:prefix]
   pem_file = "#{settings[:prefix]}/ssl/cert.pem"

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -5,12 +5,25 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
   # make the keystore
   pkg.build_requires 'facter'
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "#{settings[:gcc_bindir]}:#{settings[:bindir]}:$$PATH"
+    sslpath = platform.convert_to_windows_path(File.join(settings[:bindir], "openssl"))
+    ssl_certspath = platform.convert_to_windows_path(File.join(settings[:puppet_configdir], "ssl"))
+
+    # We need to use cygwin make for the makefile to run correctly
+    make = "/usr/bin/make"
+  else
+    sslpath = "#{settings[:bindir]}/openssl"
+    ssl_certspath = File.join(settings[:prefix], 'ssl')
+    make = platform[:make]
+  end
+
   install_commands = [
-    "#{platform[:make]} install OPENSSL=#{settings[:bindir]}/openssl USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
+    "#{make} install OPENSSL=#{sslpath} USER=0 GROUP=0 DESTDIR=#{ssl_certspath}"
   ]
 
   if settings[:java_available]
-    install_commands << "#{platform[:make]} keystore DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
+    install_commands << "#{make} keystore DESTDIR=#{ssl_certspath}"
   end
 
   pkg.install do

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -8,6 +8,8 @@ component "runtime" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
+  elsif platform.is_windows?
+    pkg.build_requires "pl-zlib-#{platform.architecture}"
   else
     pkg.build_requires "pl-gcc"
   end
@@ -23,6 +25,15 @@ component "runtime" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
+  elsif platform.is_windows?
+    lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
+    pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
+    pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
+    pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
+
+    # Curl is dynamically linking against zlib, so we need to include this file until we
+    # update curl to statically link against zlib
+    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
   else
     pkg.install_file File.join(libdir, "libstdc++.so.6.0.18"), "/opt/puppetlabs/puppet/lib/libstdc++.so.6.0.18"
     pkg.install_file File.join(libdir, "libgcc_s.so.1"), "/opt/puppetlabs/puppet/lib/libgcc_s.so.1"

--- a/configs/platforms/win-2012-x64.rb
+++ b/configs/platforms/win-2012-x64.rb
@@ -1,0 +1,21 @@
+platform "win-2012-x64" do |plat|
+  plat.vmpooler_template "win-2012r2-x86_64.make"
+
+  plat.servicetype "windows"
+
+  # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
+  plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
+  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
+
+  # We don't want to install any packages from the chocolatey repo by accident
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug"
+
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+
+  plat.make "/cygdrive/c/tools/mingw64/bin/mingw32-make"
+  plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
+
+  plat.platform_triple "x86_64-unknown-mingw32"
+end

--- a/configs/platforms/win-2012-x86.rb
+++ b/configs/platforms/win-2012-x86.rb
@@ -1,0 +1,21 @@
+platform "win-2012-x86" do |plat|
+  plat.vmpooler_template "win-2012r2-x86_64.make"
+
+  plat.servicetype "windows"
+
+  # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
+  plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
+  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
+
+  # We don't want to install any packages from the chocolatey repo by accident
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86"
+
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+
+  plat.make "/cygdrive/c/tools/mingw32/bin/mingw32-make"
+  plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
+
+  plat.platform_triple "i686-unknown-mingw32"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -152,7 +152,7 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  if platform.is_solaris? || platform.name =~ /^el-4/ || platform.is_aix?
+  if platform.is_solaris? || platform.name =~ /^el-4/ || platform.is_aix? || platform.is_windows?
     proj.component "runtime"
   end
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,37 +1,55 @@
 project "puppet-agent" do |proj|
-  # Project level settings our components will care about
-  proj.setting(:install_root, "/opt/puppetlabs")
-  proj.setting(:prefix, File.join(proj.install_root, "puppet"))
+  platform = proj.get_platform
 
-  if platform.is_eos?
-    proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
-    proj.setting(:link_sysconfdir, "/etc/puppetlabs")
-  elsif platform.is_osx?
-    proj.setting(:sysconfdir, "/private/etc/puppetlabs")
-  elsif platform.is_eos?
-    proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
-    proj.setting(:link_sysconfdir, "/etc/puppetlabs")
+  # Project level settings our components will care about
+  # Windows has its own seperate layout
+  if platform.is_windows?
+    # Our install prefix can't have spaces in it, so we take advantage of short cuts.
+    # However, in order to take advantage of these shortcuts, we need to explicitely
+    # create the directories.
+    proj.setting(:install_root, "#{platform.drive_root}/Progra~1/Puppet~1")
+    proj.directory "#{platform.drive_root}/Program Files/Puppet Labs"
+    proj.setting(:prefix, File.join(proj.install_root, "Puppet"))
+    proj.setting(:sysconfdir, "#{platform.drive_root}/ProgramData/PuppetLabs")
+    proj.setting(:puppet_configdir, File.join(proj.sysconfdir, 'puppet', 'etc'))
+    proj.setting(:link_bindir, File.join(proj.prefix, "bin"))
+    proj.setting(:logdir, File.join(proj.sysconfdir, "puppet", "var", "log"))
+    proj.setting(:piddir, File.join(proj.sysconfdir, "puppet", "var", "run"))
+    proj.setting(:tmpfilesdir, "#{platform.drive_root}/Windows/Temp")
   else
-    proj.setting(:sysconfdir, "/etc/puppetlabs")
+    proj.setting(:install_root, "/opt/puppetlabs")
+    proj.setting(:prefix, File.join(proj.install_root, "puppet"))
+    if platform.is_eos?
+      proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
+      proj.setting(:link_sysconfdir, "/etc/puppetlabs")
+    elsif platform.is_osx?
+      proj.setting(:sysconfdir, "/private/etc/puppetlabs")
+    else
+      proj.setting(:sysconfdir, "/etc/puppetlabs")
+    end
+    proj.setting(:puppet_configdir, File.join(proj.sysconfdir, 'puppet'))
+    proj.setting(:link_bindir, "/opt/puppetlabs/bin")
+    proj.setting(:logdir, "/var/log/puppetlabs")
+    proj.setting(:piddir, "/var/run/puppetlabs")
+    proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
   end
 
-  proj.setting(:puppet_configdir, File.join(proj.sysconfdir, 'puppet'))
   proj.setting(:puppet_codedir, File.join(proj.sysconfdir, 'code'))
-  proj.setting(:logdir, "/var/log/puppetlabs")
-  proj.setting(:piddir, "/var/run/puppetlabs")
   proj.setting(:bindir, File.join(proj.prefix, "bin"))
-  proj.setting(:link_bindir, "/opt/puppetlabs/bin")
   proj.setting(:libdir, File.join(proj.prefix, "lib"))
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
-  proj.setting(:gem_home, File.join(proj.libdir, "ruby/gems/2.1.0"))
-  proj.setting(:tmpfilesdir, "/usr/lib/tmpfiles.d")
+  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
-  proj.setting(:host_ruby, File.join(proj.bindir, "ruby"))
-  proj.setting(:host_gem, File.join(proj.bindir, "gem"))
 
-  platform = proj.get_platform
+  if platform.is_windows?
+    proj.setting(:host_ruby, File.join(proj.bindir, "ruby.exe"))
+    proj.setting(:host_gem, File.join(proj.bindir, "gem.bat"))
+  else
+    proj.setting(:host_ruby, File.join(proj.bindir, "ruby"))
+    proj.setting(:host_gem, File.join(proj.bindir, "gem"))
+  end
 
   # For solaris, we build cross-compilers
   if platform.is_solaris?
@@ -50,6 +68,9 @@ project "puppet-agent" do |proj|
         proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
       end
     end
+  elsif platform.is_windows?
+    # For windows, we need to ensure we are building for mingw not cygwin
+    host = "--host #{platform.platform_triple}"
   end
 
   proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local ")
@@ -82,8 +103,20 @@ project "puppet-agent" do |proj|
   end
 
   # Platform specific
-  proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+  if platform.is_windows?
+    arch = platform.architecture == "x64" ? "64" : "32"
+    proj.setting(:cflags, "-IC:/tools/pl-build-tools/include -IC:/tools/mingw#{arch}/include -I#{platform.convert_to_windows_path(proj.includedir)}")
+    proj.setting(:ldflags, "-LC:/tools/pl-build-tools/lib -LC:/tools/mingw#{arch}/lib -L#{platform.convert_to_windows_path(proj.libdir)}")
+    proj.setting(:gcc_bindir, "#{platform.drive_root}/tools/mingw#{arch}/bin")
+    proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+    proj.setting(:cc, "C:/tools/mingw#{arch}/bin/gcc")
+    proj.setting(:cxx, "C:/tools/mingw#{arch}/bin/g++")
+    proj.setting(:tools_root, "#{platform.drive_root}/tools/pl-build-tools")
+  else
+    proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+    proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+    proj.setting(:tools_root, "/opt/pl-build-tools")
+  end
   if platform.is_aix?
     proj.setting(:ldflags, "-Wl,-brtl -L#{proj.libdir} -L/opt/pl-build-tools/lib")
   end
@@ -97,20 +130,20 @@ project "puppet-agent" do |proj|
   proj.component "pxp-agent"
 
   # Then the dependencies
-  proj.component "augeas"
+  proj.component "augeas" unless platform.is_windows?
   # Curl is only needed for compute clusters (GCE, EC2); so rpm, deb, and Windows
-  proj.component "curl" if platform.is_linux?
+  proj.component "curl" if platform.is_linux? || platform.is_windows?
   proj.component "ruby"
   proj.component "ruby-stomp"
   proj.component "rubygem-deep-merge"
   proj.component "rubygem-net-ssh"
   proj.component "rubygem-hocon"
-  proj.component "ruby-shadow" unless platform.is_aix?
-  proj.component "ruby-augeas"
+  proj.component "ruby-shadow" unless platform.is_aix? || platform.is_windows?
+  proj.component "ruby-augeas" unless platform.is_windows?
   proj.component "openssl"
   proj.component "puppet-ca-bundle"
-  proj.component "libxml2"
-  proj.component "libxslt"
+  proj.component "libxml2" unless platform.is_windows?
+  proj.component "libxslt" unless platform.is_windows?
 
   # These utilites don't really work on unix
   if platform.is_linux?
@@ -138,11 +171,11 @@ project "puppet-agent" do |proj|
     proj.component "ruby-selinux"
   end
 
-  proj.directory proj.install_root
+  # We're creating this directory on windows in the above windows block
+  proj.directory proj.install_root unless platform.is_windows?
   proj.directory proj.prefix
   proj.directory proj.sysconfdir
   proj.directory proj.logdir
   proj.directory proj.piddir
   proj.directory proj.link_bindir
-
 end

--- a/resources/patches/openssl/openssl-mingw-do-not-build-applink.patch
+++ b/resources/patches/openssl/openssl-mingw-do-not-build-applink.patch
@@ -1,0 +1,12 @@
+diff -u --recursive a/Configure b/Configure
+--- a/Configure	2015-07-09 04:57:15.000000000 -0700
++++ b/Configure	2015-12-15 13:15:12.377660400 -0800
+@@ -591,7 +591,7 @@
+ "BC-32","bcc32::::WIN32::BN_LLONG DES_PTR RC4_INDEX EXPORT_VAR_AS_FN:${no_asm}:win32",
+ 
+ # MinGW
+-"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL -DOPENSSL_USE_APPLINK:-mno-cygwin:.dll.a",
++"mingw", "gcc:-mno-cygwin -DL_ENDIAN -DWIN32_LEAN_AND_MEAN -fomit-frame-pointer -O3 -march=i486 -Wall::-D_MT:MINGW32:-lws2_32 -lgdi32 -lcrypt32:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts} EXPORT_VAR_AS_FN:${x86_asm}:coff:win32:cygwin-shared:-D_WINDLL:-mno-cygwin:.dll.a",
+ # As for OPENSSL_USE_APPLINK. Applink makes it possible to use .dll
+ # compiled with one compiler with application compiled with another
+ # compiler. It's possible to engage Applink support in mingw64 build,


### PR DESCRIPTION
This initial commit adds in the base work to build the puppet-agent project on windows, and modifies the curl, openssl, puppet-ca-bundle and runtime components to run on windows.