### PR TITLE
(PA-181) Simplify/correct CFLAGS and LDFLAGS logic

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -138,7 +138,11 @@ project "puppet-agent" do |proj|
     proj.bill_of_materials File.join(proj.datadir, "doc")
   end
 
-  # Platform specific
+  # Define default CFLAGS and LDFLAGS
+  proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+
+  # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"
     proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
@@ -147,12 +151,12 @@ project "puppet-agent" do |proj|
     proj.setting(:cflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
     proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
-  elsif platform.is_osx?
-    proj.setting(:cflags, "-march=core2 -msse4 -I#{proj.includedir} -I/opt/pl-build-tools/include")
-  else
-    proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-    proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
   end
+
+  if platform.is_osx?
+    proj.setting(:cflags, "-march=core2 -msse4 -I#{proj.includedir} -I/opt/pl-build-tools/include")
+  end
+
   if platform.is_aix?
     proj.setting(:ldflags, "-Wl,-brtl -L#{proj.libdir} -L/opt/pl-build-tools/lib")
   end


### PR DESCRIPTION
The cascading if/else for setting CFLAGS could lead to more than one situation
no LDFLAGS are set or the standard LDFLAGS are duplicated in each conditional.
We can improve this by setting broad, generally correct defaults and then only
adding to them or changing them as needed. This also eases the pressures that
likely led to a cascading if/else statement.