### PR TITLE
(PA-347) Put back nssm.json

### DIFF
--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.24",
+  "md5sum": "0fa251d152383ded6850097279291bb0",
+  "url": "http://buildsources.delivery.puppetlabs.net/windows/nssm/nssm-2.24.zip"
+}


### PR DESCRIPTION
nssm.json was removed because the contents of that file were moved into
nssm.rb which vanagon uses. Currently, however, the Windows builds still
use the bin/build-windows command which needs to read information about
nssm from the json file.

Once we move fully to a pure-vanagon build of the Windows MSI, nssm.json
should be removed.