### PR TITLE
(RE-6640) Service Specific Files for Vanagon

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -66,7 +66,9 @@ component "marionette-collective" do |pkg, settings, platform|
   when "aix"
     pkg.install_service "resources/aix/mcollective.service", nil, "mcollective"
   when "windows"
-    puts "Service files not enabled on windows"
+    # Note - this definition indicates that the file should be filtered out from the Wix
+    # harvest. A corresponding service definition file is also required in resources/windows/wix
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\rubyw.exe"
   else
     fail "need to know where to put service files"
   end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -64,7 +64,9 @@ component "puppet" do |pkg, settings, platform|
   when "aix"
     pkg.install_service "resources/aix/puppet.service", nil, "puppet"
   when "windows"
-    puts "Service files not enabled on windows"
+    # Note - this definition indicates that the file should be filtered out from the Wix
+    # harvest. A corresponding service definition file is also required in resources/windows/wix
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\ruby.exe"
   else
     fail "need to know where to put service files"
   end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -103,7 +103,9 @@ component "pxp-agent" do |pkg, settings, platform|
   when "aix"
     pkg.install_service "resources/aix/pxp-agent.service", nil, "pxp-agent"
   when "windows"
-    puts "Service files not enabled on windows"
+    # Note - this definition indicates that the file should be filtered out from the Wix
+    # harvest. A corresponding service definition file is also required in resources/windows/wix
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm.exe"
   else
     fail "need to know where to put #{pkg.get_name} service files"
   end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -6,6 +6,7 @@ project "puppet-agent" do |proj|
     proj.setting(:company_name, "Puppet Labs")
     proj.setting(:company_id, "PuppetLabs")
     proj.setting(:common_product_id, "PuppetInstaller")
+    proj.setting(:puppet_service_name, "puppet")
     proj.setting(:product_id, "Puppet")
     proj.setting(:upgrade_code, "2AD3D11C-61B3-4710-B106-B4FDEC5FA358")
     if platform.architecture == "x64"

