### PR TITLE
(maint) bump Xcode CLT to 7.2 on OSX 10.10

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -3,7 +3,7 @@ platform "osx-10.10-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "yosemite"
 
-  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.1"'
+  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.2"'
   plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
   plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
   plat.vmpooler_template "osx-1010-x86_64"


### PR DESCRIPTION
During provisioning we update the CLT on OSX.  Apple has removed 7.1
for OSX 10.10 and has made 7.2 available.  This commit updates the
provisioning process to install 7.2.