### PR TITLE
(RE-6861) Add Launch Conditions

### DIFF
--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -20,6 +20,7 @@
       <ComponentGroupRef Id="FragmentEnvironment" />
       <ComponentGroupRef Id="FragmentIcon" />
       <ComponentGroupRef Id="FragmentVariables" />
+      <ComponentGroupRef Id="FragmentCondition" />
       <!-- Ensure User Account Component is loaded -->
       <ComponentRef Id="PuppetServiceUser" />
     </ComponentGroup>

--- a/resources/windows/wix/condition.wxs.erb
+++ b/resources/windows/wix/condition.wxs.erb
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <!--
+    Enivornment table for installation.
+
+  -->
+  <Fragment>
+    <ComponentGroup Id="FragmentCondition"/>
+
+    <%- if @platform.architecture == "x64" -%>
+      <!-- http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html
+        -->
+      <Condition Message="<%= settings[:product_name] %> is no longer supported on Windows Server 2003.">
+        <![CDATA[Installed OR (VersionNT64 >= 600)]]>
+      </Condition>
+    <%- else %>
+      <Condition Message="<%= settings[:product_name] %> is no longer supported on Windows Server 2003.">
+        <![CDATA[Installed OR (VersionNT >= 600)]]>
+      </Condition>
+    <%- end -%>
+
+    </Fragment>
+  </Wix>


### PR DESCRIPTION
These were missing from the initial windows/msi

The launch conditions prevent the installer from being installed on Windows 2003 or earlier.