### PR TITLE
(RE-7540) revert libxslt bump back to 1.1.28 on solaris

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,7 +1,13 @@
 component "libxslt" do |pkg, settings, platform|
-  pkg.version "1.1.29"
-  pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  if platform.is_solaris?
+    pkg.version "1.1.28"
+    pkg.md5sum "9667bf6f9310b957254fdcf6596600b7"
+    pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  else
+    pkg.version "1.1.29"
+    pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
+    pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  end
 
   pkg.build_requires "libxml2"
 


### PR DESCRIPTION
Due to failing builds on solaris OSes we are reverting the libxslt version bump
on only solaris platforms. This should be a temporary fix.