### PR TITLE
(RE-6882) hard-pin vanagon to 0.5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.5.6')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.5.6')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
The stable branch should not follow new vanagon releases unless
explicitly updated in the Gemfile.