### PR TITLE
(PA-320) Add semantic_puppet gem to puppet-agent

### DIFF
--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -1,0 +1,21 @@
+component "rubygem-semantic_puppet" do |pkg, settings, platform|
+  pkg.version "0.1.2"
+  pkg.md5sum "192ae7729997cb5d5364f64b99b13121"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/semantic_puppet-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+
+  # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
+  pkg.install do
+    ["#{settings[:gem_install]} semantic_puppet-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -196,6 +196,7 @@ project "puppet-agent" do |proj|
   proj.component "rubygem-deep-merge"
   proj.component "rubygem-net-ssh"
   proj.component "rubygem-hocon"
+  proj.component "rubygem-semantic_puppet"
   if platform.is_windows?
     proj.component "rubygem-ffi"
     proj.component "rubygem-minitar"


### PR DESCRIPTION
This is currently vendored in puppet and adding it to puppet-agent
will allow us to unvendor and thus to maintain just one copy of the code.