### PR TITLE
(maint) Skip runtime.sh on OSX

### DIFF
--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -28,6 +28,8 @@ component "runtime" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
+  elsif platform.is_osx?
+    # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"
     pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
@@ -48,7 +50,7 @@ component "runtime" do |pkg, settings, platform|
     pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
 
-  else # Linux systems
+  else # Linux and Solaris systems
     pkg.install do
       "bash runtime.sh #{libdir}"
     end


### PR DESCRIPTION
The recent addition of 'runtime.sh' fails with an
error on OSX. As it's not needed or useful on OSX,
this skips the invocation on those platforms.