### PR TITLE
Fix ref: fields in puppet agent to match

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,2 +1,2 @@
-{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "1.0.1"}
+{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.0.1"}
 

--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
   "url": "git@github.com:puppetlabs/puppet-ca-bundle.git",
-  "ref": "1.0.7"
+  "ref": "refs/tags/1.0.7"
 }


### PR DESCRIPTION
For posterity we would like to make sure all ref: fields
in puppet-agent components all look the same: i.e. each
component json has ref:"refs/tags/####" not just
ref:"####"