### PR TITLE
(maint) update the windows plat definitions to msi

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -21,5 +21,5 @@ platform "windows-2012r2-x64" do |plat|
 
   plat.platform_triple "x86_64-unknown-mingw32"
 
-  plat.package_type "nuget"
+  plat.package_type "msi"
 end

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -21,5 +21,5 @@ platform "windows-2012r2-x86" do |plat|
 
   plat.platform_triple "i686-unknown-mingw32"
 
-  plat.package_type "nuget"
+  plat.package_type "msi"
 end


### PR DESCRIPTION
The MSI packaging process is in a state where it's possible
to build an MSI straight out of the box with no changes to
vanagon or any configs. We now need MSI to be the default
type of windows build