### PR TITLE
(maint) Install pid files and log files into ProgramData

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -125,6 +125,10 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.directory configdir
   pkg.directory plugindir
 
+  if platform.is_windows?
+    pkg.directory File.join(settings[:sysconfdir], 'mcollective', 'var', 'log')
+  end
+
   # Bring in the client.cfg and server.cfg from ext/aio.
   pkg.install_file "ext/aio/common/client.cfg.dist", File.join(configdir, 'client.cfg')
   pkg.install_file "ext/aio/common/server.cfg.dist", File.join(configdir, 'server.cfg')

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -184,10 +184,14 @@ component "puppet" do |pkg, settings, platform|
   if platform.is_windows?
     vardir = File.join(settings[:sysconfdir], 'puppet', 'cache')
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
+    logdir = File.join(settings[:sysconfdir], 'puppet', 'var', 'log')
+    piddir = File.join(settings[:sysconfdir], 'puppet', 'var', 'run')
     prereqs = "--check-prereqs"
   else
     vardir = File.join(settings[:prefix], 'cache')
     configdir = settings[:puppet_configdir]
+    logdir = settings[:logdir]
+    piddir = settings[:piddir]
     prereqs = "--no-check-prereqs"
   end
   pkg.install do
@@ -200,8 +204,8 @@ component "puppet" do |pkg, settings, platform|
         --sitelibdir=#{settings[:ruby_vendordir]} \
         --codedir=#{settings[:puppet_codedir]} \
         --vardir=#{vardir} \
-        --rundir=#{settings[:piddir]} \
-        --logdir=#{settings[:logdir]} \
+        --rundir=#{piddir} \
+        --logdir=#{logdir} \
         --configs \
         --quick \
         --man \
@@ -242,7 +246,13 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'manifests')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'modules')
   pkg.install_configfile 'conf/environment.conf', File.join(settings[:puppet_codedir], 'environments', 'production', 'environment.conf')
-  pkg.directory File.join(settings[:logdir], 'puppet'), mode: "0750"
+
+  if platform.is_windows?
+    pkg.directory File.join(settings[:sysconfdir], 'puppet', 'var', 'log')
+    pkg.directory File.join(settings[:sysconfdir], 'puppet', 'var', 'run')
+  else
+    pkg.directory File.join(settings[:logdir], 'puppet'), mode: "0750"
+  end
 
   pkg.link "#{settings[:bindir]}/puppet", "#{settings[:link_bindir]}/puppet" unless platform.is_windows?
   if platform.is_eos?

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -72,11 +72,13 @@ component "pxp-agent" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'etc', 'modules')
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'spool')
+    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'log')
+    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'run')
   else
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
     pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool')
+    pkg.directory File.join(settings[:logdir], 'pxp-agent')
   end
-  pkg.directory File.join(settings[:logdir], 'pxp-agent')
 
   case platform.servicetype
   when "systemd"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -36,8 +36,6 @@ project "puppet-agent" do |proj|
     proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id))
     proj.setting(:prefix, File.join(proj.install_root, proj.product_id))
     proj.setting(:sysconfdir, File.join("C:", "CommonAppDataFolder", proj.company_id))
-    proj.setting(:logdir, File.join(proj.sysconfdir, "var", "log"))
-    proj.setting(:piddir, File.join(proj.sysconfdir,  "var", "run"))
     proj.setting(:tmpfilesdir, "C:/Windows/Temp")
   else
     proj.setting(:install_root, "/opt/puppetlabs")
@@ -213,7 +211,7 @@ project "puppet-agent" do |proj|
   proj.directory proj.prefix
   proj.directory proj.sysconfdir
   proj.directory proj.link_bindir
-  proj.directory proj.logdir
-  proj.directory proj.piddir
+  proj.directory proj.logdir unless platform.is_windows?
+  proj.directory proj.piddir unless platform.is_windows?
 
 end


### PR DESCRIPTION
Since we need to maintain a consistent set of files in our MSI, we need
to set the pid and log dirs to be consistent locations to what has
already been established.