### PR TITLE
(maint) Update to correct Leatherman version after merge

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "91c8601349b90bf7d8d92ecc66b8551e21d93c51"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "23c9c6d12b094a332d2c74c23e91b1f2955063c5"}


### PR DESCRIPTION
Merge from stable didn't bring over a related Leatherman ref bump to
support new configuration. Update it now.