### PR TITLE
(MAIN) Point to production Win-2012r2 template

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -1,5 +1,5 @@
 platform "windows-2012r2-x64" do |plat|
-  plat.vmpooler_template "win-2012r2-x86_64.make"
+  plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
 

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -1,5 +1,5 @@
 platform "windows-2012r2-x86" do |plat|
-  plat.vmpooler_template "win-2012r2-x86_64.make"
+  plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
 


### PR DESCRIPTION
The cygwin updates for vanagon are now in production, so the VM Pooler
platform needs to be updated.