### PR TITLE
(RE-6958) Update build-data to include sles-11-s390x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -41,6 +41,7 @@ pe_platforms:
   - sles-10-x86_64
   - sles-11-i386
   - sles-11-x86_64
+  - sles-11-s390x
   - sles-12-x86_64
   - solaris-10-i386
   - solaris-10-sparc


### PR DESCRIPTION
Update the pe_platforms list to include sles-11-s390x to include it in nightlies