### PR TITLE
(RE-7262) Update runtime to pull in dlls + update components to use ruby_bindir

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -28,7 +28,7 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires "openssl"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
   end

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -20,7 +20,7 @@ component "hiera" do |pkg, settings, platform|
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
     flags = " --bindir=#{settings[:hiera_bindir]} \
               --sitelibdir=#{settings[:hiera_libdir]} \
-              --ruby=#{File.join(settings[:ruby_dir], 'bin/ruby')} "
+              --ruby=#{File.join(settings[:ruby_bindir], 'ruby')} "
   end
 
   pkg.install do

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -62,7 +62,7 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "CYGWIN" => settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -92,7 +92,7 @@ component "marionette-collective" do |pkg, settings, platform|
     flags = " --bindir=#{settings[:mco_bindir]} \
               --sitelibdir=#{settings[:mco_libdir]} \
               --no-service-files \
-              --ruby=#{File.join(settings[:ruby_dir], 'bin/ruby')} "
+              --ruby=#{File.join(settings[:ruby_bindir], 'ruby')} "
   end
 
   pkg.install do

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -103,7 +103,7 @@ component "puppet" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.environment "FACTERDIR" => settings[:facter_root]
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "RUBYLIB" => "#{settings[:hiera_libdir]}"
   end
 

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -5,7 +5,7 @@ component "pxp-agent" do |pkg, settings, platform|
   cmake = "/opt/pl-build-tools/bin/cmake"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
     pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
   end

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -12,7 +12,7 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -147,12 +147,15 @@ component "ruby" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:bindir]}):$$PATH"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
     pkg.environment "CYGWIN" => settings[:cygwin]
+
     # So we need to pass -static-libgcc to the compiler, but we cannot pass -static-libgcc as
     # a regular flag, for information as to why: http://www.mingw.org/wiki/HOWTO_Sneak_GCC_Switches_Past_Libtool
     # in order to actually get gcc to honor the flag you need to set CC specifically with the flag in it
     pkg.environment "CC" => "gcc -static-libgcc"
+    pkg.environment "optflags" => settings[:cflags]
+    pkg.environment "LDFLAGS" => settings[:ldflags]
 
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
   end

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -8,7 +8,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.build_requires "ruby"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -16,7 +16,7 @@ component "rubygem-ffi" do |pkg, settings, platform|
     # Instead we use the host gem installation and override GEM_HOME. Yay?
     pkg.environment "GEM_HOME" => settings[:gem_home]
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
 
     # PA-25 in order to install gems in a cross-compiled environment we need to
     # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -10,7 +10,7 @@ component "rubygem-hocon" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -10,7 +10,7 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -10,7 +10,7 @@ component "rubygem-minitar" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -13,7 +13,7 @@ component "rubygem-net-netconf" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -11,7 +11,7 @@ component "rubygem-net-scp" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -12,7 +12,7 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -9,6 +9,10 @@ component "rubygem-semantic_puppet" do |pkg, settings, platform|
   # Instead we use the host gem installation and override GEM_HOME. Yay?
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
+  if platform.is_windows?
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+  end
+
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -10,7 +10,7 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-win32-eventlog.rb
+++ b/configs/components/rubygem-win32-eventlog.rb
@@ -10,7 +10,7 @@ component "rubygem-win32-eventlog" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -10,7 +10,7 @@ component "rubygem-win32-process" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -10,7 +10,7 @@ component "rubygem-win32-security" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -10,7 +10,7 @@ component "rubygem-win32-service" do |pkg, settings, platform|
   pkg.environment "GEM_HOME" => settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_dir]}/bin):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -37,7 +37,15 @@ component "runtime" do |pkg, settings, platform|
 
     # Curl is dynamically linking against zlib, so we need to include this file until we
     # update curl to statically link against zlib
-    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:bindir]}/zlib1.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:ruby_bindir]}/zlib1.dll"
+
+    # gdbm, yaml-cpp and iconv are all runtime dependancies of ruby, and their libraries need
+    # To exist inside our vendored ruby
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
+
   else
     pkg.install_file File.join(libdir, "libstdc++.so.6.0.18"), "/opt/puppetlabs/puppet/lib/libstdc++.so.6.0.18"
     pkg.install_file File.join(libdir, "libgcc_s.so.1"), "/opt/puppetlabs/puppet/lib/libgcc_s.so.1"


### PR DESCRIPTION
   Ruby links against several DLLs during its own compilation. Some of these DLLs
    are also runtime deps, and need to be pulled in after compilation so they will
    be included in the ruby we vendor