### PR TITLE
(PA-392) Ensure linking against PL libs

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -219,6 +219,14 @@ component "facter" do |pkg, settings, platform|
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
+  pkg.check do
+    [
+      # Ensure we're linking against our libstdc++ and libgcc_s or statically linking
+      "ldd lib/libfactero.so | grep libstdc++ && ldd lib/libfacter.so | grep libstdc++ | grep puppet || true",
+      "ldd lib/libfacter.so | grep libgcc_s && ldd lib/libfacter.so | grep puppet || true"
+    ]
+  end
+
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/facter.bat", sum: "185b8645feecac4acadc55c64abb3755")


### PR DESCRIPTION
Prior to this commit, there wasn't any verification that we were linking
against our  libstdc++ vs the system-wide library. We'd like to make
sure that we've either statically linked libstdc++ and libgcc_s into our
builds or that we're using the runtime-provided components that would
end up in /opt/puppetlabs/puppet/lib.