### PR TITLE
(MAINT) Update win-2012 Pooler template reference

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -1,5 +1,5 @@
 platform "windows-2012r2-x64" do |plat|
-  plat.vmpooler_template "win-2012r2-x86_64.make"
+  plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
 

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -1,5 +1,5 @@
 platform "windows-2012r2-x86" do |plat|
-  plat.vmpooler_template "win-2012r2-x86_64.make"
+  plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
 


### PR DESCRIPTION
The win-2012r2-x86_64.make pooler template has been switched to live
production, so windows platform needs updating.
See RE-6093