### PR TITLE
(RE-6892) Move the .bat files location

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -209,7 +209,14 @@ component "facter" do |pkg, settings, platform|
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
-
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/facter.bat", sum: "185b8645feecac4acadc55c64abb3755")
+    pkg.add_source("file://resources/files/windows/facter_interactive.bat", sum: "20a1c0bc5368ffb24980f42432f1b372")
+    pkg.add_source("file://resources/files/windows/run_facter_interactive.bat", sum: "c5e0c0a80e5c400a680a06a4bac8abd4")
+    pkg.install_file "../facter.bat", "#{settings[:link_bindir]}/facter.bat"
+    pkg.install_file "../facter_interactive.bat", "#{settings[:link_bindir]}/facter_interactive.bat"
+    pkg.install_file "../run_facter_interactive.bat", "#{settings[:link_bindir]}/run_facter_interactive.bat"
+  end
   pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter" unless platform.is_windows?
   if platform.is_windows?
     pkg.directory File.join(settings[:sysconfdir], 'facter', 'facts.d')

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -10,11 +10,22 @@ component "hiera" do |pkg, settings, platform|
   pkg.replaces 'pe-hiera'
 
   pkg.install do
-    "#{settings[:host_ruby]} install.rb --ruby=#{File.join(settings[:bindir], 'ruby')} --bindir=#{settings[:bindir]} --configdir=#{settings[:puppet_codedir]} --sitelibdir=#{settings[:ruby_vendordir]} --configs --quick --man --mandir=#{settings[:mandir]}"
+    ["#{settings[:host_ruby]} install.rb \
+    --ruby=#{File.join(settings[:bindir], 'ruby')} \
+    --bindir=#{settings[:bindir]} \
+    --configdir=#{settings[:puppet_codedir]} \
+    --sitelibdir=#{settings[:ruby_vendordir]} \
+    --configs \
+    --quick \
+    --man \
+    --mandir=#{settings[:mandir]}"]
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
-
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
+    pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
+  end
   pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -109,8 +109,11 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.install_file "ext/aio/common/client.cfg.dist", File.join(configdir, 'client.cfg')
   pkg.install_file "ext/aio/common/server.cfg.dist", File.join(configdir, 'server.cfg')
 
-  pkg.install_file "ext/windows/daemon.bat", "#{settings[:bindir]}/mco_daemon.bat" if platform.is_windows?
-
+  if platform.is_windows?
+    pkg.install_file "ext/windows/daemon.bat", "#{settings[:bindir]}/mco_daemon.bat"
+    pkg.add_source("file://resources/files/windows/mco.bat", sum: "2d29af9c926dcf8b50ae9ac1bdb18e1f")
+    pkg.install_file "../mco.bat", "#{settings[:link_bindir]}/mco.bat"
+  end
   pkg.configfile File.join(configdir, 'client.cfg')
   pkg.configfile File.join(configdir, 'server.cfg')
   pkg.configfile File.join(configdir, 'facts.yaml')

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -1,10 +1,6 @@
 component "puppet" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet.json")
 
-  if platform.is_windows?
-    pkg.add_source("file://resources/files/windows/environment.bat", sum: "c698da37e559935e904f8690dd5c26fa")
-  end
-
   pkg.build_requires "ruby"
   pkg.build_requires "facter"
   pkg.build_requires "hiera"
@@ -136,8 +132,7 @@ component "puppet" do |pkg, settings, platform|
         --configs \
         --quick \
         --man \
-        --mandir=#{settings[:mandir]}"
-    ]
+        --mandir=#{settings[:mandir]}"]
   end
 
   #The following will add the vim syntax files for puppet
@@ -155,7 +150,18 @@ component "puppet" do |pkg, settings, platform|
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
 
   if platform.is_windows?
