### PR TITLE
(maint) ensure rubygem-deep-merge is built before nokogiri

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -21,6 +21,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     # any later gem operations will trigger rebuilding the extensions for the
     # build host platform, and things then explode horrifically.
     pkg.build_requires "rubygem-net-netconf"
+    pkg.build_requires "rubygem-deep-merge"
 
     # The "gem install nokogiri" method of installing the gem won't work for
     # cross-compiled platforms, as we have no way of passing in the rbconfig


### PR DESCRIPTION
This fixes an intermittent build failure where rubygem-deep-merge
could be installed after nokogiri. As we've found, the only way to
keep nokogiri in line is to ensure it is the *last* gem installed.