### PR TITLE
Update the tag for puppet_for_the_win

### DIFF
--- a/configs/components/windows_puppet.json
+++ b/configs/components/windows_puppet.json
@@ -1,4 +1,4 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet_for_the_win.git",
-  "ref": "origin/stable"
+  "ref": "refs/tags/4.3.2"
 }


### PR DESCRIPTION
Tags for puppet_for_the_win have been pushed
for the recent update to puppet 4.3.2, this
commit remedies the reference in puppet-agent
to puppet_for_the_win