### PR TITLE
(PE-13590) Update pl-gcc build to fix solaris 10 linking

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -34,7 +34,7 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires "boost"
     pkg.build_requires "yaml-cpp --with-static-lib"
   elsif platform.name =~ /solaris-10/
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2-1.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-boost-1.58.0-1.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-yaml-cpp-0.5.1.#{platform.architecture}.pkg.gz"

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -14,7 +14,7 @@ component "openssl" do |pkg, settings, platform|
     end
   elsif platform.is_solaris?
     if platform.os_version == "10"
-      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2-1.#{platform.architecture}.pkg.gz"
       pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
     elsif platform.os_version == "11"
       pkg.build_requires "pl-gcc-#{platform.architecture}"

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -1,7 +1,7 @@
 # This component exists to link in the gcc and stdc++ runtime libraries as well as libssp.
 component "runtime" do |pkg, settings, platform|
   if platform.name =~ /solaris-10/
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2.#{platform.architecture}.pkg.gz"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2-1.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"
   elsif platform.name =~ /solaris-11/
     pkg.build_requires "pl-gcc-#{platform.architecture}"


### PR DESCRIPTION
The version of pl-gcc that is currently used in the solaris 10
build does not properly set the library rpath, leading to issues
if the user has an incompatible build of GCC in their default system
library path.

This updates to a more recent build that sets the rpath correctly.
The issue was fixed in the pl-build-tools repo a while back, but
puppet-agent was never updated to use the newer build.

The version of GCC itself does not changed, just the linker flags passed
to the build.