### PR TITLE
Revert to PTFW File Paths

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -9,30 +9,31 @@ component "hiera" do |pkg, settings, platform|
 
   pkg.replaces 'pe-hiera'
 
+  configdir = settings[:puppet_configdir]
+  flags = " --bindir=#{settings[:bindir]} \
+            --sitelibdir=#{settings[:ruby_vendordir]} \
+            --ruby=#{File.join(settings[:bindir], 'ruby')} "
+
   if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
-  else
-    configdir = settings[:puppet_configdir]
+    pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
+    flags = " --bindir=#{settings[:hiera_bindir]} \
+              --sitelibdir=#{settings[:hiera_libdir]} \
+              --ruby=#{File.join(settings[:ruby_dir], 'bin/ruby')} "
   end
 
   pkg.install do
     ["#{settings[:host_ruby]} install.rb \
-    --ruby=#{File.join(settings[:bindir], 'ruby')} \
-    --bindir=#{settings[:bindir]} \
-    --configdir=#{configdir} \
-    --sitelibdir=#{settings[:ruby_vendordir]} \
     --configs \
-    --quick \
+    --configdir=#{configdir} \
     --man \
-    --mandir=#{settings[:mandir]}"]
+    --mandir=#{settings[:mandir]} \
+    #{flags}"]
   end
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec" unless platform.is_windows?
 
-  if platform.is_windows?
-    pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
-    pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
-  end
   pkg.configfile File.join(configdir, 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -62,7 +62,7 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "CYGWIN" => settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -68,7 +68,7 @@ component "marionette-collective" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\rubyw.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\sys\\ruby\\bin\\rubyw.exe"
   else
     fail "need to know where to put service files"
   end

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -8,5 +8,5 @@ component "nssm" do |pkg, settings, platform|
 
   win_arch = platform.architecture == "x64" ? "win64" : "win32"
 
-  pkg.install_file "#{win_arch}/nssm.exe", "#{settings[:bindir]}/nssm.exe"
+  pkg.install_file "#{win_arch}/nssm.exe", "#{settings[:service_dir]}/nssm.exe"
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -63,7 +63,7 @@ component "puppet" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\ruby.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\sys\\ruby\\bin\\ruby.exe"
   else
     fail "need to know where to put service files"
   end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -102,7 +102,9 @@ component "puppet" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
-    pkg.environment "FACTERDIR" => settings[:prefix]
+    pkg.environment "FACTERDIR" => settings[:facter_root]
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "RUBYLIB" => "#{settings[:hiera_libdir]}"
   end
 
   if platform.is_windows?
@@ -164,9 +166,10 @@ component "puppet" do |pkg, settings, platform|
     pkg.install_file "../puppet_shell.bat", "#{settings[:link_bindir]}/puppet_shell.bat"
 
     pkg.install_file "ext/windows/service/daemon.bat", "#{settings[:bindir]}/daemon.bat"
-    pkg.install_file "ext/windows/service/daemon.rb", "#{settings[:bindir]}/daemon.rb"
+    pkg.install_file "ext/windows/service/daemon.rb", "#{settings[:service_dir]}/daemon.rb"
     pkg.install_file "../wix/icon/puppet.ico", "#{settings[:miscdir]}/puppet.ico"
     pkg.install_file "../wix/license/LICENSE.rtf", "#{settings[:miscdir]}/LICENSE.rtf"
+    pkg.directory settings[:service_dir]
   end
 
   pkg.configfile File.join(configdir, 'puppet.conf')

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -5,7 +5,7 @@ component "pxp-agent" do |pkg, settings, platform|
   cmake = "/opt/pl-build-tools/bin/cmake"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
   end
@@ -16,6 +16,8 @@ component "pxp-agent" do |pkg, settings, platform|
 
   make = platform[:make]
 
+  special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
+
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
@@ -23,7 +25,7 @@ component "pxp-agent" do |pkg, settings, platform|
   elsif platform.is_osx?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
-    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
+    special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
@@ -32,7 +34,7 @@ component "pxp-agent" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
 
     # PCP-87: If we build with -O3, solaris segfaults due to something in std::vector
-    special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
+    special_flags += " -DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG' "
   elsif platform.is_windows?
     pkg.build_requires "cmake"
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
@@ -41,6 +43,7 @@ component "pxp-agent" do |pkg, settings, platform|
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     pkg.environment "CYGWIN" => settings[:cygwin]
 
+    special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
   else
@@ -49,7 +52,7 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-boost"
 
     if platform.is_cisco_wrlinux?
-      special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+      special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
     end
   end
 
@@ -59,7 +62,6 @@ component "pxp-agent" do |pkg, settings, platform|
       #{toolchain} \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
-          -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           #{special_flags} \

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -116,7 +116,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\service\\nssm.exe"
   else
     fail "need to know where to put #{pkg.get_name} service files"
   end

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -11,6 +11,10 @@ component "ruby-stomp" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -7,6 +7,10 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
 
   pkg.build_requires "ruby"
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -16,6 +16,8 @@ component "rubygem-ffi" do |pkg, settings, platform|
     # Instead we use the host gem installation and override GEM_HOME. Yay?
     pkg.environment "GEM_HOME" => settings[:gem_home]
 
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+
     # PA-25 in order to install gems in a cross-compiled environment we need to
     # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
     # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -9,6 +9,10 @@ component "rubygem-hocon" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -9,6 +9,10 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -9,6 +9,10 @@ component "rubygem-minitar" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -12,6 +12,10 @@ component "rubygem-net-netconf" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -10,6 +10,10 @@ component "rubygem-net-scp" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -11,6 +11,10 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -9,6 +9,10 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-eventlog.rb
+++ b/configs/components/rubygem-win32-eventlog.rb
@@ -9,6 +9,10 @@ component "rubygem-win32-eventlog" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -9,6 +9,10 @@ component "rubygem-win32-process" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -9,6 +9,10 @@ component "rubygem-win32-security" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -9,6 +9,10 @@ component "rubygem-win32-service" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -31,6 +31,9 @@ component "runtime" do |pkg, settings, platform|
     pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
+    pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:facter_root]}/lib/libgcc_s_#{lib_type}-1.dll"
+    pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:facter_root]}/lib/libstdc++-6.dll"
+    pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:facter_root]}/lib/libwinpthread-1.dll"
 
     # Curl is dynamically linking against zlib, so we need to include this file until we
     # update curl to statically link against zlib

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -39,6 +39,18 @@ project "puppet-agent" do |proj|
     proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
     proj.setting(:sysconfdir, File.join("C:", "CommonAppDataFolder", proj.company_id))
     proj.setting(:tmpfilesdir, "C:/Windows/Temp")
