### PR TITLE
(PA-142) Add ubuntu 15.10 to foss whitelist

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -28,6 +28,8 @@ foss_platforms:
   - ubuntu-14.04-i386
   - ubuntu-15.04-amd64
   - ubuntu-15.04-i386
+  - ubuntu-15.10-amd64
+  - ubuntu-15.10-i386
   - windows-2012-x86
   - windows-2012-x64
 pe_platforms:


### PR DESCRIPTION
Add ubuntu 15.10 to foss whitelist for shipping to nightlies.