--- a/resources/windows/wix/service.mcollective.wxs.erb
+++ b/resources/windows/wix/service.mcollective.wxs.erb
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <ComponentGroup Id="Service_MARIONETTECOLLECTIVE">
+      <ComponentRef Id="Service_MARIONETTECOLLECTIVE_svc" />
+    </ComponentGroup>
+
+    <DirectoryRef Id="MARIONETTECOLLECTIVEBINDIR">
+      <Component Id='Service_MARIONETTECOLLECTIVE_svc'
+                 Guid="7601FCEA-90B3-CC69-6A69-4087FBC7292D"
+                 Win64="<%= settings[:win64] %>">
+        <File Id="RubyWExe"
+              KeyPath="yes"
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\rubyw.exe" />
+        <!-- This service is installed with start set to demand because
+        it won't be correctly configured to start right away. The
+        puppet run that configures mcollective will allow it to start
+        and set it to automatic -->
+        <ServiceInstall Id="MCOServiceInstaller"
+          Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+          Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+          Description="Puppet Labs server orchestration framework"
+          DisplayName="Marionette Collective Server"
+          Interactive="no"
+          Name="mcollective"
+          Start="demand"
+          Type="ownProcess"
+          ErrorControl="normal"
+          Vital="yes"
+          Arguments="-I&quot;[INSTALLDIR]puppet\lib&quot; -rubygems &quot;[INSTALLDIR]puppet\bin\mcollectived&quot; --daemonize"
+          />
+        <ServiceControl Id="MCOStartService"
+                        Stop="both"
+                        Remove="uninstall"
+                        Name="mcollective"
+                        Wait="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <Fragment>
+    <ComponentGroup Id="Service_PUPPET">
+      <ComponentRef Id="PuppetServiceAutomatic" />
+      <ComponentRef Id="PuppetServiceManual" />
+      <ComponentRef Id="PuppetServiceDisabled" />
+    </ComponentGroup>
+
+    <DirectoryRef Id="PUPPETBINDIR">
+      <!--Seriously?... http://stackoverflow.com/questions/9419411/wix-setting-service-startup-type-using-a-property-property-not-recognized -->
+      <!-- Yep, Seriously - http://sourceforge.net/mailarchive/forum.php?thread_name=CANJN1a6gDE2tUUnP4SE05m8Ojh2q0Y8LrWOxbrF89YyJJCHn1A%40mail.gmail.com&forum_name=wix-users -->
+      <Component Id='PuppetServiceAutomatic'
+                 Guid="639ECD7F-6186-43D5-9E1A-FC0278DBEE15"
+                 Win64="<%= settings[:win64] %>">
+        <Condition>
+          <![CDATA[ (PUPPET_AGENT_STARTUP_MODE ~<> "manual") AND (PUPPET_AGENT_STARTUP_MODE ~<> "disabled") ]]>
+        </Condition>
+        <File Id="RubyExeAutomatic"
+              KeyPath="yes"
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+
+        <ServiceInstall Id="ServiceInstaller"
+                        Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+                        Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+                        Description="Periodically fetches and applies configurations from a Puppet master server."
+                        DisplayName="Puppet Agent"
+                        Interactive="no"
+                        Name="<%= settings[:puppet_service_name] %>"
+                        Start="auto"
+                        Type="ownProcess"
+                        ErrorControl="normal"
+                        Vital="yes"
+                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+        <ServiceControl Id="ServiceControlOptions"
+                        Start="install"
+                        Stop="both"
+                        Remove="uninstall"
+                        Name="<%= settings[:puppet_service_name] %>"
+                        Wait="yes" />
+      </Component>
+
+      <Component Id='PuppetServiceManual'
+                 Guid="752A5A25-9619-4EBA-AA8B-12D8C8688236"
+                 Win64="<%= settings[:win64] %>">
+        <Condition>
+          <![CDATA[PUPPET_AGENT_STARTUP_MODE ~= "manual"]]>
+        </Condition>
+        <File Id="RubyExeManual"
+              KeyPath="yes"
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+
+        <ServiceInstall Id="ServiceInstallerManual"
+                        Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+                        Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+                        Description="Periodically fetches and applies configurations from a Puppet master server."
+                        DisplayName="Puppet Agent"
+                        Interactive="no"
+                        Name="<%= settings[:puppet_service_name] %>"
+                        Start="demand"
+                        Type="ownProcess"
+                        ErrorControl="normal"
+                        Vital="yes"
+                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+        <ServiceControl Id="ServiceControlOptionsManual"
+                        Stop="both"
+                        Remove="uninstall"
+                        Name="<%= settings[:puppet_service_name] %>"
+                        Wait="yes" />
+      </Component>
+
+      <Component Id='PuppetServiceDisabled'
+                 Guid="4D3A8CAF-C675-46AC-B3AD-75F00581D0DB"
+                 Win64="<%= settings[:win64] %>">
+        <Condition>
+          <![CDATA[PUPPET_AGENT_STARTUP_MODE ~= "disabled"]]>
+        </Condition>
+        <File Id="RubyExeDisabled"
+              KeyPath="yes"
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+
+        <ServiceInstall Id="ServiceInstallerDisabled"
+                        Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+                        Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+                        Description="Periodically fetches and applies configurations from a Puppet master server."
+                        DisplayName="Puppet Agent"
+                        Interactive="no"
+                        Name="<%= settings[:puppet_service_name] %>"
+                        Start="disabled"
+                        Type="ownProcess"
+                        ErrorControl="normal"
+                        Vital="yes"
+                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+        <ServiceControl Id="ServiceControlOptionsDisabled"
+                        Stop="both"
+                        Remove="uninstall"
+                        Name="<%= settings[:puppet_service_name] %>" Wait="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <Fragment>
+    <ComponentGroup Id="Service_PXPAGENT">
+      <ComponentRef Id="Service_PXPAGENT_svc" />
+    </ComponentGroup>
+
+    <DirectoryRef Id="PXPAGENTBINDIR">
+      <Component Id="Service_PXPAGENT_svc" Guid="52B1CD57-95A2-4CA4-AB8E-9DDD6DE8FC66">
+        <CreateFolder />
+        <File Id="NSSM"
+              KeyPath="yes"
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm.exe" />
+
+        <ServiceInstall Id="PXPServiceInstaller"
+                        Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+                        Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+                        Description="Puppet Execution Protocol (PXP) Service"
+                        DisplayName="Puppet PXP Agent"
+                        Interactive="no"
+                        Name="pxp-agent"
+                        Start="demand"
+                        Type="ownProcess"
+                        ErrorControl="normal"
+                        Vital="yes" />
+        <!-- Various registry keys documented at https://nssm.cc/usage -->
+        <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\pxp-agent\Parameters">
+          <RegistryValue Name="AppDirectory"
+                         Value="[INSTALLDIR]puppet\bin"
+                         Type="expandable" />
+          <RegistryValue Name="Application"
+                         Value="[INSTALLDIR]puppet\bin\pxp-agent.exe"
+                         Type="expandable" />
+          <RegistryValue Name="AppParameters"
+                         Value=""
+                         Type="expandable" />
+          <RegistryValue Name="AppEnvironmentExtra"
+                         Value="PATH=[INSTALLDIR]puppet\bin;%PATH%"
+                         Type="multiString"
+                         Action="append" />
+          <!-- Skip responding to WM_QUIT and WM_CLOSE -->
+          <RegistryValue Name="AppStopMethodSkip"
+                         Value="6"
+                         Type="integer" />
+          <RegistryKey Key="AppExit">
+            <!-- Stop the service completely on exit(2) (Invalid configuration) otherwise restart with NSSM service throttling -->
+            <!-- nssm AppExit codes reference https://nssm.cc/usage#exit -->
+            <RegistryValue Value="Restart" Type="string" />
+            <RegistryValue Name="2" Value="Exit" Type="string" />
+          </RegistryKey>
+        </RegistryKey>
+
+        <ServiceControl Id="PXPStartService"
+                        Stop="both"
+                        Remove="uninstall"
+                        Name="pxp-agent" Wait="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
This is the initial set of service specific files to support the Puppet
Agent Vanagon Windows build.

This PR replaces https://github.com/puppetlabs/puppet-agent/pull/514/