### PR TITLE
(RE-6507) Add USER_ACCOUNT Wix definitions

### DIFF
--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -16,6 +16,8 @@
       <ComponentGroupRef Id="FragmentProperties" />
       <ComponentGroupRef Id="FragmentSequences" />
       <ComponentGroupRef Id="FragmentCustomActions" />
+      <!-- Ensure User Account Component is loaded -->
+      <ComponentRef Id="PuppetServiceUser" />
     </ComponentGroup>
 
     <UI>

--- a/resources/windows/wix/users.wxs.erb
+++ b/resources/windows/wix/users.wxs.erb
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <!-- Puppet Agent Specific Component Group File -->
+
+  <Fragment>
+    <!--
+      If puppet is configured to run as someone other than LocalSystem
+      and we are installing or upgrading, then allow the account to
+      logon as a service and add the account to the local Administrators
+      account. If the account doesn't exist, the install will fail.
+    -->
+    <util:Group Id="AdminGroup" Name="Administrators"/>
+    
+    <Component
+      Id="PuppetServiceUser"
+      Guid="0CCA1CDC-CD25-43A5-BE8A-0D455C63D1BE"
+      Directory="TARGETDIR"
+      Win64="<%= settings[:win64] %>">
+      <Condition><![CDATA[NOT Installed AND PUPPET_AGENT_ACCOUNT_USER <> "LocalSystem"]]></Condition>
+      <util:User
+        Id="puppetServiceUser"
+        Domain="[PUPPET_AGENT_ACCOUNT_DOMAIN]"
+        Name="[PUPPET_AGENT_ACCOUNT_USER]"
+        Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
+        LogonAsService="yes"
+        CreateUser="no"
+        UpdateIfExists="yes"
+        RemoveOnUninstall="no">
+        <util:GroupRef Id="AdminGroup"/>
+      </util:User>
+    </Component>
+
+  </Fragment>
+</Wix>


### PR DESCRIPTION
Normally the puppet services are run under LocalSystem, but the User
settings allow it to be overridden so that for example a Domain account
can be configured to run the services