### PR TITLE
(PA-185) Use publicly available URIs for git clone

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,2 +1,2 @@
-{"url": "git@github.com:puppetlabs/cpp-pcp-client.git", "ref": "master"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "master"}
 

--- a/configs/components/puppet-ca-bundle.json
+++ b/configs/components/puppet-ca-bundle.json
@@ -1,4 +1,4 @@
 {
-  "url": "git@github.com:puppetlabs/puppet-ca-bundle.git",
+  "url": "git://github.com/puppetlabs/puppet-ca-bundle.git",
   "ref": "refs/tags/1.0.7"
 }

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:puppetlabs/pxp-agent.git", "ref": "5b8ffc93d78374f0bf202d0e804a01e5ff1c19c6"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "5b8ffc93d78374f0bf202d0e804a01e5ff1c19c6"}


### PR DESCRIPTION
Prior to this, some components were accessing github over SSH which is
something that most of the world can't do. This commit changes to using
the public URIs. Thus removing one of many issues when trying to build
puppet-agent outside of Puppet Labs.