### PR TITLE
(HUAWEI-15) Include cross-compiled dmidecode in huaweios builds

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -15,6 +15,14 @@ component 'dmidecode' do |pkg, settings, platform|
   pkg.environment "LDFLAGS" => settings[:ldflags]
   pkg.environment "CFLAGS" => settings[:cflags]
 
+  if platform.is_huaweios? # TODO: change to platform.is_cross_compiled?
+    # The Makefile doesn't honor environment overrides, so we need to
+    # edit it directly for cross-compiling
+    pkg.configure do
+      ["sed -i \"s|gcc|/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc|g\" Makefile"]
+    end
+  end
+
   pkg.build do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -130,7 +130,7 @@ project "puppet-agent" do |proj|
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"
-    proj.component "dmidecode" unless platform.is_huaweios?
+    proj.component "dmidecode"
     proj.component "shellpath"
   end
 


### PR DESCRIPTION
It's unlikely that dmidecode will ever be used on CloudEngine switches, but I have confirmed that the Yocto Project builds dmidecode for powerpc 32 and 64 bit platforms, and this will quiet a warning message that puppet spews during runs when the dmidecode binary is missing. 