### PR TITLE
(PA-148) update component tags for 1.3.3 release

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "c08a5ed7606b6cd8be3a146b247c03bf7213c445"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.1.4"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "d12b1947f02069054c3ec4fb5eed54e36da79490"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.0.6"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "280674ff8e2cb4ee62ad24fec67f40e2e9110fa3"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.3.2"}


### PR DESCRIPTION
this will update tags for puppet (to 4.3.2)
hiera (to 3.0.6) and facter (to 3.1.4)