### PR TITLE
(PA-138) Build native software on windows with secure components

### DIFF
--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -29,7 +29,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client;$toolsDir\$opensslPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -29,7 +29,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client;$toolsDir\$opensslPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$opensslPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -29,7 +29,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$opensslPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -29,7 +29,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -22,7 +22,7 @@ Write-Host "Starting cpp-pcp-client build"
 mkdir -Force release
 cd release
 
-## Build pxp_agent
+## Build cpp_pcp_client
 $cmake_args = @(
   '-G',
   "MinGW Makefiles",

--- a/bin/build-facter.ps1
+++ b/bin/build-facter.ps1
@@ -37,7 +37,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-facter.ps1
+++ b/bin/build-facter.ps1
@@ -37,7 +37,7 @@ $cmake_args = @(
   "-DBOOST_ROOT=`"$toolsDir\$boostPkg`"",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-pxp-agent.ps1
+++ b/bin/build-pxp-agent.ps1
@@ -33,7 +33,7 @@ $cmake_args = @(
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$sourceDir`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg;$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-pxp-agent.ps1
+++ b/bin/build-pxp-agent.ps1
@@ -33,7 +33,7 @@ $cmake_args = @(
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_ROOT=`"$toolsDir\$yamlPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$sourceDir`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -27,7 +27,7 @@ PRESERVE             = ENV['PRESERVE'] || false
 
 # Parsed information that we need to specify in order to know where to find different built facter bits
 # and correctly pass information to the facter build script
-script_arch          = "#{ARCH == 'x64' ? '64' : '32'}"
+script_arch          = ARCH == 'x64' ? '64' : '32'
 
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))

--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -28,6 +28,8 @@ PRESERVE             = ENV['PRESERVE'] || false
 # Parsed information that we need to specify in order to know where to find different built facter bits
 # and correctly pass information to the facter build script
 script_arch          = ARCH == 'x64' ? '64' : '32'
+ruby_arch            = ARCH == 'x64' ? 'x64' : 'i386'
+ruby_version         = "2.1.7"
 
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))
@@ -70,7 +72,7 @@ end
 
 # Set up the environment so I don't keep crying
 ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null Administrator@#{hostname}"
-ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
+ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/home/Administrator/deps/ruby-#{ruby_version}-#{ruby_arch}-mingw32/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
 scp_command = "scp #{ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 result = Kernel.system("set -vx;#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")
@@ -193,7 +195,7 @@ fail "It seems there were some issues cloning the puppet_for_the_win repo" unles
 Kernel.system("set -vx;#{scp_command} winconfig.yaml Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/")
 
 # Build the MSI with automation in puppet_for_the_win
-result = Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} c:/tools/ruby21/bin/rake clobber windows:build config=winconfig.yaml\"")
+result = Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} C:/cygwin64/home/Administrator/deps/ruby-#{ruby_version}-#{ruby_arch}-mingw32/bin/rake clobber windows:build config=winconfig.yaml\"")
 fail "It seems there were some issues building the puppet-agent msi" unless result
 
 # Fetch back the built installer

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -52,6 +52,3 @@ $env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
 "$toolsDir\$opensslPkg\bin") |
  % { $Env:PATH += ";$($_)" }
 Write-Host "Updated Path to $env:PATH"
-
-# SSL root pointer.
-$env:OPENSSL_ROOT_DIR = $toolsDir + "\" + $opensslPkg

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -27,13 +27,15 @@ $mingwThreads = "win32"
 if ($arch -eq 64) {
   $mingwExceptions = "seh"
   $mingwArch = "x86_64"
+  $opensslArch = "x64"
 } else {
   $mingwExceptions = "sjlj"
   $mingwArch = "i686"
+  $opensslArch = "x86"
 }
 $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
 
