### PR TITLE
(PA-181) Explicitly specify -march for OS X builds

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -68,6 +68,7 @@ component 'augeas' do |pkg, settings, platform|
     end
   elsif platform.is_osx?
     pkg.environment "PATH" => "$$PATH:/usr/local/bin"
+    pkg.environment "CFLAGS" => settings[:cflags]
   end
 
   pkg.configure do

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -23,6 +23,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
+    platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
     toolchain = ""
   elsif platform.is_huaweios?
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -14,7 +14,8 @@ component 'curl' do |pkg, settings, platform|
   end
 
   pkg.configure do
-    ["LDFLAGS='#{settings[:ldflags]}' \
+    ["CFLAGS='#{settings[:cflags]}' \
+      LDFLAGS='#{settings[:ldflags]}' \
      ./configure --prefix=#{settings[:prefix]} \
         --with-ssl=#{settings[:prefix]} \
         --enable-threaded-resolver \

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -12,6 +12,9 @@ component 'dmidecode' do |pkg, settings, platform|
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-install-to-bin.patch"
 
+  pkg.environment "LDFLAGS" => settings[:ldflags]
+  pkg.environment "CFLAGS" => settings[:cflags]
+
   pkg.build do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -139,6 +139,7 @@ component "facter" do |pkg, settings, platform|
   if platform.is_osx?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
+    special_flags = "-DCMAKE_CXX_FLAGS='-march=core2 -msse4'"
   elsif platform.is_huaweios?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -139,7 +139,7 @@ component "facter" do |pkg, settings, platform|
   if platform.is_osx?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
-    special_flags = "-DCMAKE_CXX_FLAGS='-march=core2 -msse4'"
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   elsif platform.is_huaweios?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -46,6 +46,7 @@ component "leatherman" do |pkg, settings, platform|
   if platform.is_osx?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   elsif platform.is_huaweios?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -13,6 +13,10 @@ component 'libedit' do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => settings[:ldflags]
   end
 
+  if platform.is_osx?
+    pkg.environment "CFLAGS" => settings[:cflags]
+  end
+
   pkg.configure do
     "bash configure --enable-shared --prefix=#{settings[:prefix]} #{settings[:host]}"
   end

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -14,7 +14,10 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS" => settings[:cflags]
     pkg.environment "LDFLAGS" => settings[:ldflags]
-  elsif !platform.is_osx?
+  elsif platform.is_osx?
+    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CFLAGS" => settings[:cflags]
+  else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
     pkg.environment "LDFLAGS" => settings[:ldflags]

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -21,7 +21,10 @@ component "libxslt" do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
-  elsif !platform.is_osx?
+  elsif platform.is_osx?
+    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CFLAGS" => settings[:cflags]
+  else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
     pkg.environment "LDFLAGS" => settings[:ldflags]

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -23,6 +23,7 @@ component "pxp-agent" do |pkg, settings, platform|
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   elsif platform.is_huaweios?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -113,6 +113,10 @@ component "ruby" do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
+  if platform.is_osx?
+    pkg.environment "optflags" => settings[:cflags]
+  end
+
   if platform.is_solaris?
     if platform.architecture == "sparc"
       if platform.os_version == "10"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -150,6 +150,8 @@ project "puppet-agent" do |proj|
     proj.setting(:cflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
     proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
+  elsif platform.is_osx?
+    proj.setting(:cflags, "-march=core2 -msse4 -I#{proj.includedir} -I/opt/pl-build-tools/include")
   else
     proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
     proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")


### PR DESCRIPTION
This should explcitly target `core2` as the chipset to optimize for
at compilation time. That will hopefully help move along the
"illegal instruction" problem we've been seeing.