### PR TITLE
(maint) Use ruby built against OpenSSL 1.0.2g

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.8.1-x86",
-    "x64": "refs/tags/2.1.8.1-x64"
+    "x86": "refs/tags/2.1.8.2-x86",
+    "x64": "refs/tags/2.1.8.2-x64"
   }
 }


### PR DESCRIPTION
This is to address the March 2016 OpenSSL CVEs.