### PR TITLE
(maint) Remove obsolete definitions for huaweios

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -27,7 +27,7 @@ component 'augeas' do |pkg, settings, platform|
 
   if platform.is_rpm? && !platform.is_aix?
     pkg.build_requires 'readline-devel'
-    if platform.is_cisco_wrlinux? || platform.is_huaweios?
+    if platform.is_cisco_wrlinux?
       pkg.requires 'libreadline6'
     else
       pkg.requires 'readline'

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -33,11 +33,6 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
     pkg.build_requires "yaml-cpp --with-static-lib"
-  elsif platform.name =~ /huaweios/
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-gcc-4.8.2-1.huaweios6.ppce500mc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-cmake-3.2.3-1.huaweios6.ppce500mc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-boost-1.58.0-1.huaweios6.ppce500mc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-yaml-cpp-0.5.1-1.huaweios6.ppce500mc.rpm"
   elsif platform.name =~ /solaris-10/
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -6,9 +6,7 @@ component "openssl" do |pkg, settings, platform|
   pkg.replaces 'pe-openssl'
 
   # Use our toolchain on linux systems (it's not available on osx)
-  if platform.is_huaweios?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/HuaweiOS/#{platform.os_version}/ppce500mc/pl-gcc-4.8.2-1.huaweios6.ppce500mc.rpm"
-  elsif platform.is_linux?
+  if platform.is_linux?
     pkg.build_requires 'pl-binutils'
     pkg.build_requires 'pl-gcc'
     if platform.name =~ /el-4/

--- a/configs/platforms/huaweios-6-ppce500mc.rb
+++ b/configs/platforms/huaweios-6-ppce500mc.rb
@@ -1,8 +1,0 @@
-platform "huaweios-6-ppce500mc" do |plat|
-  plat.servicedir "/etc/init.d"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "sysv"
-
-  # This is how we clean up our last build since we don't have a pooler image
-  plat.provision_with "rm -rf /opt/pl-build-tools /opt/puppetlabs /etc/puppetlabs /var/log/puppetlabs /var/tmp/root-root /var/tmp/rpm /var/tmp/tmp.* /home/root/*.jam"
-end


### PR DESCRIPTION
This removes obsolete code referring to HuaweiOS when it was targeted for
WRL/RPM.