### PR TITLE
(maint) Use /bin/true instead of : for the null-test-run in leatherman

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -74,7 +74,7 @@ component "leatherman" do |pkg, settings, platform|
   # Make test will explode horribly in a cross-compile situation
   # Tests will be skipped on AIX until they are expected to pass
   if platform.architecture == 'sparc' || platform.is_aix?
-    test = ":"
+    test = "/bin/true"
   else
     test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{platform[:make]} test ARGS=-V"
   end


### PR DESCRIPTION
Becasue we're setting multiple environment variables for testing, we
need to use `env` to set them. Unfortunately, the null test case was
using `:`, which is a shell built-in. Using `/bin/true` instead of `:`
allows env to run (doing nothing)