### PR TITLE
(PA-186) components should use upstream and rewrite urls

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,7 +1,7 @@
 component 'augeas' do |pkg, settings, platform|
   pkg.version '1.4.0'
   pkg.md5sum 'a2536a9c3d744dc09d234228fe4b0c93'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "http://download.augeas.net/augeas-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-augeas'
   pkg.apply_patch 'resources/patches/augeas/osx-stub-needed-readline-functions.patch'

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,7 +1,7 @@
 component 'curl' do |pkg, settings, platform|
   pkg.version '7.46.0'
   pkg.md5sum '230e682d59bf8ab6eca36da1d39ebd75'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
+  pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"
   pkg.build_requires "puppet-ca-bundle"

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,7 +1,7 @@
 component 'dmidecode' do |pkg, settings, platform|
   pkg.version '2.12'
   pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
+  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.173.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.175.patch"

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -1,7 +1,7 @@
 component 'libedit' do |pkg, settings, platform|
   pkg.version '20150325-3.1'
   pkg.md5sum '43cdb5df3061d78b5e9d59109871b4f6'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/libedit-20150325-3.1.tar.gz"
+  pkg.url "http://thrysoee.dk/editline/libedit-#{pkg.get_version}.tar.gz"
 
   pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
 

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -1,7 +1,7 @@
 component "libxml2" do |pkg, settings, platform|
   pkg.version "2.9.3"
   pkg.md5sum "daece17e045f1c107610e137ab50c179"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "http://xmlsoft.org/sources/libxml2-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,7 +1,7 @@
 component "libxslt" do |pkg, settings, platform|
   pkg.version "1.1.28"
   pkg.md5sum "9667bf6f9310b957254fdcf6596600b7"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "http://xmlsoft.org/sources/libxslt-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,5 +1,0 @@
-{
-  "version": "2.24",
-  "md5sum": "0fa251d152383ded6850097279291bb0",
-  "url": "http://buildsources.delivery.puppetlabs.net/windows/nssm/nssm-2.24.zip"
-}

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -1,5 +1,7 @@
 component "nssm" do |pkg, settings, platform|
-  pkg.load_from_json("configs/components/nssm.json")
+  pkg.version "2.24"
+  pkg.md5sum "0fa251d152383ded6850097279291bb0"
+  pkg.url "https://nssm.cc/release/nssm-#{pkg.get_version}.zip"
 
   # Because we're unpacking a zip archive, we need to set the path to the executable.
   # We don't automatically have this set on windows, unfortunately. We need to set the

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -1,7 +1,7 @@
 component "openssl" do |pkg, settings, platform|
   pkg.version "1.0.2h"
   pkg.md5sum "9392e65072ce4b614c1392eefc1f23d0"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
+  pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-openssl'
 

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -1,7 +1,7 @@
 component "ruby-augeas" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-augeas-0.5.0.tgz"
+  pkg.url "http://download.augeas.net/ruby/ruby-augeas-#{pkg.get_version}.tgz"
 
   pkg.replaces 'pe-ruby-augeas'
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -1,14 +1,16 @@
 component "ruby-selinux" do |pkg, settings, platform|
   if platform.name =~ /^el-5-.*$/
+    # This is a _REALLY_ old version of libselinux found only in Fedora/RH archives and not upstream
     pkg.version "1.33.4"
     pkg.md5sum "08762379de2242926854080dad649b67"
     pkg.apply_patch "resources/patches/ruby-selinux/libselinux-rhat.patch"
+    pkg.url "http://pkgs.fedoraproject.org/repo/pkgs/libselinux/libselinux-1.33.4.tgz/08762379de2242926854080dad649b67/libselinux-1.33.4.tgz"
   else
     pkg.version "2.0.94"
     pkg.md5sum "f814c71fca5a85ebfeb81b57afed59db"
+    pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
   end
 
-  pkg.url "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
 
   pkg.replaces 'pe-ruby-selinux'
 

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -1,7 +1,8 @@
 component "ruby-shadow" do |pkg, settings, platform|
   pkg.version "2.3.3"
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-shadow-2.3.3.tar.gz"
+  # I am unable to find ruby-shadow-2.3.3 source anywhere other than our own website. Upstream appears to be dead.
+  pkg.url "https://downloads.puppetlabs.com/enterprise/sources/3.8.3/solaris/11/source/ruby-shadow-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby-shadow'
 

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -1,7 +1,7 @@
 component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.3.3"
   pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/stomp-1.3.3.gem"
+  pkg.url "https://rubygems.org/downloads/stomp-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-ruby-stomp'
 

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -1,7 +1,7 @@
 component "ruby" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
+  pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -1,7 +1,7 @@
 component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.version "1.0.1"
   pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/deep_merge-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/deep_merge-#{pkg.get_version}.gem"
 
   pkg.replaces "pe-rubygem-deep-merge"
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -4,10 +4,10 @@ component "rubygem-ffi" do |pkg, settings, platform|
   if platform.is_windows?
     if platform.architecture == "x64"
       pkg.md5sum "e3ba1afc17b47ad261bf290b31ce46d7"
