### PR TITLE
(PA-156) bump vanagon to 0.5.0 to fix failing AIX builders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.4.1')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.5.0')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
AIX builders now use a build_host method that is only available
in vanagon 0.5, this commit simply bumps vanagon to 0.5 to
remedy the issue