### PR TITLE
(RE-7178) Update build-data to include sles-12-s390x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -43,6 +43,7 @@ pe_platforms:
   - sles-11-x86_64
   - sles-11-s390x
   - sles-12-x86_64
+  - sles-12-s390x
   - solaris-10-i386
   - solaris-10-sparc
   - solaris-11-i386


### PR DESCRIPTION
Update the pe_platforms list to include sles-12-s390x to include it in
nightlies