### PR TITLE
Revert "bumping puppet to 0fd9d93d36ff461b6ac7d4d60b97cf3426a691cb"

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "d728dd5f800e4ebb408d9ad73879709e7dbadb48"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "8a63d549ae9b1ea57ae8bf20ed258d0352432139"}


### PR DESCRIPTION
This reverts commit 537d75e78ec62bb3c4efafe0ca7be7dcfe191d35.

This version of puppet is breaking ci