### PR TITLE
(PA-187) Install environment.bat on windows

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -1,6 +1,10 @@
 component "puppet" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet.json")
 
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/environment.bat", sum: "c698da37e559935e904f8690dd5c26fa")
+  end
+
   pkg.build_requires "ruby"
   pkg.build_requires "facter"
   pkg.build_requires "hiera"
@@ -142,6 +146,9 @@ component "puppet" do |pkg, settings, platform|
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
 
+  if platform.is_windows?
+    pkg.install_file "../environment.bat", "#{settings[:bindir]}/environment.bat"
+  end
 
   pkg.configfile File.join(configdir, 'puppet.conf')
   pkg.configfile File.join(configdir, 'auth.conf')

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -1,0 +1,19 @@
+@ECHO OFF
+REM This is the parent directory of the directory containing this script.
+SET "PL_BASEDIR=%~dp0.."
+REM Avoid the nasty \..\ littering the paths.
+SET "PL_BASEDIR=%PL_BASEDIR:\bin\..=%"
+
+REM Set a fact so we can easily source the environment.bat file in the future.
+SET "FACTER_env_windows_installdir=%PL_BASEDIR%"
+SET "FACTERDIR=%PL_BASEDIR%"
+
+SET "PATH=%PL_BASEDIR%\bin;%PATH%"
+
+REM Enable rubygems support
+SET RUBYOPT=rubygems
+REM Now return to the caller.
+
+REM Set SSL variables to ensure trusted locations are used
+SET "SSL_CERT_FILE=%PL_BASEDIR%\ssl\cert.pem"
+SET "SSL_CERT_DIR=%PL_BASEDIR%\ssl\certs"


### PR DESCRIPTION
In puppet-agent on windows, we need to install environment.bat so our
batch files can have access to a cohesive group of environment
variables, etc. This commit adds that.