### PR TITLE
(PA-141) Don't enable pxp-agent service on install

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -62,9 +62,13 @@ component "pxp-agent" do |pkg, settings, platform|
   when "systemd"
     pkg.install_service "ext/systemd/pxp-agent.service", "ext/redhat/pxp-agent.sysconfig"
     pkg.install_configfile "ext/systemd/pxp-agent.logrotate", "/etc/logrotate.d/pxp-agent"
+    if platform.is_deb?
+      pkg.add_postinstall_action ["install"], ["systemctl disable pxp-agent.service >/dev/null || :"]
+    end
   when "sysv"
     if platform.is_deb?
       pkg.install_service "ext/debian/pxp-agent.init", "ext/debian/pxp-agent.default"
+      pkg.add_postinstall_action ["install"], ["update-rc.d pxp-agent disable > /dev/null || :"]
     elsif platform.is_sles?
       pkg.install_service "ext/suse/pxp-agent.init", "ext/redhat/pxp-agent.sysconfig"
     elsif platform.is_rpm?


### PR DESCRIPTION
When installing a fresh puppet-agent package on a debian-based system,
our services will be enabled but not running by default. This means that
on restart, our services will start running. This goes against what
happens on rpm systems, which do not start services by default.

This is fine for the most part, but given pxp-agent is a new product and
is not usable outside of PE, we want to ensure it is disabled by default
on a fresh install.

This will not impact users who are upgrading. If they have the pxp-agent
service running, it will restart. If they have the service disabled, it
will remain that way.