### PR TITLE
(maint) Remove Huaweios exclusion for dmidecode

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -215,7 +215,7 @@ project "puppet-agent" do |proj|
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"
-    proj.component "dmidecode" unless platform.is_huaweios?
+    proj.component "dmidecode"
     proj.component "shellpath"
   end
 


### PR DESCRIPTION
This was apparently lost during a merge, and is needed
for HuaweiOS