### PR TITLE
Revert "(RE-7398) Update libxslt to 1.1.29"

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,6 +1,6 @@
 component "libxslt" do |pkg, settings, platform|
-  pkg.version "1.1.29"
-  pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
+  pkg.version "1.1.28"
+  pkg.md5sum "9667bf6f9310b957254fdcf6596600b7"
   pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"


### PR DESCRIPTION
Reverts puppetlabs/puppet-agent#722, This update was causing build failures with solaris and the issue is non-trivial to fix, so we are reverting for now to keep the pipelines clear