### PR TITLE
(RE-6143) Use ruby 2.1.8 with windows

### DIFF
--- a/bin/build-windows.rb
+++ b/bin/build-windows.rb
@@ -29,7 +29,7 @@ PRESERVE             = ENV['PRESERVE'] || false
 # and correctly pass information to the facter build script
 script_arch          = ARCH == 'x64' ? '64' : '32'
 ruby_arch            = ARCH == 'x64' ? 'x64' : 'i386'
-ruby_version         = "2.1.7"
+ruby_version         = "2.1.8"
 
 # The refs we will use when building the MSI
 PUPPET       = JSON.parse(File.read('configs/components/puppet.json'))

--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -37,7 +37,7 @@ if ($arch -eq 64) {
 }
 $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExceptions}"
 
-$rubyPkg = "ruby-2.1.7-${rubyArch}-mingw32"
+$rubyPkg = "ruby-2.1.8-${rubyArch}-mingw32"
 
 $opensslPkg = "openssl-1.0.2e-${opensslArch}-windows"
 

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.7.2-x86",
-    "x64": "refs/tags/2.1.7.2-x64"
+    "x86": "refs/tags/2.1.8.0-x86",
+    "x64": "refs/tags/2.1.8.0-x64"
   }
 }


### PR DESCRIPTION
To address CVE-2015-7551 we need to update from ruby 2.1.7 to ruby
2.1.8.