### PR TITLE
(maint) Track the stable branch of cpp-pcp-client

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,2 +1,2 @@
-{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.0.1"}
+{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "stable"}
 


### PR DESCRIPTION
Previously puppet-agent#stable was tracking cpp-pcp-client#master,
which led to a little confusion. There's room for discussion about
how we want to handle internal components that do *not* have promoting
pipelines (e.g. branches or tags), and right now cpp-pcp-client is
the only example of such. But for now, this is more consistent with
what puppet-agent does for most other internal components.