### PR TITLE
Revert "(PA-375) Disable locales on SLES and EL-4"

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -46,10 +46,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -166,10 +166,7 @@ component "facter" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -71,10 +71,7 @@ component "leatherman" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -48,10 +48,7 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
 
-    # SLES-10 and EL-4 have old versions of gettext on them; until we build our own, disable using locales.
-    # gettext 0.17 is required to compile .mo files with msgctxt. This shouldn't cause an issue otherwise,
-    # as we use their default locales anyway.
-    if platform.is_cisco_wrlinux? || platform.is_sles? || platform.name =~ /el-4/
+    if platform.is_cisco_wrlinux?
       special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
     end
   end


### PR DESCRIPTION
This reverts commit 4ac2e2bb747df97dd99ac35f19b7e6564a9dbfb1.
Causing facter test failures with leatherman 0.7.1