### PR TITLE
(PA-287) Move hiera.yaml from codedir to puppet_configdir

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -28,6 +28,7 @@ component "hiera" do |pkg, settings, platform|
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
@@ -41,4 +42,7 @@ component "hiera" do |pkg, settings, platform|
   else
     pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'hieradata')
   end
+
+  pkg.add_preinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml')} ]; then cp #{File.join(settings[:puppet_codedir], 'hiera.yaml')} #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')}; fi"]
+  pkg.add_postinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} ]; then mv #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} #{File.join(settings[:puppet_codedir], 'hiera.yaml')}; fi"]
 end

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -9,11 +9,17 @@ component "hiera" do |pkg, settings, platform|
 
   pkg.replaces 'pe-hiera'
 
+  if platform.is_windows?
+    configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
+  else
+    configdir = settings[:puppet_configdir]
+  end
+
   pkg.install do
     ["#{settings[:host_ruby]} install.rb \
     --ruby=#{File.join(settings[:bindir], 'ruby')} \
     --bindir=#{settings[:bindir]} \
-    --configdir=#{settings[:puppet_codedir]} \
+    --configdir=#{configdir} \
     --sitelibdir=#{settings[:ruby_vendordir]} \
     --configs \
     --quick \
@@ -26,7 +32,7 @@ component "hiera" do |pkg, settings, platform|
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
   end
-  pkg.configfile File.join(settings[:puppet_codedir], 'hiera.yaml')
+  pkg.configfile File.join(configdir, 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?
 

--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -85,6 +85,10 @@
         Guid="B9179A60-483F-4F32-8E3F-AD632B0DEBB4"
         Directory="PuppetConfDir">
         <CreateFolder />
+        <File
+          Id="HieraConf"
+          KeyPath="yes"
+          Source="SourceDir\CommonAppDataFolder\Puppetlabs\puppet\etc\hiera.yaml" />
         <IniFile
           Id="PuppetConfServer" Name="puppet.conf"
           Action="addLine"
@@ -191,10 +195,6 @@
         Guid="0D29EB1B-604D-4FE1-A75C-F18CC230BEED"
         Directory="CodeDir">
         <CreateFolder />
-        <File
-          Id="HieraConf"
-          KeyPath="yes"
-          Source="SourceDir\CommonAppDataFolder\Puppetlabs\code\hiera.yaml" />
       </Component>
       <Component
         Id="HieraDataDir"


### PR DESCRIPTION
For new installations, hiera.yaml will be installed in the puppet_configdir rather than codedir.

For upgrades, if hiera.yaml exists in codedir it will be preserved there.