### PR TITLE
(RE-6793) Update puppetres Registry Key

### DIFF
--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -55,7 +55,7 @@
           <RegistryValue
             Type="string"
             Name="EventMessageFile"
-            Value="[INSTALLDIR]misc\puppetres.dll"/>
+            Value="[INSTALLDIR]puppet\bin\puppetres.dll"/>
           <RegistryValue
             Type="integer"
             Name="TypesSupported"


### PR DESCRIPTION
puppetres.dll now resides in [INSTALLDIR]puppet/bin, so the event log
registry key
(SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet) needs
updated to this directory.

Note - this change is still under some discussion - i.e. whether using
the Ruby install.rb is correct in the build for windows/vanagon.

This change should be merged in the interim, as at the moment,
puppetres.dll is in the puppet/bin directory, so event log messages
won't work unless the registry entry points to it.