### PR TITLE
(PA-308) update timeout for windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.6.0')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.6.1')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -253,4 +253,6 @@ project "puppet-agent" do |proj|
   proj.directory proj.logdir unless platform.is_windows?
   proj.directory proj.piddir unless platform.is_windows?
 
+  proj.timeout 7200 if platform.is_windows?
+
 end


### PR DESCRIPTION
windows builds of puppet agent are longer than the standard 1 hour set by the
new vanagon retry logic. we need to extend the timeout.