### PR TITLE
(RE-7021) Update the puppet-msi with fixes

### DIFF
--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -13,7 +13,7 @@
 
         <RegistryKey
           Root="HKLM"
-          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_id] %>"
           Action="create" >
           <!-- This is the default (aka 'unnamed') key value of this path -->
           <RegistryValue
@@ -72,7 +72,7 @@
 
         <RegistryKey
           Root="HKLM"
-          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_id] %>"
           ForceCreateOnInstall="yes" >
 
           <RegistryValue

--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -66,7 +66,7 @@
         <!-- This registry entry is required to be a keypath for this component -->
         <RegistryValue
           Root="HKCU"
-          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_id] %>"
           Name="installed"
           Value="1"
           Type="integer"
@@ -124,7 +124,7 @@
           On="uninstall"/>
         <RegistryValue
           Root="HKCU"
-          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_name] %>\Documentation"
+          Key="SOFTWARE\<%= settings[:company_name] %>\<%= settings[:product_id] %>\Documentation"
           Name="installed"
           Value="1"
           Type="integer"


### PR DESCRIPTION
This replaces "settings[:product_name]" with
"settings[:product_id]" to use the correct name for
names of registry entries

I cannot fix the batch file tickets RE-7018 and RE-7019 until the major change to paths in RE-7027 is complete. so this PR is now just one ticket worth of work