### PR TITLE
(maint) Enable tests, use check on all CMake projects

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -69,6 +69,14 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
+  # Can't run binaries when cross-compiling, and Solaris has an issue with
+  # accessing the certs while testing. AIX tests are always iffy.
+  if !platform.is_cross_compiled? && !platform.is_solaris? && !platform.is_aix?
+    pkg.check do
+      ["#{make} test ARGS=-V"]
+    end
+  end
+
   pkg.install do
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -193,20 +193,16 @@ component "facter" do |pkg, settings, platform|
         ."]
   end
 
-  # Make test will explode horribly in a cross-compile situation
-  # Tests will be skipped on AIX until they are expected to pass
-  if platform.is_cross_compiled? || platform.is_aix?
-    test = ":"
-  else
-    test = "#{make} test ARGS=-V"
+  pkg.build do
+    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
-  pkg.build do
-    # Until a `check` target exists, run tests are part of the build.
-    [
-      "#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
-      test
-    ]
+  # Make test will explode horribly in a cross-compile situation
+  # Tests will be skipped on AIX until they are expected to pass
+  if !platform.is_cross_compiled? && !platform.is_aix?
+    pkg.check do
+      ["#{make} test ARGS=-V"]
+    end
   end
 
   pkg.install do

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -89,24 +89,25 @@ component "leatherman" do |pkg, settings, platform|
         ."]
   end
 
-  # Make test will explode horribly in a cross-compile situation
-  # Tests will be skipped on AIX until they are expected to pass
-  if platform.is_cross_compiled? || platform.is_aix?
-    test = "/bin/true"
-  else
-    test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{make} test ARGS=-V"
-  end
-
-  if platform.is_solaris? && platform.architecture != 'sparc'
-    test = "LANG=C LC_ALL=C #{test}"
-  end
-
   pkg.build do
     # Until a `check` target exists, run tests are part of the build.
     [
       "#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
       "#{test}"
     ]
+  end
+
+  # Make test will explode horribly in a cross-compile situation
+  # Tests will be skipped on AIX until they are expected to pass
+  if !platform.is_cross_compiled? && !platform.is_aix?
+    test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{make} test ARGS=-V"
+    if platform.is_solaris? && platform.architecture != 'sparc'
+      test = "LANG=C LC_ALL=C #{test}"
+    end
+
+    pkg.check do
+      [test]
+    end
   end
 
   pkg.install do

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -74,6 +74,14 @@ component "pxp-agent" do |pkg, settings, platform|
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
+  # Can't run binaries when cross-compiling, and Solaris has an issue with
+  # accessing the certs while testing. AIX tests are always iffy.
+  if !platform.is_cross_compiled? && !platform.is_solaris? && !platform.is_aix?
+    pkg.check do
+      ["#{make} test ARGS=-V"]
+    end
+  end
+
   pkg.install do
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end


### PR DESCRIPTION
Enable tests on cpp-pcp-client and pxp-agent (on platforms where they're
expected to pass). Update facter and leatherman to use the
Component#check method for tests.