### PR TITLE
(PA-241) Set AIO_AGENT_VERSION fact when building Facter

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -189,6 +189,7 @@ component "facter" do |pkg, settings, platform|
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \
+        -DAIO_AGENT_VERSION=#{settings[:package_version]} \
         #{java_includedir} \
         ."]
   end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -142,6 +142,9 @@ project "puppet-agent" do |proj|
     proj.bill_of_materials File.join(proj.datadir, "doc")
   end
 
+  # Set package version, for use by Facter in creating the AIO_AGENT_VERSION fact.
+  proj.setting(:package_version, proj.get_version)
+
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
   proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")


### PR DESCRIPTION
Configures Facter to hard-code the AIO_AGENT_VERSION based on the
puppet-agent package version.