### PR TITLE
(maint) Bump Leatherman to fix platforms with locale disabled

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.7.2"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "91c8601349b90bf7d8d92ecc66b8551e21d93c51"}


### PR DESCRIPTION
Leatherman 0.7.2 made a few untested changes to a file only tested when
`std::locale` use is disabled. Bump to pick up a fix for that.