### PR TITLE
(PA-138) Build native software on windows with secure components

### DIFF
--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -28,7 +28,7 @@ $cmake_args = @(
   "MinGW Makefiles",
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\pcp-client;$toolsDir\$opensslPkg`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/bin/build-facter.ps1
+++ b/bin/build-facter.ps1
@@ -37,7 +37,7 @@ $cmake_args = @(
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
   "-DYAMLCPP_STATIC=ON",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-pxp-agent.ps1
+++ b/bin/build-pxp-agent.ps1
@@ -32,7 +32,7 @@ $cmake_args = @(
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
   "-DCMAKE_INSTALL_PREFIX=`"$sourceDir`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\pcp-client;$toolsDir\$opensslPkg`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -28,6 +28,7 @@ PRESERVE             = ENV['PRESERVE'] || false
 # Parsed information that we need to specify in order to know where to find different built facter bits
 # and correctly pass information to the facter build script
 script_arch          = "#{ARCH == 'x64' ? '64' : '32'}"
+ruby_arch            = ARCH == 'x64' ? 'x64' : 'i386'
 
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))
@@ -70,7 +71,7 @@ end
 
 # Set up the environment so I don't keep crying
 ssh_command = "ssh #{ssh_key} -tt -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null Administrator@#{hostname}"
-ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/tools/ruby21/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin\'"
+ssh_env = "export PATH=\'/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Program Files (x86)/Windows Installer XML v3.5/bin:/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/bin:/home/Administrator/deps/ruby-2.1.7-#{ruby_arch}-mingw32/bin\'"
 scp_command = "scp #{ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 result = Kernel.system("set -vx;#{ssh_command} \"echo \\\"#{ssh_env}\\\" >> ~/.bash_profile\"")
@@ -193,7 +194,7 @@ fail "It seems there were some issues cloning the puppet_for_the_win repo" unles
 Kernel.system("set -vx;#{scp_command} winconfig.yaml Administrator@#{hostname}:/home/Administrator/puppet_for_the_win/")
 
 # Build the MSI with automation in puppet_for_the_win
-result = Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} c:/tools/ruby21/bin/rake clobber windows:build config=winconfig.yaml\"")
+result = Kernel.system("set -vx;#{ssh_command} \"source .bash_profile ; cd /home/Administrator/puppet_for_the_win ; AGENT_VERSION_STRING=#{AGENT_VERSION_STRING} ARCH=#{ARCH} C:/cygwin64/home/Administrator/deps/ruby-2.1.7-#{ruby_arch}-mingw32/bin/rake clobber windows:build config=winconfig.yaml\"")
 fail "It seems there were some issues building the puppet-agent msi" unless result
 
 # Fetch back the built installer

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -27,13 +27,19 @@ $mingwThreads = "win32"
 if ($arch -eq 64) {
   $mingwExceptions = "seh"
   $mingwArch = "x86_64"
+  $opensslArch = "x64"
+  $rubyArch = "x64"
 } else {
   $mingwExceptions = "sjlj"
   $mingwArch = "i686"
+  $opensslArch = "x86"
+  $rubyArch = "i386"
 }
 $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
 
-$opensslPkg = "openssl-1.0.0s-x64-windows"
+$rubyPkg = "ruby-2.1.7-${rubyArch}-mingw32"
+
+$opensslPkg = "openssl-1.0.2e-${opensslArch}-windows"
 
 $curlVer = "curl-7.42.1"
 $curlPkg = "${curlVer}-${mingwVer}"
@@ -43,9 +49,8 @@ $Wix35_VERSION = '3.5.2519.20130612'
 $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 if ($arch -eq 32) {
   $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
+} else {
+  $env:PATH = "C:\tools\mingw64\bin;" + $env:PATH
 }
-$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
+$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd" + ";" + "$toolsDir\$rubyPkg\bin" + ";" + "$toolsDir\$opensslPkg\bin"
 Write-Host "Updated Path to $env:PATH"
-
-# SSL root pointer.
-$env:OPENSSL_ROOT_DIR = $toolsDir + "\" + $opensslPkg

