### PR TITLE
(maint) Remove `env` from Leatherman tests

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -83,8 +83,6 @@ component "leatherman" do |pkg, settings, platform|
     test = "LANG=C #{test}"
   end
 
-  test = "env #{test}"
-
   pkg.build do
     # Until a `check` target exists, run tests are part of the build.
     [


### PR DESCRIPTION
This was originally put here to deal with environment variables on
solaris. We don't actually require it though.

This is currently only causing problems on windows when we deal with
different environments. `env` isn't available in the windows
environment, only in cygwin. So this fails when we need to exclude
everything cygwin from the path.