### PR TITLE
Revert "(maint) Update Leatherman to 0.7.2"

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.7.2"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.7.1"}


### PR DESCRIPTION
Needs https://github.com/puppetlabs/leatherman/pull/186 to work on some platforms, and seems to have broken something on Windows as well. Needs more testing before bumping.