-      pkg.url "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x64-mingw32.gem"
+      pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
     else
       pkg.md5sum "e83fb2971a03e52ab3b00e8662ac20ea"
-      pkg.url "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x86-mingw32.gem"
+      pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
     end
 
     pkg.build_requires "ruby"

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -1,7 +1,7 @@
 component "rubygem-hocon" do |pkg, settings, platform|
   pkg.version "0.9.3"
   pkg.md5sum "af89595899c3b893787045039ff02ee0"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/hocon-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/hocon-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -1,7 +1,7 @@
 component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.version "2.0.0"
   pkg.md5sum "e608463ac8081fe600f7bb6ea46c3e64"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/mini_portile2-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/mini_portile2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,7 +1,7 @@
 component "rubygem-minitar" do |pkg, settings, platform|
   pkg.version "0.5.4"
   pkg.md5sum "f5bd734fb3eda7b979d1485ba48fc0ea"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/minitar-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/minitar-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -1,6 +1,6 @@
 component "rubygem-net-netconf" do |pkg, settings, platform|
   pkg.version "0.4.3"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/net-netconf-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/net-netconf-#{get_version}.gem"
   pkg.md5sum "fa173b0965766a427d8692f6b31c85a4"
 
   pkg.build_requires "ruby"

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -1,7 +1,7 @@
 component "rubygem-net-scp" do |pkg, settings, platform|
   pkg.version "1.2.1"
   pkg.md5sum "abeec1cab9696e02069e74bd3eac8a1b"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/net-scp-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/net-scp-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
   pkg.build_requires "rubygem-net-ssh"

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,7 +1,7 @@
 component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version "2.9.2"
   pkg.md5sum "ac7574a89e2b422468d98f5387ceb41e"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/net-ssh-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-rubygem-net-ssh'
 

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -8,7 +8,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-precompiled-huaweios-#{pkg.get_version}.tar.gz"
     pkg.md5sum "8c0a9dfccca51332e35f75d9816440eb"
   else
-    pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-#{pkg.get_version}.gem"
+    pkg.url "https://rubygems.org/downloads/nokogiri-#{pkg.get_version}.gem"
     pkg.md5sum "3e2169ebd67863a8a992289e2a887366"
   end
 

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -1,7 +1,7 @@
 component "rubygem-win32-dir" do |pkg, settings, platform|
   pkg.version "0.4.9"
   pkg.md5sum "df14aa01bd6011f4b6332a05e15b7fb8"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/win32-dir-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/win32-dir-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-win32-eventlog.rb
+++ b/configs/components/rubygem-win32-eventlog.rb
@@ -1,7 +1,7 @@
 component "rubygem-win32-eventlog" do |pkg, settings, platform|
   pkg.version "0.6.2"
   pkg.md5sum "89b2e7dd8cc599168fa444e73c014c3d"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/win32-eventlog-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/win32-eventlog-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -1,7 +1,7 @@
 component "rubygem-win32-process" do |pkg, settings, platform|
   pkg.version "0.7.4"
   pkg.md5sum "3231cf152383fb2d792dcac8036b060f"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/win32-process-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/win32-process-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -1,7 +1,7 @@
 component "rubygem-win32-security" do |pkg, settings, platform|
   pkg.version "0.2.5"
   pkg.md5sum "97c4b971ea19ca48cea7dec1d21d506a"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/win32-security-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/win32-security-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -1,7 +1,7 @@
 component "rubygem-win32-service" do |pkg, settings, platform|
   pkg.version "0.8.6"
   pkg.md5sum "b9b410177485069f5e4c3e1afac0779c"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/win32-service-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/win32-service-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,7 +1,7 @@
 component "virt-what" do |pkg, settings, platform|
-  pkg.version "1.1.4"
+  pkg.version "1.14"
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/virt-what-1.14.tar.gz"
+  pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-virt-what'
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -266,4 +266,9 @@ project "puppet-agent" do |proj|
 
   proj.timeout 7200 if platform.is_windows?
 
+  # Here we rewrite public http urls to use our internal source host instead.
+  # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
+  # rewritten as
+  # http://buildsources.delivery.puppetlabs.net/openssl-1.0.0r.tar.gz
+  proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
 end


### PR DESCRIPTION
Prior to this commit, for anybody not on the Puppet, Inc VPN a person
had to manually gather sources for ~20 items and place them at a
location web accessable and then modify component files to point to that
location just to get started on a build.

Vanagon has had http rewrite rule magic in it for a while. This commit
simply puts the upstream URL in place for primary url on most
components. This should remove the first hour or two of work from any
community member attempting to build out the puppet-agent.

If you're a community member, now you'll simply have to comment out the
rewrite line in configs/projects/puppet-agent.rb

This will not allow community members to build hauwei, or aix due to
other things required that our only on our build infrastructure.

Windows will not work with just this commit, as other changes are
required. That will be addressed in another PR.

Yet another note: This doesn't help with things requiring pl-gcc, pl-* and the like. 