### PR TITLE
(maint) Only check reqs on windows

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -109,15 +109,17 @@ component "puppet" do |pkg, settings, platform|
   if platform.is_windows?
     vardir = File.join(settings[:sysconfdir], 'puppet', 'cache')
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
+    prereqs = "--check-prereqs"
   else
     vardir = File.join(settings[:prefix], 'cache')
     configdir = settings[:puppet_configdir]
+    prereqs = "--no-check-prereqs"
   end
   pkg.install do
     [
       "#{settings[:host_ruby]} install.rb \
         --ruby=#{File.join(settings[:bindir], 'ruby')} \
-        --check-prereqs \
+        #{prereqs} \
         --bindir=#{settings[:bindir]} \
         --configdir=#{configdir} \
         --sitelibdir=#{settings[:ruby_vendordir]} \


### PR DESCRIPTION
In install.rb, the check-prereqs flag will check the system we are
running on and check to see if our requirements for install are
available. This requires that facter can run on the build system. This
is generally fine except when we are cross compiling. This flag also
enables some windows-specific functionality.

Because we need the extra functionality only on windows, we only need to
set this flag for windows. Everything else, including systems we cross
compile on, shouldn't need to check prereqs