### PR TITLE
(RE-6663) Update openssl for march CVEs

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -1,6 +1,6 @@
 component "openssl" do |pkg, settings, platform|
-  pkg.version "1.0.2f"
-  pkg.md5sum "b3bf73f507172be9292ea2a8c28b659d"
+  pkg.version "1.0.2g"
+  pkg.md5sum "f3c710c045cdee5fd114feb69feba7aa"
   pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-openssl'


### PR DESCRIPTION
This will update the puppet-agent openssl to 1.0.2g in order
to facilitate fixes for the openssl march CVEs

build succeeded at http://jenkins-release.delivery.puppetlabs.net/job/vanagon_generic_job/310/