### PR TITLE
(maint) move project.wxs from vanagon to puppet-agent

### DIFF
--- a/resources/windows/wix/project.wxs.erb
+++ b/resources/windows/wix/project.wxs.erb
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Product
+    Id="*"
+    UpgradeCode="<%= settings[:upgrade_code] %>"
+    Name="<%= settings[:product_name] %>"
+    Language="1033"
+    Codepage="1252"
+    Version="<%= @platform.wix_product_version(@version) %>"
+    Manufacturer="<%= settings[:company_name] %>" >
+
+    <Package
+      InstallerVersion="300"
+      InstallScope="perMachine"
+      Description="<%= "#{settings[:product_id]}#{@platform.architecture == "x64" ? " (64-bit)" : ""}" %> Installer"
+      Comments="<%= @homepage %>"
+      Compressed="yes"
+      Platform="<%= @platform.architecture %>" />
+
+    <!-- We will use DirectoryRef at the project level to hook in the project directory structure -->
+    <Directory Id='TARGETDIR' Name='SourceDir' />
+
+    <MajorUpgrade AllowDowngrades="yes" />
+    <Media Id="1" Cabinet="<%= settings[:product_id] %>.cab" EmbedCab="yes" CompressionLevel="high" />
+
+    <Feature
+      Id="<%= settings[:product_id] %>Runtime"
+      Title="<%= settings[:product_id] %> Runtime"
+      Level="1">
+      <ComponentGroupRef Id="MainComponentGroup" />
+    </Feature>
+
+  </Product>
+</Wix>


### PR DESCRIPTION
After realizing that project.wxs does not actually constitute a default that
belongs in vanagon, this file should be moved under puppet-agent. Vanagon is
already built to handle this change so no vanagon changes will be required.