### PR TITLE
(RE-6801) Add Start Menu Shortcuts and other Vanagon/MSI Fixes

### DIFF
--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -17,6 +17,7 @@
       <ComponentGroupRef Id="FragmentProperties" />
       <ComponentGroupRef Id="FragmentSequences" />
       <ComponentGroupRef Id="FragmentCustomActions" />
+      <ComponentGroupRef Id="FragmentEnvironment" />
       <ComponentGroupRef Id="FragmentIcon" />
       <!-- Ensure User Account Component is loaded -->
       <ComponentRef Id="PuppetServiceUser" />

--- a/resources/windows/wix/environment.wxs
+++ b/resources/windows/wix/environment.wxs
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <!--
+    Enivornment table for installation.
+
+  -->
+  <Fragment>
+    <ComponentGroup Id="FragmentEnvironment">
+      <Component 
+        Id="PuppetInstallDirBinToPath"
+        Guid="F46FA9A8-43A2-4379-8933-EAAE2D0E5D72"
+        Directory="TARGETDIR"
+        Win64="$(var.Win64)">
+        <Environment
+          Id="PuppetBinPath"
+          Name="PATH"
+          Value="[INSTALLDIR]bin"
+          Permanent="no"
+          Part="last"
+          Action="set"
+          System="yes" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/environment.wxs.erb
+++ b/resources/windows/wix/environment.wxs.erb
@@ -6,11 +6,11 @@
   -->
   <Fragment>
     <ComponentGroup Id="FragmentEnvironment">
-      <Component 
+      <Component
         Id="PuppetInstallDirBinToPath"
         Guid="F46FA9A8-43A2-4379-8933-EAAE2D0E5D72"
         Directory="TARGETDIR"
-        Win64="$(var.Win64)">
+        Win64="<%= settings[:win64] %>">
         <Environment
           Id="PuppetBinPath"
           Name="PATH"

--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -14,7 +14,10 @@
     <!-- Directory Definitions for Start Menu Shortcuts -->
     <DirectoryRef Id='TARGETDIR'>
       <Directory Id='ProgramMenuFolder'>
-        <Directory Id='PuppetShortcutDir' Name="<%= settings[:product_id] %>" />
+        <Directory Id='PuppetShortcutDir' Name="<%= settings[:product_id] %>">
+          <Directory Id='PuppetShortcutDocumentationDir' Name="Documentation">
+          </Directory>
+        </Directory>
       </Directory>
     </DirectoryRef>
 
@@ -70,7 +73,65 @@
           KeyPath="yes" />
       </Component>
 
+      <Component
+        Id="PuppetDocumentationShortcuts"
+        Guid="651178BC-76D8-4574-B97B-B132064EE2FB"
+        Directory="PuppetShortcutDocumentationDir"
+        Win64="<%= settings[:win64] %>">
+        <IniFile
+          Id="PuppetSupportURL"
+          Name="Get <%= settings[:product_name] %> Support.url"
+          Action="addLine"
+          Section="InternetShortcut"
+          Key="URL"
+          Value="<%= settings[:links][:HelpLink] %>"
+          Directory="PuppetShortcutDocumentationDir" />
+        <IniFile
+          Id="PuppetCommunityURL"
+          Name="Explore the Puppet Community.url"
+          Action="addLine"
+          Section="InternetShortcut"
+          Key="URL"
+          Value="<%= settings[:links][:CommunityLink] %>"
+          Directory="PuppetShortcutDocumentationDir" />
+        <IniFile
+          Id="PuppetNextStepURL"
+          Name="<%= settings[:product_name] %> First Steps.url"
+          Action="addLine"
+          Section="InternetShortcut"
+          Key="URL"
+          Value="<%= settings[:links][:NextStepLink] %>"
+          Directory="PuppetShortcutDocumentationDir" />
+        <IniFile
+          Id="PuppetManualURL"
+          Name="<%= settings[:product_name] %> Manual.url"
+          Action="addLine"
+          Section="InternetShortcut"
+          Key="URL"
+          Value="<%= settings[:links][:ManualLink] %>"
+          Directory="PuppetShortcutDocumentationDir" />
+        <IniFile
+          Id="PuppetForgeURL"
+          Name="Puppet Forge.url"
+          Action="addLine"
+          Section="InternetShortcut"
+          Key="URL"
+          Value="<%= settings[:links][:ForgeLink] %>"
+          Directory="PuppetShortcutDocumentationDir" />
+        <CreateFolder />
+        <RemoveFolder
+          Id="PuppetShortcutDocumentationDir"
+          On="uninstall"/>
+        <RegistryValue
+          Root="HKCU"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>\Documentation"
+          Name="installed"
+          Value="1"
+          Type="integer"
+          KeyPath="yes" />
+      </Component>
 
