### PR TITLE
(RE-6251,6252) remove external build dependencies on OSX

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -32,7 +32,7 @@ component "facter" do |pkg, settings, platform|
   if platform.is_osx?
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
-    pkg.build_requires "yaml-cpp --with-static-lib"
+    pkg.build_requires "yaml-cpp"
   elsif platform.name =~ /solaris-10/
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2-1.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.25.#{platform.architecture}.pkg.gz"

--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -3,8 +3,11 @@ platform "osx-10.10-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "yosemite"
 
-  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X 10.10) for Xcode-7.2"'
-  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
-  plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
+  plat.provision_with 'mkdir /usr/local; curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
+  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
+  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
+  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1010-x86_64"
 end

--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -3,7 +3,11 @@ platform "osx-10.11-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "elcapitan"
 
-  plat.provision_with 'cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; /usr/local/bin/brew install pkgconfig'
-  plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
+  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
+  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
+  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1011-x86_64"
 end

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -3,8 +3,11 @@ platform "osx-10.9-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "mavericks"
 
-  plat.provision_with 'softwareupdate -i "Command Line Tools (OS X Mavericks)-6.2"'
-  plat.provision_with 'mkdir /usr/local; cd /usr/local; git clone https://github.com/Homebrew/homebrew.git .; git checkout ab475 -- Library/Formula/boost.rb; /usr/local/bin/brew install pkgconfig'
-  plat.install_build_dependencies_with "PATH=$PATH:/usr/local/bin brew install "
+  plat.provision_with 'mkdir /usr/local; curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
+  plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
+  plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-6.2 pkg-config'
+  plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-109-x86_64"
 end


### PR DESCRIPTION
This PR attempts to remove external build dependencies on OSX.

* The required CLT updates are now installed via a DMG that is hosted locally.  

* brew is now installed from a tar ball that is hosted locally, a private tap has been created for required build tools, and a local bottle mirror is utilized.  The build tool formulas for versions we require were pulled from upstream and only slight modifications were made ( update/add checksum for bottles if required and default to build yaml-cpp with static libs ).

* A wrapper script is utilized to assist in installing packages via the OSX installer ( for DMGs such as the CLT ) and brew ( for build dependencies ).  All necessary bits are currently hosted on pl-build-tools.

There's certainly opportunity for additional automation here.

