### PR TITLE
(RE-6217) Use Ruby 2.0 during Solaris 10 SPARC builds

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -117,7 +117,7 @@ component "ruby" do |pkg, settings, platform|
     if platform.architecture == "sparc"
       if platform.os_version == "10"
         # ruby1.8 is not new enough to successfully cross-compile ruby 2.1.x (it doesn't understand the --disable-gems flag)
-        pkg.build_requires 'ruby19'
+        pkg.build_requires 'ruby20'
       elsif platform.os_version == "11"
         pkg.build_requires 'pl-ruby'
       end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -97,7 +97,7 @@ project "puppet-agent" do |proj|
       # For cross-compiling, we have a standalone ruby
       if platform.os_version == "10"
         proj.setting(:host_ruby, "/opt/csw/bin/ruby")
-        proj.setting(:host_gem, "/opt/csw/bin/gem19")
+        proj.setting(:host_gem, "/opt/csw/bin/gem2.0")
       else
         proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
         proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")


### PR DESCRIPTION
Prior to this commit, puppet-agent builds for Solaris
10 SPARC frequently fail with a ruby segfault. These
builds (which are cross-crompiled), currently use
openscsw's ruby 1.9 (currently 1.9.3p0) in lieu of a
a miniruby.

This commit updates Solaris 10 SPARC to use opencsw's
ruby 2.0 (currently 2.0.0p594) instead of ruby 1.9
during Solaris 10 SPARC builds.