### PR TITLE
(PA-131) Add leatherman as its own component

### DIFF
--- a/bin/build-facter.ps1
+++ b/bin/build-facter.ps1
@@ -37,7 +37,7 @@ $cmake_args = @(
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_STATIC=ON",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\leatherman`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-leatherman.ps1
+++ b/bin/build-leatherman.ps1
@@ -1,0 +1,53 @@
+### Set variables from command line
+# $arch => Choose 32 or 64-bit build
+# $cores => Set the number of cores to use for parallel builds
+# $leathermanRef => the git repository to build from
+# $leathermanFork => the git ref to build from
+param (
+[int] $arch=64,
+[int] $cores=2,
+[string] $leathermanRef='origin/master',
+[string] $leathermanFork='git://github.com/puppetlabs/leatherman'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
+. $scriptDirectory\build-helpers.ps1
+. $scriptDirectory\windows-env.ps1
+
+Write-Host "arch=$arch, cores=$cores"
+
+Write-Host "Starting leatherman build"
+
+cd $sourceDir
+
+## Download leatherman and setup build directories
+Invoke-External { git clone $leathermanFork leatherman }
+cd leatherman
+Invoke-External { git checkout $leathermanRef }
+mkdir -Force release
+cd release
+
+## Build leatherman
+$cmake_args = @(
+  '-G',
+  "MinGW Makefiles",
+  "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
+  "-DBOOST_STATIC=ON",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg`"",
+  "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\leatherman`"",
+  "-DCURL_STATIC=ON",
+  ".."
+)
+Invoke-External { cmake $cmake_args }
+Invoke-External { mingw32-make -j $cores }
+Invoke-External { mingw32-make install }
+
+Write-Host "leatherman Build completed."
+## Write out the version that was just built.
+#git describe --long | Out-File -FilePath 'bin/VERSION' -Encoding ASCII -Force
+
+## Test the results.
+Write-Host "Starting Tests"
+Invoke-External { mingw32-make test ARGS=-V }

--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -32,6 +32,7 @@ script_arch          = "#{ARCH == 'x64' ? '64' : '32'}"
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))
 FACTER       = JSON.parse(File.read('configs/components/facter.json'))
+LEATHERMAN   = JSON.parse(File.read('configs/components/leatherman.json'))
 CPPPCPCLIENT = JSON.parse(File.read('configs/components/cpp-pcp-client.json'))
 PXPAGENT     = JSON.parse(File.read('configs/components/pxp-agent.json'))
 HIERA        = JSON.parse(File.read('configs/components/hiera.json'))
@@ -98,6 +99,13 @@ puts "Build-Windows.rb... Setting up windows toolset - windows-toolset.ps1"
 result = Kernel.system("#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./windows-toolset.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE}\"")
 fail "It looks like the Windows-toolset build script failed for some reason. I would suggest ssh'ing into the box and poking around" unless result
 puts "Build-Windows.rb... Windows Setup Completed!!"
+
+puts "Build-Windows.rb... building leatherman"
+Kernel.system("#{scp_command} #{File.join(SCRIPT_ROOT, 'build-leatherman.ps1')} Administrator@#{hostname}:/home/Administrator/")
+fail "Copying build-leatherman.ps1 to #{hostname} failed" unless $?.success?
+result = Kernel.system("set -vx;#{ssh_command} \"powershell.exe -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command ./build-leatherman.ps1 -arch #{script_arch} -buildSource #{BUILD_SOURCE} -leathermanRef #{LEATHERMAN['ref']} -leathermanFork #{LEATHERMAN['url']}\"")
+fail "It looks like the leatherman build script build-leatherman.ps1 failed for some reason. I would suggest ssh'ing into the box and poking around:\n#{result}" unless result
+puts "Build-Windows.rb... leatherman build Completed!!"
 
 puts "Build-Windows.rb... building facter"
 Kernel.system("#{scp_command} #{File.join(SCRIPT_ROOT, 'build-facter.ps1')} Administrator@#{hostname}:/home/Administrator/")

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -16,6 +16,7 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires "ruby"
   pkg.build_requires 'openssl'
+  pkg.build_requires 'leatherman'
 
   if platform.is_linux?
     # Running facter (as part of testing) expects virt-what is available

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,0 +1,1 @@
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "0.3.4"}

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -1,0 +1,99 @@
+component "leatherman" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/leatherman.json')
+
+  if platform.is_osx?
+    pkg.build_requires "cmake"
+    pkg.build_requires "boost"
+  elsif platform.name =~ /huaweios/
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-gcc-4.8.2-1.huaweios6.ppce500mc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-cmake-3.2.3-1.huaweios6.ppce500mc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-boost-1.58.0-1.huaweios6.ppce500mc.rpm"
+  elsif platform.name =~ /solaris-10/
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-boost-1.58.0-1.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-cmake-3.2.3-2.i386.pkg.gz"
+  elsif platform.name =~ /solaris-11/
+    pkg.build_requires "pl-gcc-#{platform.architecture}"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost-#{platform.architecture}"
+  elsif platform.is_aix?
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
+  else
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+  end
+
+  # curl is only used for compute clusters (GCE, EC2); so rpm, deb, and Windows
+  use_curl = 'FALSE'
+  if platform.is_linux?
+    pkg.build_requires "curl"
+    use_curl = 'TRUE'
+  end
+
+  pkg.build_requires "ruby"
+
+  ruby = "#{settings[:host_ruby]} -rrbconfig"
+
+  # cmake on OSX is provided by brew
+  # a toolchain is not currently required for OSX since we're building with clang.
+  if platform.is_osx?
+    toolchain = ""
+    cmake = "/usr/local/bin/cmake"
+  elsif platform.is_solaris?
+    if platform.architecture == 'sparc'
+      ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
+    end
+
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+    cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
+
+    # FACT-1156: If we build with -O3, solaris segfaults due to something in std::vector
+    special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
+  else
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
+    cmake = "/opt/pl-build-tools/bin/cmake"
+  end
+
+  pkg.configure do
+    ["#{cmake} \
+        #{toolchain} \
+        -DCMAKE_VERBOSE_MAKEFILE=ON \
+        -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+        -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+        -DLEATHERMAN_SHARED=TRUE \
+        #{special_flags} \
+        -DBOOST_STATIC=ON \
+        -DLEATHERMAN_USE_CURL=#{use_curl} \
+        ."]
+  end
+
+  # Make test will explode horribly in a cross-compile situation
+  # Tests will be skipped on AIX until they are expected to pass
+  if platform.architecture == 'sparc' || platform.is_aix?
+    test = ":"
+  else
+    test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{platform[:make]} test ARGS=-V"
+  end
+
+  if platform.is_solaris? && platform.architecture != 'sparc'
+    test = "LANG=C #{test}"
+  end
+
+  test = "env #{test}"
+
+  pkg.build do
+    # Until a `check` target exists, run tests are part of the build.
+    [
+      "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
+      "#{test}"
+    ]
+  end
+
+  pkg.install do
+    ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -89,6 +89,7 @@ project "puppet-agent" do |proj|
   proj.component "puppet"
   proj.component "facter"
   proj.component "hiera"
+  proj.component "leatherman"
   proj.component "marionette-collective"
   proj.component "cpp-pcp-client"
   proj.component "pxp-agent"


### PR DESCRIPTION
This enables us to un-vendor leatherman from all of our individual
projects. Until those projects are ready to consume an external
leatherman install, this will go unused. We can't remove the vendoring
until we have this in place in P-A, though.