### PR TITLE
(RE-6194) Use updated ruby builds

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.7.1-x86",
-    "x64": "refs/tags/2.1.7.1-x64"
+    "x86": "refs/tags/2.1.7.2-x86",
+    "x64": "refs/tags/2.1.7.2-x64"
   }
 }


### PR DESCRIPTION
Ruby was rebuilt with a newer version of openssl. Use those for windows
puppet-agent builds.