+      <!-- Shortcuts from bin directory -->
       <Component
         Id="ShortCutsComponent"
         Directory="ShortCutBinDir"

--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -11,7 +11,66 @@
       </Directory>
     </DirectoryRef>
 
+    <!-- Directory Definitions for Start Menu Shortcuts -->
+    <DirectoryRef Id='TARGETDIR'>
+      <Directory Id='ProgramMenuFolder'>
+        <Directory Id='PuppetShortcutDir' Name="<%= settings[:product_id] %>" />
+      </Directory>
+    </DirectoryRef>
+
     <ComponentGroup Id="ShortCutsComponentGroup">
+
+      <Component
+        Id="PuppetShortcuts"
+        Guid="0B69C3FF-8967-4F8A-AC71-0EAE34E91ACC"
+        Directory="PuppetShortcutDir"
+        Win64="<%= settings[:win64] %>">
+        <Shortcut
+          Id="PuppetShortcut"
+          Name="Run Puppet Agent"
+          Description="Run Puppet in an interactive command window"
+          Target="[INSTALLDIR]puppet\bin\run_puppet_interactive.bat"
+          Icon="PuppetShortcutIcon"
+          WorkingDirectory="bin">
+          <Icon
+            Id="PuppetShortcutIcon"
+            SourceFile="wix\icon\puppetlabs.ico"/>
+        </Shortcut>
+        <Shortcut
+          Id="FacterShortcut"
+          Name="Run Facter"
+          Description="Run Facter in an interactive command window"
+          Target="[INSTALLDIR]puppet\bin\run_facter_interactive.bat"
+          Icon="FacterShortcutIcon"
+          WorkingDirectory="bin">
+          <Icon
+            Id="FacterShortcutIcon"
+            SourceFile="wix\icon\puppetlabs.ico"/>
+        </Shortcut>
+        <Shortcut
+          Id="PuppetShellShortcut"
+          Name="Start Command Prompt with Puppet"
+          Description="Start a Command Prompt with Puppet already in the PATH and RUBYLIB load path."
+          Target="[%ComSpec]"
+          Arguments='/E:ON /K "[INSTALLDIR]puppet\bin\puppet_shell.bat"'
+          Icon="PuppetShellShortcutIcon"
+          WorkingDirectory="bin">
+          <Icon
+            Id="PuppetShellShortcutIcon"
+            SourceFile="wix\icon\puppetlabs.ico"/>
+        </Shortcut>
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <!-- This registry entry is required to be a keypath for this component -->
+        <RegistryValue
+          Root="HKCU"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>"
+          Name="installed"
+          Value="1"
+          Type="integer"
+          KeyPath="yes" />
+      </Component>
+
+
       <Component
         Id="ShortCutsComponent"
         Directory="ShortCutBinDir"


### PR DESCRIPTION
This PR contains a number of small fixes to the Vanagon/MSI installer for Puppet Agent to fix defects detected as part of the RE-5735/RE-5736.

Separate commits are used for each ticket and include:
RE-6858 - Add PATH/Environment Variable (Also RE-6857)
RE-6801 - Add Start Menu/App Shortcuts (Also RE-6859)
RE-6860 - Some Inifiles are missing from Installer 

