### PR TITLE
(PA-349) Remove facter/curl/puppet-ca-bundle curcular deps

### DIFF
--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -1,9 +1,7 @@
 component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet-ca-bundle.json")
+
   pkg.build_requires "openssl"
-  # facter will pull in java for server platforms, so require that so we can
-  # make the keystore
-  pkg.build_requires 'facter'
 
   openssl_cmd = "#{settings[:bindir]}/openssl"
   if platform.is_cross_compiled_linux?
@@ -11,15 +9,8 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
     openssl_cmd = "/usr/bin/openssl"
   end
 
-  install_commands = [
-    "#{platform[:make]} install OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
-  ]
-
-  if settings[:java_available]
-    install_commands << "#{platform[:make]} keystore OPENSSL=#{openssl_cmd} DESTDIR=#{File.join(settings[:prefix], 'ssl')}"
-  end
-
   pkg.install do
-    install_commands
+    ["#{platform[:make]} install OPENSSL=#{openssl_cmd} USER=0 GROUP=0 DESTDIR=#{File.join(settings[:prefix], 'ssl')}",
+    "#{platform[:make]} keystore OPENSSL=#{openssl_cmd} DESTDIR=#{File.join(settings[:prefix], 'ssl')}"]
   end
 end


### PR DESCRIPTION
Prior to this commit, facter depended on curl, which depended on
puppet-ca-bundle, which depended on facter. This is bad, since we don't
want circular dependencies in our build systems.

This commit removed that circular dependency by altering
puppet-ca-bundle's requirement on facter. The only reason facter was
listed as a build dependency was to get a list of platforms that had
java installed on them. Though the Makefile for puppet-ca-bundle does
not require java explicitly, this was a means to determine which
platforms would be made available as master platforms. These required
the additional keystore to be available to the puppetserver package. The
original logic behind this decision was to avoid duplication of logic in
determining which platforms to make the keystore available on. Rather
than perpetuating the circular logic in favor of reduced maintenance,
this commit simply generates the keystore for all agents.