### PR TITLE
(PA-140) Specify builders for AIX targets

### DIFF
--- a/configs/platforms/aix-5.3-ppc.rb
+++ b/configs/platforms/aix-5.3-ppc.rb
@@ -13,4 +13,5 @@ platform "aix-5.3-ppc" do |plat|
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.14-2.aix5.1.ppc.rpm"
 
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs "
+  plat.build_host ["pe-aix-53-builder.delivery.puppetlabs.net"]
 end

--- a/configs/platforms/aix-6.1-ppc.rb
+++ b/configs/platforms/aix-6.1-ppc.rb
@@ -13,4 +13,5 @@ platform "aix-6.1-ppc" do |plat|
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs "
+  plat.build_host ["pe-aix-61-builder.delivery.puppetlabs.net"]
 end

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -13,4 +13,5 @@ platform "aix-7.1-ppc" do |plat|
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs "
+  plat.build_host ["pe-aix-71-builder.delivery.puppetlabs.net"]
 end


### PR DESCRIPTION
This commit enables the vanagon hardware engine for AIX builds by
specifying a specific builder to use. The hardware engine produces a
lock so that other builds/tests do not trample on the instance being
used during the build. Right now we're only specifying one host, but
this could easily be multiple if we had the builders available.