### PR TITLE
(maint) fix facter failure with special_flags

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -134,6 +134,8 @@ component "facter" do |pkg, settings, platform|
 
   make = platform[:make]
 
+  special_flags = ''
+
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
   if platform.is_osx?


### PR DESCRIPTION
special_flags is a variable we use in the cmake
invocation of facter, it was never initialized
so for many platforms facter was trying to do a
"+=" to a non existing string, this commit fixes
that