### PR TITLE
(RE-6882) hard-pin vanagon to 0.5.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.5.7')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.5.7')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This is a temporary change since the rubygems.org index cache
is still reporting that vanagon 0.5.8 is available, but now
the gem itself can no longer be downloaded as it was yanked.