### PR TITLE
(MAINT) Fixed spelling mistake in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ can be found [here](https://github.com/puppetlabs/puppet-agent-osx-installer-plu
 
 Issues
 ---
-File issues in the [Pupept Agent (PA) project](https://tickets.puppetlabs.com/browse/PA) on the Puppet Labs Jira site. Issues with individual components should be filed in their respective projects.
+File issues in the [Puppet Agent (PA) project](https://tickets.puppetlabs.com/browse/PA) on the Puppet Labs Jira site. Issues with individual components should be filed in their respective projects.
 
 License
 ---


### PR DESCRIPTION
I just noticed this. Its just to correct the spelling of the link title.