### PR TITLE
(PA-375) Avoid using gettext

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -46,19 +46,19 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end
 
+  # Until we build our own gettext packages, disable using locales.
+  # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     [
       "#{cmake} \
       #{toolchain} \
       #{platform_flags} \
+          -DLEATHERMAN_GETTEXT=OFF \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -166,10 +166,7 @@ component "facter" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end
@@ -182,10 +179,14 @@ component "facter" do |pkg, settings, platform|
     special_flags += " -DFACTER_PATH=#{settings[:bindir]} \
                        -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]')"
   end
+
+  # Until we build our own gettext packages, disable using locales.
+  # gettext 0.17 is required to compile .mo files with msgctxt.
   # FACTER_RUBY Needs bindir
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        -DLEATHERMAN_GETTEXT=OFF \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "91c8601349b90bf7d8d92ecc66b8551e21d93c51"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "23c9c6d12b094a332d2c74c23e91b1f2955063c5"}

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -71,17 +71,17 @@ component "leatherman" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end
 
+  # Until we build our own gettext packages, disable using locales.
+  # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        -DLEATHERMAN_GETTEXT=OFF \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -48,18 +48,18 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end
 
+  # Until we build our own gettext packages, disable using locales.
+  # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     [
       "#{cmake}\
       #{toolchain} \
+          -DLEATHERMAN_GETTEXT=OFF \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \


### PR DESCRIPTION
We haven't built our own gettext packages yet, so avoid using them
altogether.