### PR TITLE
(docs) Update README merge instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Here's a sample snippet used for a stable -> master merge:
 
 ```
 git merge --no-commit --no-ff stable
-for i in {hiera,facter,puppet,marionette-collective,pxp-agent,cpp-pcp-client}; do git checkout aardwolf -- configs/components/$i.json;done
-git checkout aardwolf -- configs/components/windows_*.json
+for i in {hiera,facter,puppet,marionette-collective,pxp-agent,cpp-pcp-client}; do git checkout master -- configs/components/$i.json;done
+git checkout master -- configs/components/windows_puppet.json
 git commit -m "(maint) Restore promoted components refs after merge from stable"
 ```
 


### PR DESCRIPTION
Aardwolf no longer exists, and the instructions specify a merge from
stable to master. So restore json files to master versions, not
aardwolf. Windows Ruby is always tagged, so don't revert newer commits.