### PR TITLE
(PA-304) Bump to Leatherman 0.6.1 for Facter bug fixes

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "03516a90a9a3a4ccfce44bbfb71930510779aa50"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "2a0cbb5dbab8c967272b9cd04a0a923b6b42b73f"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.4.2"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.6.1"}


### PR DESCRIPTION
Facter fixes on stable require Leatherman 0.6.0. Update to it.