### PR TITLE
(maint) Add xenial to build targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -50,7 +50,7 @@ pe_platforms:
   - ubuntu-10.04-i386
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
-deb_targets: 'lucid-i386 lucid-amd64 precise-i386 precise-amd64 squeeze-i386 squeeze-amd64 trusty-i386 trusty-amd64 wheezy-i386 wheezy-amd64'
+deb_targets: 'lucid-i386 lucid-amd64 precise-i386 precise-amd64 squeeze-i386 squeeze-amd64 trusty-i386 trusty-amd64 wheezy-i386 wheezy-amd64 xenial-i386 xenial-amd64'
 rpm_targets: 'el-5-i386 el-5-x86_64 el-6-i386 el-6-x86_64 el-7-x86_64 sles-11-i386 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"


### PR DESCRIPTION
It seems that we need to specify deb_targets in order to have packages
promote successfully into PE. The promotion job takes this list of
platforms and will only promote the packages that correspond to this
list somehow. I could very well be wrong in this assertion, but that is
certainly how things seem to work at the moment.