### PR TITLE
Revert "(RE-7221) Update to OpenSSL 1.0.2h"

### DIFF
--- a/bin/windows-env.ps1
+++ b/bin/windows-env.ps1
@@ -39,7 +39,7 @@ $mingwVer = "${mingwArch}_mingw-w64_${mingwVerNum}_${mingwThreads}_${mingwExcept
 
 $rubyPkg = "ruby-2.1.8-${rubyArch}-mingw32"
 
-$opensslPkg = "openssl-1.0.2h-${opensslArch}-windows"
+$opensslPkg = "openssl-1.0.2g-${opensslArch}-windows"
 
 $curlVer = "curl-7.42.1"
 $curlPkg = "${curlVer}-${mingwVer}"

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -1,6 +1,6 @@
 component "openssl" do |pkg, settings, platform|
-  pkg.version "1.0.2h"
-  pkg.md5sum "9392e65072ce4b614c1392eefc1f23d0"
+  pkg.version "1.0.2g"
+  pkg.md5sum "f3c710c045cdee5fd114feb69feba7aa"
   pkg.url "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-openssl'

--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.8.3-x86",
-    "x64": "refs/tags/2.1.8.3-x64"
+    "x86": "refs/tags/2.1.8.2-x86",
+    "x64": "refs/tags/2.1.8.2-x64"
   }
 }


### PR DESCRIPTION
Reverts puppetlabs/puppet-agent#659

The openssl update is causing a test failure, reverting until we fully understand the root cause.