### PR TITLE
(maint) Remove duplicate settings

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -8,9 +8,6 @@ project "puppet-agent" do |proj|
     proj.setting(:link_sysconfdir, "/etc/puppetlabs")
   elsif platform.is_osx?
     proj.setting(:sysconfdir, "/private/etc/puppetlabs")
-  elsif platform.is_eos?
-    proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
-    proj.setting(:link_sysconfdir, "/etc/puppetlabs")
   else
     proj.setting(:sysconfdir, "/etc/puppetlabs")
   end


### PR DESCRIPTION
We currently have duplicate entires for eos settings. This is confusing
and unnecessary. This commit removes the duplicate entries.