### PR TITLE
(maint) fix cross-compiling of virt-what

### DIFF
--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -19,12 +19,19 @@ component "virt-what" do |pkg, settings, platform|
 
   if platform.is_linux?
     if platform.architecture =~ /ppc64le$/
-      target = 'powerpc64le-unknown-linux-gnu'
+      host_opt = '--host powerpc64le-unknown-linux-gnu'
     end
   end
 
+  if platform.is_huaweios?
+    host_opt = '--host powerpc-linux-gnu'
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS" => settings[:ldflags]
+  end
+
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{target}"]
+    ["./configure --prefix=#{settings[:prefix]} --sbindir=#{settings[:prefix]}/bin --libexecdir=#{settings[:prefix]}/lib/virt-what #{host_opt}"]
   end
 
   pkg.build do


### PR DESCRIPTION
virt-what needs the --host option to specify the platform for cross
compiling, so previously this never actually worked. This commit
adds the proper --host flag and sets PATH/CFLAGS/LDFLAGS for huaweios.

I've tested this with the huaweios agent build and it now builds a binary for powerpc. I did *not* touch the el-7 powerpc64 configuration as I don't even believe it includes the necessary cross-toolchain so I can't fully test that. It looks like that platform was added by a community member. 