### PR TITLE
(RE-6863) Remove pxp-agent service custom actions

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -166,19 +166,6 @@ End If
       Value="NT AUTHORITY"
       Execute="firstSequence"/>
 
-    <!--<Property Id="WixQuietExecCmdLine" Value="&quot;[INSTALLDIR]service\nssm.exe&quot; stop pxp-agent"/> -->
-    <CustomAction
-      Id="ShutdownPxpAgentService_SetProp"
-      Property="QtExecCmdLine"
-      Value="&quot;[INSTALLDIR]service\nssm.exe&quot; stop pxp-agent"
-      Execute="immediate" />
-    <CustomAction
-      Id="ShutdownPxpAgentService"
-      BinaryKey="WixCA"
-      DllEntry="CAQuietExec"
-      Execute="immediate"
-      Return="ignore" />
-
     <%- if @platform.architecture == "x86" -%>
     <!-- If these fail, we don't want to fail the installer -->
     <!-- We can't do a registry search for powershell's installed location because it will turn up the WOW64Node version due to not being able to bypass redirection in RegistrySearch

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -133,14 +133,6 @@
         <![CDATA[VersionNT64 >= 100 AND <%= settings[:win64] %> = no AND NOT (&<%= settings[:product_id] %>Runtime = 2)]]>
       </Custom>
       <%-end-%>
-      <!-- Make sure pxp-agent service is shutdown before we validate the install -->
-      <!-- Only executed if pxp-agent is already installed (i.e. an Uninstall or upgrade - check for repair also) -->
-      <Custom Action='ShutdownPxpAgentService_SetProp' Before='ShutdownPxpAgentService'>
-        REMOVE="ALL" OR WIX_UPGRADE_DETECTED or REINSTALL
-      </Custom>
-      <Custom Action='ShutdownPxpAgentService' Before='InstallValidate'>
-        REMOVE="ALL" OR WIX_UPGRADE_DETECTED or REINSTALL
-      </Custom>
     </InstallExecuteSequence>
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />


### PR DESCRIPTION
These Custom actions leaked into to the Vanagon build and should be
removed. They were included for PA-65, but this change was subsequently
removed.