--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -52,31 +52,19 @@ Install-Choco Wix35 $Wix35_VERSION $nugetTempFeed
 # - win32 threads, as the libpthread library is buggy
 # - seh exceptions on 64-bit, to work around an obscure bug loading Ruby in Facter
 if ($arch -eq 64) {
-  Install-Choco ruby 2.1.6 $nugetTempFeed
   Install-Choco mingw-w64 $mingwVerChoco $nugetTempFeed
   Install-Choco pl-boost-x64 1.58.0.2
   Install-Choco pl-toolchain-x64 2015.12.01.1
   Install-Choco pl-yaml-cpp-x64 0.5.1.2
 } else {
-  Install-Choco ruby 2.1.6  $nugetTempFeed @('-x86')
   Install-Choco mingw-w32 $mingwVerChoco  $nugetTempFeed @('-x86')
   Install-Choco pl-boost-x86 1.58.0.2
   Install-Choco pl-toolchain-x86 2015.12.01.1
   Install-Choco pl-yaml-cpp-x86 0.5.1.2
 }
-$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-if ($arch -eq 32) {
-  $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
-}
-$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd"
-Write-Host "Updated Path to $env:PATH"
 
 cd $toolsDir
 
-Write-Host "Tool Versions Installed:`n`n"
-$PSVersionTable.Keys | % { Write-Host "$_ : $($PSVersionTable[$_])" }
-@('git', 'cmake', 'mingw32-make', 'ruby', 'rake') |
-  % { Verify-Tool $_ }
 Verify-Tool '7za' ''
 
 if ($buildSource) {
@@ -100,11 +88,29 @@ if ($buildSource) {
 cd $toolsDir
 
 # Download openssl
-Write-Host "Downloading http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma"
-(New-Object net.webclient).DownloadFile("http://buildsources.delivery.puppetlabs.net/windows/openssl/${opensslPkg}.tar.lzma", "$toolsDir\${opensslPkg}.tar.lzma")
+Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${opensslPkg}.tar.lzma"
+(New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${opensslPkg}.tar.lzma", "$toolsDir\${opensslPkg}.tar.lzma")
 Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar.lzma" }
 mkdir $toolsDir\${opensslPkg}
 cd $toolsDir\${opensslPkg}
 Invoke-External { & 7za x "$toolsDir\${opensslPkg}.tar" }
 
 cd $toolsDir
+# Download ruby
+Write-Host "Downloading https://s3.amazonaws.com/kylo-pl-bucket/${rubyPkg}.7z"
+(New-Object net.webclient).DownloadFile("https://s3.amazonaws.com/kylo-pl-bucket/${rubyPkg}.7z", "$toolsDir\${rubyPkg}.7z")
+Invoke-External { & 7za x "$toolsDir\${rubyPkg}.7z" | FIND /V "ing " }
+
+$env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+if ($arch -eq 32) {
+    $env:PATH = "C:\tools\mingw32\bin;" + $env:PATH
+} else {
+    $env:PATH = "C:\tools\mingw64\bin;" + $env:PATH
+}
+$env:PATH += [Environment]::GetFolderPath('ProgramFiles') + "\Git\cmd" + ";" + "$toolsDir\$rubyPkg\bin" + ";" + "$toolsDir\$opensslPkg\bin"
+Write-Host "Updated Path to $env:PATH"
+
+Write-Host "Tool Versions Installed:`n`n"
+$PSVersionTable.Keys | % { Write-Host "$_ : $($PSVersionTable[$_])" }
+@('git', 'cmake', 'mingw32-make', 'ruby', 'rake', 'openssl') |
+  % { Verify-Tool $_ }


### PR DESCRIPTION
Prior to this commit, we were building facter, pxp-agent, and
cpp-pcp-client with an outdated version of openssl and with a ruby that
was linked against the same outdated version of openssl.

Given that we are building everything else with a much more recent
version of openssl, we really really should continue to use that.

This commit also updates the paths that facter searches when linking.
We need to ensure all our dependency directories are included in the
search path, including openssl and ruby. This ensures facter will find
and correctly link against those libraries.

Conflicts:
	bin/build-cpp-pcp-client.ps1
	bin/build-facter.ps1
	bin/windows-toolset.ps1