### PR TITLE
(maint) Set GEM_HOME in project

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -11,11 +11,7 @@ component "ruby-stomp" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -11,11 +11,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -16,11 +16,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
 
     # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
     # Instead we use the host gem installation and override GEM_HOME. Yay?
-    if platform.is_windows?
-      pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-    else
-      pkg.environment "GEM_HOME" => settings[:gem_home]
-    end
+    pkg.environment "GEM_HOME" => settings[:gem_home]
 
     # PA-25 in order to install gems in a cross-compiled environment we need to
     # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -9,11 +9,7 @@ component "rubygem-hocon" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -9,11 +9,7 @@ component "rubygem-minitar" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -11,11 +11,7 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -9,11 +9,7 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-win32-eventlog.rb
+++ b/configs/components/rubygem-win32-eventlog.rb
@@ -9,11 +9,7 @@ component "rubygem-win32-eventlog" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -9,11 +9,7 @@ component "rubygem-win32-process" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -9,11 +9,7 @@ component "rubygem-win32-security" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -9,11 +9,7 @@ component "rubygem-win32-service" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  if platform.is_windows?
-    pkg.environment "GEM_HOME" => platform.convert_to_windows_path(settings[:gem_home])
-  else
-    pkg.environment "GEM_HOME" => settings[:gem_home]
-  end
+  pkg.environment "GEM_HOME" => settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -40,13 +40,14 @@ project "puppet-agent" do |proj|
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
-  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   if platform.is_windows?
+    proj.setting(:gem_home, platform.convert_to_windows_path(File.join(proj.libdir, "ruby", "gems", "2.1.0")))
     proj.setting(:host_ruby, File.join(proj.bindir, "ruby.exe"))
     proj.setting(:host_gem, File.join(proj.bindir, "gem.bat"))
   else
+    proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
     proj.setting(:host_ruby, File.join(proj.bindir, "ruby"))
     proj.setting(:host_gem, File.join(proj.bindir, "gem"))
   end


### PR DESCRIPTION
For windows, there is no reason we have GEM_HOME defined in the cygwin
path format. We shouldn't be converting it to a windows style path every
time we need it. Instead, we make sure it's a windows style patch from
the get-go.