-$opensslPkg = "openssl-1.0.0s-x64-windows"
+$opensslPkg = "openssl-1.0.0s-${opensslArch}-windows"
 
 $boostVer = "boost_1_58_0"
 $boostPkg = "${boostVer}-${mingwVer}"

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -47,10 +47,10 @@ $curlPkg = "${curlVer}-${mingwVer}"
 $Wix35_VERSION = '3.5.2519.20130612'
 
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-if ($arch -eq 32) {
-  $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
-}
-$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
+$env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
+@([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
+"$toolsDir\$opensslPkg\bin") |
+ % { $Env:PATH += ";$($_)" }
 Write-Host "Updated Path to $env:PATH"
 
 # SSL root pointer.

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -28,14 +28,18 @@ if ($arch -eq 64) {
   $mingwExceptions = "seh"
   $mingwArch = "x86_64"
   $opensslArch = "x64"
+  $rubyArch = "x64"
 } else {
   $mingwExceptions = "sjlj"
   $mingwArch = "i686"
   $opensslArch = "x86"
+  $rubyArch = "i386"
 }
 $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
 
-$opensslPkg = "openssl-1.0.0s-${opensslArch}-windows"
+$rubyPkg = "ruby-2.1.7-${rubyArch}-mingw32"
+
+$opensslPkg = "openssl-1.0.2e-${opensslArch}-windows"
 
 $boostVer = "boost_1_58_0"
 $boostPkg = "${boostVer}-${mingwVer}"
@@ -51,6 +55,7 @@ $Wix35_VERSION = '3.5.2519.20130612'
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 $env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
 @([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
+"$toolsDir\$rubyPkg\bin",
 "$toolsDir\$opensslPkg\bin") |
  % { $Env:PATH += ";$($_)" }
 Write-Host "Updated Path to $env:PATH"

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -52,10 +52,17 @@ $curlPkg = "${curlVer}-${mingwVer}"
 
 $Wix35_VERSION = '3.5.2519.20130612'
 
-$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-$env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
-@([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
-"$toolsDir\$rubyPkg\bin",
-"$toolsDir\$opensslPkg\bin") |
- % { $Env:PATH += ";$($_)" }
-Write-Host "Updated Path to $env:PATH"
+Function Set-Path {
+  $path = [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
+  @([System.Environment]::GetEnvironmentVariable("Path","Machine"),
+  [System.Environment]::GetEnvironmentVariable("Path","User"),
+  "$toolsDir\$rubyPkg\bin",
+  "$toolsDir\$opensslPkg\bin",
+  "C:\tools\mingw$arch\bin",
+  "C:\ProgramData\chocolatey\bin") |
+    % { $path = "$_;" + $path }
+  $env:PATH = $path
+  Write-Host "Updated Path to $env:PATH"
+}
+
+Set-Path

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -51,10 +51,8 @@ Install-Choco Wix35 $Wix35_VERSION
 # - seh exceptions on 64-bit, to work around an obscure bug loading Ruby in Facter
 # These are the defaults on our myget feed.
 if ($arch -eq 64) {
-  Install-Choco ruby 2.1.6
   Install-Choco mingw-w64 $mingwVerChoco
 } else {
-  Install-Choco ruby 2.1.6 @('-x86')
   Install-Choco mingw-w32 $mingwVerChoco @('-x86')
 }
 
@@ -161,10 +159,15 @@ cd $toolsDir\${opensslPkg}
 Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar" }
 
 cd $toolsDir
+# Download ruby
+Write-Host "Downloading http://buildsources.delivery.puppetlabs.net/windows/ruby/${rubyPkg}.7z"
+(New-Object net.webclient).DownloadFile("http://buildsources.delivery.puppetlabs.net/windows/ruby/${rubyPkg}.7z", "$toolsDir\${rubyPkg}.7z")
+Invoke-External { & 7za x "$toolsDir\${rubyPkg}.7z" | FIND /V "ing " }
 
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 $env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
 @([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
+"$toolsDir\$rubyPkg\bin",
 "$toolsDir\$opensslPkg\bin") |
   % { $Env:PATH += ";$($_)" }
 Write-Host "Updated Path to $env:PATH"

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -57,19 +57,9 @@ if ($arch -eq 64) {
   Install-Choco ruby 2.1.6 @('-x86')
   Install-Choco mingw-w32 $mingwVerChoco @('-x86')
 }
-$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-if ($arch -eq 32) {
-  $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
-}
-$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
-Write-Host "Updated Path to $env:PATH"
 
 cd $toolsDir
 
-Write-Host "Tool Versions Installed:`n`n"
-$PSVersionTable.Keys | % { Write-Host "$_ : $($PSVersionTable[$_])" }
-@('git', 'cmake', 'mingw32-make', 'ruby', 'rake') |
-  % { Verify-Tool $_ }
 Verify-Tool '7za' ''
 
 if ($buildSource) {
@@ -171,3 +161,15 @@ cd $toolsDir\${opensslPkg}
 Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar" }
 
 cd $toolsDir
+
+$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+$env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
+@([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
+"$toolsDir\$opensslPkg\bin") |
+  % { $Env:PATH += ";$($_)" }
+Write-Host "Updated Path to $env:PATH"
+
+Write-Host "Tool Versions Installed:`n`n"
+$PSVersionTable.Keys | % { Write-Host "$_ : $($PSVersionTable[$_])" }
+@('git', 'cmake', 'mingw32-make', 'ruby', 'rake', 'openssl') |
+  % { Verify-Tool $_ }

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -167,13 +167,7 @@ Write-Host "Downloading $buildSourcesURL/ruby/${rubyPkg}.7z"
 (New-Object net.webclient).DownloadFile("$buildSourcesURL/ruby/${rubyPkg}.7z", "$toolsDir\${rubyPkg}.7z")
 Invoke-External { & 7za x "$toolsDir\${rubyPkg}.7z" | FIND /V "ing " }
 
-$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-$env:PATH = "C:\tools\mingw$arch\bin;" + $env:PATH
-@([Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd",
-"$toolsDir\$rubyPkg\bin",
-"$toolsDir\$opensslPkg\bin") |
-  % { $Env:PATH += ";$($_)" }
-Write-Host "Updated Path to $env:PATH"
+Set-Path
 
 Write-Host "Tool Versions Installed:`n`n"
 $PSVersionTable.Keys | % { Write-Host "$_ : $($PSVersionTable[$_])" }

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -60,6 +60,9 @@ cd $toolsDir
 
 Verify-Tool '7za' ''
 
+$buildSourcesURL = "http://buildsources.delivery.puppetlabs.net/windows"
+$s3URL = "https://s3.amazonaws.com/kylo-pl-bucket"
+
 if ($buildSource) {
   ## Download, build, and install Boost
   Write-Host "Downloading http://downloads.sourceforge.net/boost/$boostVer.7z"
@@ -134,25 +137,25 @@ if ($buildSource) {
   cd $toolsDir
 } else {
   ## Download and unpack Boost from a pre-built package in S3
-  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${boostPkg}.7z"
-  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${boostPkg}.7z", "$toolsDir\${boostPkg}.7z")
+  Write-Host "Downloading $s3URL/${boostPkg}.7z"
+  (New-Object net.webclient).DownloadFile("$s3URL/${boostPkg}.7z", "$toolsDir\${boostPkg}.7z")
   Invoke-External { & 7za x "${boostPkg}.7z" | FIND /V "ing " }
 
   ## Download and unpack yaml-cpp from a pre-built package in S3
-  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${yamlPkg}.7z"
-  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${yamlPkg}.7z", "$toolsDir\${yamlPkg}.7z")
+  Write-Host "Downloading $s3URL/${yamlPkg}.7z"
+  (New-Object net.webclient).DownloadFile("$s3URL/${yamlPkg}.7z", "$toolsDir\${yamlPkg}.7z")
   Invoke-External { & 7za x "${yamlPkg}.7z" | FIND /V "ing " }
 
   ## Download and unpack curl from a pre-built package in S3
-  Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${curlPkg}.7z"
-  (New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${curlPkg}.7z", "$toolsDir\${curlPkg}.7z")
+  Write-Host "Downloading $s3URL/${curlPkg}.7z"
+  (New-Object net.webclient).DownloadFile("$s3URL/${curlPkg}.7z", "$toolsDir\${curlPkg}.7z")
   Invoke-External { & 7za x "${curlPkg}.7z" | FIND /V "ing " }
 }
 cd $toolsDir
 
 # Download openssl
-Write-Host "Downloading http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma"
-(New-Object net.webclient).DownloadFile("http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma", "$toolsDir\${opensslPkg}.tar.lzma")
+Write-Host "Downloading $buildSourcesURL/openssl/${opensslPkg}.tar.lzma"
+(New-Object net.webclient).DownloadFile("$buildSourcesURL/openssl/${opensslPkg}.tar.lzma", "$toolsDir\${opensslPkg}.tar.lzma")
 Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar.lzma" }
 mkdir $toolsDir\${opensslPkg}
 cd $toolsDir\${opensslPkg}
@@ -160,8 +163,8 @@ Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar" }
 
 cd $toolsDir
 # Download ruby
-Write-Host "Downloading http://buildsources.delivery.puppetlabs.net/windows/ruby/${rubyPkg}.7z"
-(New-Object net.webclient).DownloadFile("http://buildsources.delivery.puppetlabs.net/windows/ruby/${rubyPkg}.7z", "$toolsDir\${rubyPkg}.7z")
+Write-Host "Downloading $buildSourcesURL/ruby/${rubyPkg}.7z"
+(New-Object net.webclient).DownloadFile("$buildSourcesURL/ruby/${rubyPkg}.7z", "$toolsDir\${rubyPkg}.7z")
 Invoke-External { & 7za x "$toolsDir\${rubyPkg}.7z" | FIND /V "ing " }
 
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")


### PR DESCRIPTION
Prior to this commit, we were building facter, pxp-agent, and
cpp-pcp-client with an outdated version of openssl and with a ruby that
was linked against the same outdated version of openssl.

Given that we are building everything else with a much more recent
version of openssl, we really really should continue to use that.

This commit also updates the paths that facter searches when linking.
We need to ensure all our dependency directories are included in the
search path, including openssl and ruby. This ensures facter will find
and correctly link against those libraries.

This commit addresses CVE-2015-7551