### PR TITLE
(PA-135) Can't manage puppet service on ubuntu wily

### DIFF
--- a/configs/platforms/ubuntu-15.10-amd64.rb
+++ b/configs/platforms/ubuntu-15.10-amd64.rb
@@ -1,5 +1,5 @@
 platform "ubuntu-15.10-amd64" do |plat|
-  plat.servicedir "/etc/init.d"
+  plat.servicedir "/lib/systemd/system"
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"
   plat.codename "wily"

--- a/configs/platforms/ubuntu-15.10-i386.rb
+++ b/configs/platforms/ubuntu-15.10-i386.rb
@@ -1,5 +1,5 @@
 platform "ubuntu-15.10-i386" do |plat|
-  plat.servicedir "/etc/init.d"
+  plat.servicedir "/lib/systemd/system"
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"
   plat.codename "wily"


### PR DESCRIPTION
before this commit the location of the service directory
for systemd was incorrect and puppet installs on ubuntu wily
failed trying to load puppet.service. this commit changes
the servicedir for systemd on both wily installs to the
correct path