### PR TITLE
(maint) Bump to pre-release cpp-pcp-client

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.1.2"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "stable"}


### PR DESCRIPTION
Bump to cpp-pcp-client#stable, the pre-release code for cpp-pcp-client.