### PR TITLE
(MAINT) Use a SHA reference for CFPropertylist

### DIFF
--- a/configs/components/cfpropertylist.json
+++ b/configs/components/cfpropertylist.json
@@ -1,0 +1,1 @@
+{"url": "git@github.com:ckruse/CFPropertyList.git", "ref": "2.2.7"}

--- a/configs/components/cfpropertylist.rb
+++ b/configs/components/cfpropertylist.rb
@@ -1,7 +1,5 @@
 component "cfpropertylist" do |pkg, settings, platform|
-  pkg.version "2.2.7"
-  pkg.md5sum "be2fc619084422cc28cb68f6084bea91"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/CFPropertyList-2.2.7.tar.gz"
+  pkg.load_from_json('configs/components/cfpropertylist.json')
 
   pkg.build_requires "ruby"
 


### PR DESCRIPTION
The tarball we use to package this is of unknown provenance and the mixed case has been sort of an annoyance to use with Vanagon's rewrite engine. By switching to a git SHA (specifically for the version we're already using), we should hopefully avoid both of these problems.