+    proj.setting(:facter_root, File.join(proj.install_root, "facter"))
+    proj.setting(:hiera_root, File.join(proj.install_root, "hiera"))
+    proj.setting(:hiera_bindir, File.join(proj.hiera_root, "bin"))
+    proj.setting(:hiera_libdir, File.join(proj.hiera_root, "lib"))
+    proj.setting(:mco_root, File.join(proj.install_root, "mcollective"))
+    proj.setting(:mco_bindir, File.join(proj.mco_root, "bin"))
+    proj.setting(:mco_libdir, File.join(proj.mco_root, "lib"))
+    proj.setting(:pxp_root, File.join(proj.install_root, "pxp-agent"))
+    proj.setting(:service_dir, File.join(proj.install_root, "service"))
+    proj.setting(:windows_tools, File.join(proj.install_root, "sys/tools/bin"))
+    proj.setting(:ruby_dir, File.join(proj.install_root, "sys/ruby"))
+    proj.setting(:ruby_bindir, File.join(proj.ruby_dir, "bin"))
   else
     proj.setting(:install_root, "/opt/puppetlabs")
     if platform.is_eos?
@@ -60,20 +72,22 @@ project "puppet-agent" do |proj|
   proj.setting(:puppet_codedir, File.join(proj.sysconfdir, 'code'))
   proj.setting(:bindir, File.join(proj.prefix, "bin"))
   proj.setting(:link_bindir, File.join(proj.install_root, "bin"))
-  proj.setting(:libdir, File.join(proj.prefix, "lib"))
   proj.setting(:includedir, File.join(proj.prefix, "include"))
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
-  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
-  proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   if platform.is_windows?
-    proj.setting(:host_ruby, File.join(proj.bindir, "ruby.exe"))
-    proj.setting(:host_gem, File.join(proj.bindir, "gem.bat"))
+    proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby.exe"))
+    proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem.bat"))
+    proj.setting(:libdir, File.join(proj.ruby_dir, "lib"))
   else
     proj.setting(:host_ruby, File.join(proj.bindir, "ruby"))
     proj.setting(:host_gem, File.join(proj.bindir, "gem"))
+    proj.setting(:libdir, File.join(proj.prefix, "lib"))
   end
+
+  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
+  proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   # Cross-compiled Linux platforms
   platform_triple = "powerpc-linux-gnu" if platform.is_huaweios?
@@ -112,7 +126,7 @@ project "puppet-agent" do |proj|
 
   proj.setting(:gem_install, "#{proj.host_gem} install --no-rdoc --no-ri --local ")
   if platform.is_windows?
-    proj.setting(:gem_install, "#{proj.gem_install} --bindir #{proj.bindir} ")
+    proj.setting(:gem_install, "#{proj.gem_install} --bindir #{proj.ruby_bindir} ")
   end
 
   # For AIX, we use the triple to install a better rbconfig

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -1,22 +1,32 @@
 @ECHO OFF
 REM This is the parent directory of the directory containing this script.
-SET "PL_BASEDIR=%~dp0.."
+SET PL_BASEDIR=%~dp0..
 REM Avoid the nasty \..\ littering the paths.
-SET "PL_BASEDIR=%PL_BASEDIR:\bin\..=%"
-SET "PL_BASEDIR=%PL_BASEDIR%\puppet"
+SET PL_BASEDIR=%PL_BASEDIR:\bin\..=%
 
 REM Set a fact so we can easily source the environment.bat file in the future.
