### PR TITLE
(maint) Update conflicting components after merge-up

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "8150368f38349f1dbf44e25a238c5e3d00dcda21"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "7c86863931e83ce9215aa35ccca7780ba33029fc"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:puppetlabs/pxp-agent.git", "ref": "e076bb03c64ae5bf83329470cc92c54c894550ff"}
+{"url": "git@github.com:puppetlabs/pxp-agent.git", "ref": "84a5fe67ff7c94f1e297118d98051c6c467108b0"}


### PR DESCRIPTION
Merging master to stable left two components - facter and pxp-agent -
unable to update independently. The old SHAs use a vendored Leatherman,
but a flaw in how they added Leatherman include directories means the
installed Leatherman causes a conflict. That would be fine if it were
just one (that one would pass on update), but since two components have
that issue the one not being updated will cause a build failure.

Update them concurrently to the latest SHA to bypass the issue.