### PR TITLE
(maint) The puppet component needs to replace pe-puppetserver-common

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -14,6 +14,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.replaces 'pe-cloud-provisioner'
   pkg.replaces 'pe-puppet-enterprise-release', '4.0.0'
   pkg.replaces 'pe-agent'
+  pkg.replaces 'pe-puppetserver-common', '4.0.0'
 
   if platform.is_deb?
     pkg.replaces 'puppet-common', '4.0.0'


### PR DESCRIPTION
Both packages own /etc/puppetlabs/puppet/auth.conf, so this is needed
to ensure that packages get installed/uninstalled in the correct order
on upgrade.