### PR TITLE
(PA-40) Remove unneeded binaries from dmidecode

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -17,7 +17,11 @@ component 'dmidecode' do |pkg, settings, platform|
   end
 
   pkg.install do
-    ["#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    [
+      "#{platform[:make]} prefix=#{settings[:prefix]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
+      "rm -f #{settings[:bindir]}/vpddecode #{settings[:bindir]}/biosdecode #{settings[:bindir]}/ownership",
+      "rm -f #{settings[:mandir]}/man8/ownership.8 #{settings[:mandir]}/man8/biosdecode.8 #{settings[:mandir]}/man8/vpddecode.8"
+    ]
   end
 end
 


### PR DESCRIPTION
We build our own dmidecode. This ships 3 items in the bin directory, but
we only need dmidecode for the puppet-agent package. So, this removes
vpddecode and biosdecode.