### PR TITLE
(PA-241) AIO_AGENT_VERSION excludes git sha

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -171,6 +171,10 @@ component "facter" do |pkg, settings, platform|
     end
   end
 
+  # In PE, aio_agent_version is distinguished from aio_agent_build by not including the git sha.
+  # Strip it off; this should have no impact on final releases, as git sha would not be included.
+  aio_agent_version = settings[:package_version].match(/^\d+\.\d+\.\d+(\.\d+){0,2}/).to_s
+
   unless platform.is_windows?
     special_flags += " -DFACTER_PATH=#{settings[:bindir]} \
                        -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]')"
@@ -189,7 +193,7 @@ component "facter" do |pkg, settings, platform|
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \
-        -DAIO_AGENT_VERSION=#{settings[:package_version]} \
+        -DAIO_AGENT_VERSION=#{aio_agent_version} \
         #{java_includedir} \
         ."]
   end


### PR DESCRIPTION
Make the `aio_agent_version` fact in Facter consistent with that in PE
by excluding the git sha from git describe.