### PR TITLE
(RE-7099) Update Ruby to 2.1.9 for sles-11-s390x

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -49,7 +49,7 @@ component "ruby" do |pkg, settings, platform|
       :target_double => "powerpc-linux",
     },
     's390x-linux-gnu' => {
-      :sum => "07bd699a2fbe131e25d3d37ea82ada78",
+      :sum => "3bb93ed43fddc4807347a988cbb2e0c1",
       :target_double => "s390x-linux",
     },
     'i386-pc-solaris2.10' => {

--- a/resources/files/rbconfig-s390x-linux-gnu.rb
+++ b/resources/files/rbconfig-s390x-linux-gnu.rb
@@ -3,8 +3,8 @@
 # changes made to this file will be lost the next time ruby is built.
 
 module RbConfig
-  RUBY_VERSION == "2.1.8" or
-    raise "ruby lib version (2.1.8) doesn't match executable version (#{RUBY_VERSION})"
+  RUBY_VERSION == "2.1.9" or
+    raise "ruby lib version (2.1.9) doesn't match executable version (#{RUBY_VERSION})"
 
   TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.1.0/s390x-linux")
   DESTDIR = '' unless defined? DESTDIR
@@ -13,7 +13,7 @@ module RbConfig
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "1"
   CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "440"
+  CONFIG["PATCHLEVEL"] = "490"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")


### PR DESCRIPTION
Our switch to ruby 2.1.9 happened in the midst of me working on
this platform, so bumping it apart from the other platform rbconfigs.