### PR TITLE
(PA-321) Bump Leatherman version to resolve test failure on win2012

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "c7490efda698a7e4c0505827eaed0bdac92a47fe"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "79c501db43be899230899b5c61b3ef094542f186"}


### PR DESCRIPTION
Bumps to a Leatherman version that disables the Leatherman.curl tests
under the puppet-agent build configuration. AppVeyor CI is still testing
using different configurations, but we haven't yet resolved how to use
libcurl stubs with dynamic Leatherman and libcurl. See LTH-70.

/cc @McdonaldSeanp; I'm running a test build locally, I'll update when it finishes.