### PR TITLE
(PA-242) Disable boost::locale on cisco wrlinux 

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -28,6 +28,10 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc"
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
+
+    if platform.is_cisco_wrlinux?
+      platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+    end
   end
 
   pkg.configure do

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -144,6 +144,10 @@ component "facter" do |pkg, settings, platform|
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+
+    if platform.is_cisco_wrlinux?
+      special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+    end
   end
 
   pkg.configure do

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "0.4.1"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "0.4.2"}

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -56,6 +56,10 @@ component "leatherman" do |pkg, settings, platform|
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+
+    if platform.is_cisco_wrlinux?
+      special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+    end
   end
 
   pkg.configure do

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -28,6 +28,10 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc"
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
+
+    if platform.is_cisco_wrlinux?
+      special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+    end
   end
 
   pkg.configure do


### PR DESCRIPTION
wrlinux is an embedded environment that does not have full locale support. We shouldn't be attempting to do i18n there.

This requires Leatherman 0.4.2, which we plan to tag Monday. The only change in 0.4.2 will be the necessary support for disabling using locales on Linux variants that don't properly support it.