### PR TITLE
(RE-7020) Remove extraneous batch files from bin dirs

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -190,6 +190,7 @@ component "facter" do |pkg, settings, platform|
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \
         -DAIO_AGENT_VERSION=#{settings[:package_version]} \
+        -DINSTALL_BATCH_FILES=NO \
         #{java_includedir} \
         ."]
   end

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -29,6 +29,7 @@ component "hiera" do |pkg, settings, platform|
     --configdir=#{configdir} \
     --man \
     --mandir=#{settings[:mandir]} \
+    --no-batch-files \
     #{flags}"]
   end
 

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -101,6 +101,7 @@ component "marionette-collective" do |pkg, settings, platform|
         --sbindir=#{settings[:bindir]} \
         --plugindir=#{plugindir} \
         --quick \
+        --no-batch-files \
         #{flags}"]
   end
 

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -134,6 +134,7 @@ component "puppet" do |pkg, settings, platform|
         --logdir=#{logdir} \
         --configs \
         --quick \
+        --no-batch-files \
         --man \
         --mandir=#{settings[:mandir]}"]
   end


### PR DESCRIPTION
Now that puppet-agent carries batch files inside it's own project, we need to
specify to the component installers that they do not need to install them.