### PR TITLE
(PCP-209) Remove leatherman git submodule from pxp-agent

### DIFF
--- a/bin/build-pxp-agent.ps1
+++ b/bin/build-pxp-agent.ps1
@@ -32,7 +32,7 @@ $cmake_args = @(
   "-DCMAKE_TOOLCHAIN_FILE=C:/tools/pl-build-tools/pl-build-toolchain.cmake",
   "-DBOOST_STATIC=ON",
   "-DCMAKE_INSTALL_PREFIX=`"$sourceDir`"",
-  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg;$toolsDir\pcp-client`"",
+  "-DCMAKE_PREFIX_PATH=`"$toolsDir\$curlPkg;$toolsDir\$opensslPkg;$toolsDir\$rubyPkg;$toolsDir\pcp-client;$toolsDir\leatherman`"",
   "-DCURL_STATIC=ON",
   ".."
 )

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -6,6 +6,7 @@ component "pxp-agent" do |pkg, settings, platform|
   pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
 
   pkg.build_requires "openssl"
+  pkg.build_requires "leatherman"
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -7,6 +7,7 @@ component "pxp-agent" do |pkg, settings, platform|
 
   pkg.build_requires "openssl"
   pkg.build_requires "leatherman"
+  pkg.build_requires "cpp-pcp-client"
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"


### PR DESCRIPTION
With this commit, we add leatherman's path to cpp-pcp-client's
CMAKE_PREFIX_PATH and we require leatherman's package when building
pxp-agent.

Those changes are required after removing leatherman's git submodule
from pxp-agent. Note that cpp-pcp-client's submodule has been removed as
well but no change in puppet-agent's build scripts should be necessary
since cpp-pcp-client dependency is managed directly.