### PR TITLE
(maint) Track puppet_for_the_win#stable

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/master"
+  "ref": "origin/stable"
 }


### PR DESCRIPTION
 - In 418268e a commit was introduced for stable to track stable.
   In 0270b3a that was reverted for some reason, and stable began to
   track puppet_for_the_win#master.  Let's set this back to stable.

 - Note that releases 1.3.2, 1.3.1, 1.3.0, 1.2.7, etc were all
   properly pinned to the appropriate version tag in puppet_for_the_win