### PR TITLE
(PCP-209) Remove leatherman git submodule from cpp-pcp-client

### DIFF
--- a/bin/build-cpp-pcp-client.ps1
+++ b/bin/build-cpp-pcp-client.ps1
@@ -28,7 +28,7 @@ $cmake_args = @(
   "MinGW Makefiles",
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg;$toolsDir\leatherman`"",
   "-DCMAKE_INSTALL_PREFIX=`"$toolsDir\pcp-client`"",
   "-DCURL_STATIC=ON",
   ".."

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -6,6 +6,8 @@ component "cpp-pcp-client" do |pkg, settings, platform|
 
   platform_flags = ''
   pkg.build_requires "openssl"
+  pkg.build_requires "leatherman"
+
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"


### PR DESCRIPTION
With this commit, we add leatherman's path to cpp-pcp-client's
CMAKE_PREFIX_PATH and we require leatherman's package when building
cpp-pcp-client.

Those changes are required after removing leatherman's git submodule
from cpp-pcp-client.