-SET "FACTER_env_windows_installdir=%PL_BASEDIR%"
-SET "FACTERDIR=%PL_BASEDIR%"
+SET FACTER_env_windows_installdir=%PL_BASEDIR%\facter
 
-REM we only need to add the path to the executables, the path to the current
-REM bin directory was already set by the install.
-SET "PATH=%PL_BASEDIR%\bin;%PATH%"
+SET PUPPET_DIR=%PL_BASEDIR%\puppet
+REM Facter will load FACTER_ env vars as facts, so don't use FACTER_DIR
+SET FACTERDIR=%PL_BASEDIR%\facter
+SET HIERA_DIR=%PL_BASEDIR%\hiera
+SET MCOLLECTIVE_DIR=%PL_BASEDIR%\mcollective
+SET RUBY_DIR=%PL_BASEDIR%\sys\ruby
+
+SET PATH=%PUPPET_DIR%\bin;%FACTERDIR%\bin;%HIERA_DIR%\bin;%MCOLLECTIVE_DIR%\bin;%PL_BASEDIR%\bin;%RUBY_DIR%\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
+
+REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
+SET RUBYLIB=%PUPPET_DIR%\lib;%FACTERDIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%
+
+REM Translate all slashes to / style to avoid issue #11930
+SET RUBYLIB=%RUBYLIB:\=/%
+
 
 REM Enable rubygems support
 SET RUBYOPT=rubygems
 REM Now return to the caller.
 
 REM Set SSL variables to ensure trusted locations are used
-SET "SSL_CERT_FILE=%PL_BASEDIR%\ssl\cert.pem"
-SET "SSL_CERT_DIR=%PL_BASEDIR%\ssl\certs"
+SET SSL_CERT_FILE=%PL_BASEDIR%\ssl\cert.pem
+SET SSL_CERT_DIR=%PL_BASEDIR%\ssl\certs

--- a/resources/windows/wix/service.mcollective.wxs.erb
+++ b/resources/windows/wix/service.mcollective.wxs.erb
@@ -8,7 +8,7 @@
                  Win64="<%= settings[:win64] %>">
         <File Id="RubyWExe"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\rubyw.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\rubyw.exe" />
         <!-- This service is installed with start set to demand because
         it won't be correctly configured to start right away. The
         puppet run that configures mcollective will allow it to start
@@ -24,7 +24,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-I&quot;[INSTALLDIR]puppet\lib&quot; -rubygems &quot;[INSTALLDIR]puppet\bin\mcollectived&quot; --daemonize" />
+                        Arguments="-I&quot;[INSTALLDIR]puppet\lib;[INSTALLDIR]facter\lib;[INSTALLDIR]hiera\lib;[INSTALLDIR]mcollective\lib&quot; -rubygems &quot;[INSTALLDIR]mcollective\bin\mcollectived&quot; --daemonize" />
         <ServiceControl Id="MCOStartService"
                         Stop="both"
                         Remove="uninstall"

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -13,7 +13,7 @@
         </Condition>
         <File Id="RubyExeAutomatic"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -26,7 +26,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptions"
                         Start="install"
                         Stop="both"
@@ -44,7 +44,7 @@
         </Condition>
         <File Id="RubyExeManual"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerManual"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -57,7 +57,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptionsManual"
                         Stop="both"
                         Remove="uninstall"
@@ -74,7 +74,7 @@
         </Condition>
         <File Id="RubyExeDisabled"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerDisabled"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -87,7 +87,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]puppet\bin\daemon.rb&quot;" />
+                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptionsDisabled"
                         Stop="both"
                         Remove="uninstall"

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -9,7 +9,7 @@
         <CreateFolder />
         <File Id="NSSM"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\service\nssm.exe" />
 
         <ServiceInstall Id="PXPServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -25,16 +25,16 @@
         <!-- Various registry keys documented at https://nssm.cc/usage -->
         <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\pxp-agent\Parameters">
           <RegistryValue Name="AppDirectory"
-                         Value="[INSTALLDIR]puppet\bin"
+                         Value="[INSTALLDIR]pxp-agent\bin"
                          Type="expandable" />
           <RegistryValue Name="Application"
-                         Value="[INSTALLDIR]puppet\bin\pxp-agent.exe"
+                         Value="[INSTALLDIR]pxp-agent\bin\pxp-agent.exe"
                          Type="expandable" />
           <RegistryValue Name="AppParameters"
                          Value=""
                          Type="expandable" />
           <RegistryValue Name="AppEnvironmentExtra"
-                         Value="PATH=[INSTALLDIR]puppet\bin;%PATH%"
+                         Value="PATH=[INSTALLDIR]pxp-agent\bin;%PATH%"
                          Type="multiString"
                          Action="append" />
           <!-- Skip responding to WM_QUIT and WM_CLOSE -->


### PR DESCRIPTION
We are doing a major path change to the current windows Puppet-Agent work. The change itself is actually a reversion to old standards for MSIs. See https://tickets.puppetlabs.com/browse/RE-7027 for details on why we are doing this