### PR TITLE
(PA-100) Update version of libxml2 built in puppet-agent

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -1,6 +1,6 @@
 component "libxml2" do |pkg, settings, platform|
-  pkg.version "2.9.2"
-  pkg.md5sum "9e6a9aca9d155737868b3dc5fd82f788"
+  pkg.version "2.9.3"
+  pkg.md5sum "daece17e045f1c107610e137ab50c179"
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?


### PR DESCRIPTION
Per http://www.xmlsoft.org/news.html, we should update
libxml2 2.9.3 that will be shipped with puppet-agent
(currently only in master). This commit updates the
md5 sum of and version number for the libxml2
component