### PR TITLE
(maint) Set LC_ALL=C when running leatherman tests on Solaris

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -98,7 +98,7 @@ component "leatherman" do |pkg, settings, platform|
   end
 
   if platform.is_solaris? && platform.architecture != 'sparc'
-    test = "LANG=C #{test}"
+    test = "LANG=C LC_ALL=C #{test}"
   end
 
   pkg.build do


### PR DESCRIPTION
Recently, Solaris builds of Puppet Agent began failing due
to leatherman test failures following the build. These test
errors are due to a locale issue, specifically:

unexpected exception with message:
   locale::facet::_S_create_c_locale name not valid

Setting LC_ALL before running `make test` prevents this
issue, though this is a temporary solution. Future
improvements could include attempting to invoke std::locale
early in the execution lifetime, and setting LANG and LC_ALL
if an exception is thrown. Alternatively, these variables
could become part of the environment for tests in CMake.

(Thanks to @MikaelSmith for tracking this down and for the
above suggestions)