### PR TITLE
ppc64le support

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -25,8 +25,14 @@ component "libxslt" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc-#{platform.architecture}"
   end
 
+  if platform.is_linux?
+    if platform.architecture =~ /ppc64le$/
+      target = 'powerpc64le-unknown-linux-gnu'
+    end
+  end
+
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]} #{settings[:host]}"]
+    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]} #{settings[:host]} #{target}"]
   end
 
   pkg.build do

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -61,6 +61,8 @@ component "openssl" do |pkg, settings, platform|
       target = 'linux-x86_64'
     elsif platform.architecture =~ /ppce500mc$/
       target = 'linux-ppc'
+    elsif platform.architecture =~ /ppc64le$/
+      target = 'linux-ppc64le'
     elsif platform.architecture =~ /s390/
       target = 'linux64-s390x'
     end

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -17,8 +17,14 @@ component "virt-what" do |pkg, settings, platform|
     pkg.build_requires "util-linux"
   end
 
+  if platform.is_linux?
+    if platform.architecture =~ /ppc64le$/
+      target = 'powerpc64le-unknown-linux-gnu'
+    end
+  end
+
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what"]
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{target}"]
   end
 
   pkg.build do

--- a/configs/platforms/el-7-ppc64le.rb
+++ b/configs/platforms/el-7-ppc64le.rb
@@ -1,0 +1,8 @@
+platform "el-7-ppc64le" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+end


### PR DESCRIPTION
With this change I can successfully build puppet-agent on RHEL 7.2 ppc64le.

I suspect there is a better way to implement the changes libxslt.rb and virt-what.rb. I'll gladly update this patch set.

I plan on submitting upstream bug reports requesting config.guess gets updated in virt-what and libxslt.