### PR TITLE
(maint) Add elevate.exe to ruby on windows

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -3,6 +3,11 @@ component "ruby" do |pkg, settings, platform|
   pkg.md5sum "091b62f0a9796a3c55de2a228a0e6ef3"
   pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
+  if platform.is_windows?
+    pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
+    pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
+  end
+
   pkg.replaces 'pe-ruby'
   pkg.replaces 'pe-ruby-mysql'
   pkg.replaces 'pe-rubygems'
@@ -148,6 +153,11 @@ component "ruby" do |pkg, settings, platform|
 
   pkg.install do
     "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"
+  end
+
+  if platform.is_windows?
+    pkg.install_file "../elevate.exe", "#{settings[:bindir]}/elevate.exe"
+    pkg.install_file "../elevate.exe.config", "#{settings[:bindir]}/elevate.exe.config"
   end
 
   if platform.is_solaris? || platform.is_aix?

--- a/resources/files/windows/elevate.exe.config
+++ b/resources/files/windows/elevate.exe.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+      <supportedRuntime version="v4.0.30319" />
+      <supportedRuntime version="v3.5" />
+      <supportedRuntime version="v3.0" />
+      <supportedRuntime version="v2.0.50727" />
+    </startup>
+</configuration>


### PR DESCRIPTION
This is an executable compiled by Josh Cooper and used to run our
projects interactively

We need elevate.exe.config to allow elevate.exe to run against .NET 4.
See
puppetlabs/puppet-win32-ruby@70847bd
and PUP-1951 for more information.

elevate.exe is used to run our project with elevated permissions. This
doesn't work in a cygwin environment, but otherwise allows facter and
puppet to request UAC elevation and run in a command prompt window with
administrator privileges.