### PR TITLE
(PA-160) Add platform config for huaweios-6-ppc

### DIFF
--- a/configs/platforms/huaweios-6-ppc.rb
+++ b/configs/platforms/huaweios-6-ppc.rb
@@ -1,0 +1,12 @@
+platform "huaweios-6-ppc" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "jessie"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  # We're cross-compiling the agent for ppc using the x86_64 template
+  plat.vmpooler_template "debian-8-x86_64"
+end


### PR DESCRIPTION
The HuaweiOS environment is based on a containerized instance of
Debian 8, and runs on PPC hardware. We are using the x86_64 debian 8
pooler template to run cross-compiled builds from.