### PR TITLE
(RE-7032) Fix puppet-ca-bundle installs on cross-compiled platforms

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -4,9 +4,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.url "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"
-  # TODO: remove the exception here once puppet-ca-bundle can be
-  # installed in cross-compiled environments (sgarman: 2016-04-15)
-  pkg.build_requires "puppet-ca-bundle" unless platform.architecture == "s390x"
+  pkg.build_requires "puppet-ca-bundle"
 
   if platform.architecture == "s390x"
     pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -5,12 +5,18 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
   # make the keystore
   pkg.build_requires 'facter'
 
+  openssl_cmd = "#{settings[:bindir]}/openssl"
+  if platform.architecture == "s390x"
+    # Use the build host's openssl command, not our cross-compiled one
+    openssl_cmd = "/usr/bin/openssl"
+  end
+
   install_commands = [
-    "#{platform[:make]} install OPENSSL=#{settings[:bindir]}/openssl USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
+    "#{platform[:make]} install OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
   ]
 
   if settings[:java_available]
-    install_commands << "#{platform[:make]} keystore DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
+    install_commands << "#{platform[:make]} keystore OPENSSL=#{openssl_cmd} DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
   end
 
   pkg.install do

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -208,9 +208,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby-shadow" unless platform.is_aix? || platform.is_windows?
   proj.component "ruby-augeas" unless platform.is_windows?
   proj.component "openssl"
-  # TODO: remove the exception here once puppet-ca-bundle can be
-  # installed in cross-compiled environments (sgarman 2016-04-15)
-  proj.component "puppet-ca-bundle" unless platform.architecture == "s390x"
+  proj.component "puppet-ca-bundle"
   proj.component "libxml2" unless platform.is_windows?
   proj.component "libxslt" unless platform.is_windows?
 


### PR DESCRIPTION
And re-enable it on sles-11-s390x.