### PR TITLE
(MAINT) Fix bad tag for CF Property List

### DIFF
--- a/configs/components/cfpropertylist.json
+++ b/configs/components/cfpropertylist.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:ckruse/CFPropertyList.git", "ref": "2.2.7"}
+{"url": "git@github.com:ckruse/CFPropertyList.git", "ref": "cfpropertylist-2.2.7"}


### PR DESCRIPTION
Should have used `cfpropertylist-2.2.7`. Oops.