### PR TITLE
(RE-6520) Build the huaweios package as powerpc instead of noarch

### DIFF
--- a/configs/platforms/huaweios-6-powerpc.rb
+++ b/configs/platforms/huaweios-6-powerpc.rb
@@ -6,7 +6,7 @@ platform "huaweios-6-powerpc" do |plat|
   plat.codename "jessie"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends binutils-powerpc-linux-gnu build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   # We're cross-compiling the agent for powerpc using the x86_64 template
   plat.vmpooler_template "debian-8-x86_64"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -80,10 +80,6 @@ project "puppet-agent" do |proj|
     # Use a standalone ruby for cross-compilation
     proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
     proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
-
-    # This will be removed once vanagon fixes are in to specify the
-    # debian target arch:
-    proj.noarch
   end
 
   # For solaris, we build cross-compilers


### PR DESCRIPTION
The addition of binutils-powerpc-linux-gnu is necessary for the debian
packaging to be able to find the target arch strip command. I cannot
force debuilder to pass along a modified PATH environment to dh_strip,
so the distro version of binutils is required for this instead of our
pl-binutils.

This PR depends on [PR-322](https://github.com/puppetlabs/vanagon/pull/322) getting merged into vanagon first. 