-    pkg.install_file "../environment.bat", "#{settings[:bindir]}/environment.bat"
+    # Install the appropriate .batch files to the INSTALLDIR/bin directory
+    pkg.add_source("file://resources/files/windows/environment.bat", sum: "810195e5fe09ce1704d0f1bf818b2d9a")
+    pkg.add_source("file://resources/files/windows/puppet.bat", sum: "002618e115db9fd9b42ec611e1ec70d2")
+    pkg.add_source("file://resources/files/windows/puppet_interactive.bat", sum: "4b40eb0df91d2ca8209302062c4940c4")
+    pkg.add_source("file://resources/files/windows/puppet_shell.bat", sum: "24477c6d2c0e7eec9899fb928204f1a0")
+    pkg.add_source("file://resources/files/windows/run_puppet_interactive.bat", sum: "d4ae359425067336e97e4e3a200027d5")
+    pkg.install_file "../environment.bat", "#{settings[:link_bindir]}/environment.bat"
+    pkg.install_file "../puppet.bat", "#{settings[:link_bindir]}/puppet.bat"
+    pkg.install_file "../puppet_interactive.bat", "#{settings[:link_bindir]}/puppet_interactive.bat"
+    pkg.install_file "../run_puppet_interactive.bat", "#{settings[:link_bindir]}/run_puppet_interactive.bat"
+    pkg.install_file "../puppet_shell.bat", "#{settings[:link_bindir]}/puppet_shell.bat"
+
     pkg.install_file "ext/windows/service/daemon.bat", "#{settings[:bindir]}/daemon.bat"
     pkg.install_file "ext/windows/service/daemon.rb", "#{settings[:bindir]}/daemon.rb"
     pkg.install_file "../wix/icon/puppetlabs.ico", "#{settings[:miscdir]}/puppetlabs.ico"

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -3,11 +3,14 @@ REM This is the parent directory of the directory containing this script.
 SET "PL_BASEDIR=%~dp0.."
 REM Avoid the nasty \..\ littering the paths.
 SET "PL_BASEDIR=%PL_BASEDIR:\bin\..=%"
+SET "PL_BASEDIR=%PL_BASEDIR%\puppet"
 
 REM Set a fact so we can easily source the environment.bat file in the future.
 SET "FACTER_env_windows_installdir=%PL_BASEDIR%"
 SET "FACTERDIR=%PL_BASEDIR%"
 
+REM we only need to add the path to the executables, the path to the current
+REM bin directory was already set by the install.
 SET "PATH=%PL_BASEDIR%\bin;%PATH%"
 
 REM Enable rubygems support

--- a/resources/files/windows/facter.bat
+++ b/resources/files/windows/facter.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+facter.exe %*

--- a/resources/files/windows/facter_interactive.bat
+++ b/resources/files/windows/facter_interactive.bat
@@ -1,0 +1,5 @@
+@echo off
+echo Running Facter on demand ...
+cd "%~dp0"
+call .\facter.bat %*
+PAUSE

--- a/resources/files/windows/hiera.bat
+++ b/resources/files/windows/hiera.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+ruby -S -- hiera %*

--- a/resources/files/windows/mco.bat
+++ b/resources/files/windows/mco.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+ruby -S -- mco %*

--- a/resources/files/windows/puppet.bat
+++ b/resources/files/windows/puppet.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+ruby -S -- puppet %*

--- a/resources/files/windows/puppet_interactive.bat
+++ b/resources/files/windows/puppet_interactive.bat
@@ -1,0 +1,5 @@
+@echo off
+echo Running Puppet agent on demand ...
+cd "%~dp0"
+call puppet.bat agent --test %*
+PAUSE

--- a/resources/files/windows/puppet_shell.bat
+++ b/resources/files/windows/puppet_shell.bat
@@ -1,0 +1,6 @@
+@ECHO OFF
+
+call "%~dp0environment.bat" %0 %*
+
+REM Display Ruby version
+ruby.exe -v

