### PR TITLE
(RE-6970) Use huaweios as the codename for the huaweios agent

### DIFF
--- a/configs/platforms/huaweios-6-powerpc.rb
+++ b/configs/platforms/huaweios-6-powerpc.rb
@@ -3,7 +3,7 @@ platform "huaweios-6-powerpc" do |plat|
   plat.defaultdir "/etc/default"
   # HuaweiOS is based on Debian 8 but uses sysv instead of systemd
   plat.servicetype "sysv"
-  plat.codename "jessie"
+  plat.codename "huaweios"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends binutils-powerpc-linux-gnu build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"


### PR DESCRIPTION
Previously we were building it as 'jessie', which means the package
will get shipped to the Debian Jessie repo. Instead we want to ensure
the package is shipped to a separate apt repo for huaweios.