### PR TITLE
(HUAWEI-2) Add ruby gems for net-netconf and depdencies

### DIFF
--- a/configs/components/rubygem-mini_portile.rb
+++ b/configs/components/rubygem-mini_portile.rb
@@ -1,0 +1,15 @@
+component "rubygem-mini_portile" do |pkg, settings, platform|
+  pkg.version "0.6.2"
+  pkg.md5sum "281cc0d974d3810d1195ad4a863ba5b6"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/mini_portile-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} mini_portile-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -1,0 +1,17 @@
+component "rubygem-net-netconf" do |pkg, settings, platform|
+  pkg.version "0.4.3"
+  pkg.md5sum "fa173b0965766a427d8692f6b31c85a4"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/net-netconf-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-nokogiri"
+  pkg.build_requires "rubygem-net-scp"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} net-netconf-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -1,0 +1,16 @@
+component "rubygem-net-scp" do |pkg, settings, platform|
+  pkg.version "1.2.1"
+  pkg.md5sum "abeec1cab9696e02069e74bd3eac8a1b"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/net-scp-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-net-ssh"
+
+  # Because we are cross-compiling, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} net-scp-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -1,0 +1,16 @@
+component "rubygem-nokogiri" do |pkg, settings, platform|
+  pkg.version "1.6.6.2"
+  pkg.md5sum "fc9f91534bf93d57b84f625b55732a7c"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-mini_portile"
+
+  # Because we are cross-compiling on ppc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  pkg.install do
+    ["#{settings[:gem_install]} nokogiri-#{pkg.get_version}.gem -- --use-system-libraries --with-xml2-lib=/opt/puppetlabs/puppet/lib --with-xml2-include=/opt/puppetlabs/puppet/include/libxml2 --with-xslt-lib=/opt/puppetlabs/puppet/lib --with-xslt-include=/opt/puppetlabs/puppet/include/libxslt"]
+  end
+end


### PR DESCRIPTION
This adds component definitions for the following gems:

* net-netconf
* net-scp (dependency of net-netconf)
* nokogiri (dependency of net-netconf)
* mini_portile (dependency of nokogiri)

These gems will be included in the Huawei agent package.