--- a/resources/files/windows/run_facter_interactive.bat
+++ b/resources/files/windows/run_facter_interactive.bat
@@ -1,0 +1,5 @@
+@echo Running puppet on demand ...
+@echo off
+SETLOCAL
+call "%~dp0environment.bat" %0 %*
+@elevate.exe "%~dp0facter_interactive.bat"

--- a/resources/files/windows/run_puppet_interactive.bat
+++ b/resources/files/windows/run_puppet_interactive.bat
@@ -1,0 +1,5 @@
+@echo Running puppet on demand ...
+@echo off
+SETLOCAL
+call "%~dp0environment.bat" %0 %*
+@elevate.exe "%~dp0puppet_interactive.bat"

--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -131,64 +131,6 @@
           KeyPath="yes" />
       </Component>
 
-      <!-- Shortcuts from bin directory -->
-      <Component
-        Id="ShortCutsComponent"
-        Directory="ShortCutBinDir"
-        KeyPath="yes"
-        Guid="B1F39383-C765-4939-8550-EA88800B5938" >
-
-        <Shortcut
-          Id="ShortCutEnvironmentBat"
-          Name="environment.bat"
-          Target="[INSTALLDIR]puppet\bin\environment.bat" />
-
-        <Shortcut
-          Id="ShortCutFacterBat"
-          Name="facter.bat"
-          Target="[INSTALLDIR]puppet\bin\facter.bat" />
-
-        <Shortcut
-          Id="ShortCutFacterIntBat"
-          Name="facter_interactive.bat"
-          Target="[INSTALLDIR]puppet\bin\facter_interactive.bat" />
-
-        <Shortcut
-          Id="ShortCutHieraBat"
-          Name="hiera.bat"
-          Target="[INSTALLDIR]puppet\bin\hiera.bat" />
-
-        <Shortcut
-          Id="ShortCutMCOBat"
-          Name="mco.bat"
-          Target="[INSTALLDIR]puppet\bin\mco.bat" />
-
-        <Shortcut
-          Id="ShortCutPuppetBat"
-          Name="puppet.bat"
-          Target="[INSTALLDIR]puppet\bin\puppet.bat" />
-
-        <Shortcut
-          Id="ShortCutPuppetIntBat"
-          Name="puppet_interactive.bat"
-          Target="[INSTALLDIR]puppet\bin\puppet_interactive.bat" />
-
-        <Shortcut
-          Id="ShortCutPuppetShellBat"
-          Name="puppet_shell.bat"
-          Target="[INSTALLDIR]puppet\bin\puppet_shell.bat" />
-
-        <Shortcut
-          Id="ShortCutRunFacterIntBat"
-          Name="run_facter_interactive.bat"
-          Target="[INSTALLDIR]puppet\bin\run_facter_interactive.bat" />
-
-        <Shortcut
-          Id="ShortCutRunPuppetIntBat"
-          Name="run_puppet_interactive.bat"
-          Target="[INSTALLDIR]puppet\bin\run_puppet_interactive.bat" />
-      </Component>
-
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Before this we were planning on keeping the .bat files
that actually execute puppet in windows inside Puppet\puppet\bin
and creating symlinks in Puppet/bin to the .bat files. However
we have since decided that the symlinks are not the way to proceed
since they require custom actions for both install and uninstall
and the act of symlinking is moving away from being windows native.

Thus we elected to move the .bat files entirely to the Puppet\bin
directory and change the contents to point to the correct paths.

This update does the following:

* Adds each .bat file we were using in Puppet-Agent to the actual
Puppet-agent vanagon project. this means those files are now under
the resources/files/windows and we will no longer use those generated
by any of the install.rb scripts.

    * AS A SPECIAL NOTE: this PR itself does not explicitly
    deprecate those .bat files created by the install.rb
    scripts. that work (to remove those files from Puppet/puppet/bin)
    will come as a different PR.

* Updates the .bat files to point to the correct location of all the
executables in Puppet/puppet/bin