### PR TITLE
(MAINT) Shorten MCO Wix ID Service Name

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -68,7 +68,8 @@ component "marionette-collective" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\rubyw.exe"
+    # Providing shortened service name for MCO to simplify Wix ID lengths.
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\rubyw.exe", nil, "MCO"
   else
     fail "need to know where to put service files"
   end

--- a/resources/windows/wix/service.mcollective.wxs.erb
+++ b/resources/windows/wix/service.mcollective.wxs.erb
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Fragment>
-    <ComponentGroup Id="Service_MARIONETTECOLLECTIVE">
-      <ComponentRef Id="Service_MARIONETTECOLLECTIVE_svc" />
+  <ComponentGroup Id="Service_MCO">
+      <ComponentRef Id="Service_MCO_svc" />
     </ComponentGroup>
 
-    <DirectoryRef Id="MARIONETTECOLLECTIVEBINDIR">
-      <Component Id='Service_MARIONETTECOLLECTIVE_svc'
+    <DirectoryRef Id="MCOBINDIR">
+      <Component Id='Service_MCO_svc'
                  Guid="7601FCEA-90B3-CC69-6A69-4087FBC7292D"
                  Win64="<%= settings[:win64] %>">
         <File Id="RubyWExe"


### PR DESCRIPTION
The default of MARIONETTECOLLECTIVE leads to very long ID names in the
MCO service wix files. Adding MCO as a third argument to the
install_service call reduces the ID the more manageable MCO

See https://github.com/puppetlabs/puppet-agent/pull/557#discussion_r55449724 for further details.