### PR TITLE
(maint) provision Debian platforms with rsync

### DIFF
--- a/configs/platforms/cumulus-2.2-amd64.rb
+++ b/configs/platforms/cumulus-2.2-amd64.rb
@@ -18,7 +18,7 @@ apt-get dist-upgrade -qy --force-yes -o Dpkg::Options::="--force-confold" --allo
 echo 'deb http://osmirror.delivery.puppetlabs.net/debian/ wheezy main
 deb http://osmirror.delivery.puppetlabs.net/debian/ wheezy-updates main' >> /etc/apt/sources.list
 apt-get update -qq
-apt-get install -qy --no-install-recommends build-essential make quilt pkg-config debhelper devscripts
+apt-get install -qy --no-install-recommends build-essential make quilt pkg-config debhelper devscripts rsync
 )
 
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "

--- a/configs/platforms/debian-6-amd64.rb
+++ b/configs/platforms/debian-6-amd64.rb
@@ -5,7 +5,7 @@ platform "debian-6-amd64" do |plat|
   plat.codename "squeeze"
 
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-6-x86_64"
 end

--- a/configs/platforms/debian-6-i386.rb
+++ b/configs/platforms/debian-6-i386.rb
@@ -5,7 +5,7 @@ platform "debian-6-i386" do |plat|
   plat.codename "squeeze"
 
   plat.apt_repo "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-squeeze.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-6-i386"
 end


### PR DESCRIPTION
prior to this commit we did not ensure Debian Squeeze and Cumulus 2.2
was provisioned with rsync ( which is a requirement of Vanagon ).