### PR TITLE
(PA-282) Fix special_flags handling to restore builds on *nix

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -134,6 +134,8 @@ component "facter" do |pkg, settings, platform|
 
   make = platform[:make]
 
+  special_flags = ""
+
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
   if platform.is_osx?


### PR DESCRIPTION
Commit 7b4256ab28fcc535e70d1887c991d5525c9f88cc for RE-7004 introduced
a 'special_flags += <stuff>' stanza to separate some functionality
not needed on windows. Unfortunately, special_flags is not defined
at the point the stanza is executed which results in an exception.

This change simply initializes special_flags so it is always defined.