### PR TITLE
(RE-7407) move facter rb

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -134,6 +134,7 @@ component "facter" do |pkg, settings, platform|
   ruby = "#{settings[:host_ruby]} -rrbconfig"
 
   make = platform[:make]
+  cp = platform[:cp]
 
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
 
@@ -163,7 +164,8 @@ component "facter" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-    special_flags = "-DCMAKE_INSTALL_PREFIX=#{settings[:facter_root]}"
+    special_flags = "-DCMAKE_INSTALL_PREFIX=#{settings[:facter_root]} \
+                     -DRUBY_LIB_INSTALL=#{settings[:facter_root]}/lib "
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -179,7 +181,8 @@ component "facter" do |pkg, settings, platform|
 
   unless platform.is_windows?
     special_flags += " -DFACTER_PATH=#{settings[:bindir]} \
-                       -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]')"
+                       -DFACTER_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
+                       -DRUBY_LIB_INSTALL=#{settings[:ruby_vendordir]}"
   end
 
   # Until we build our own gettext packages, disable using locales.
@@ -194,7 +197,6 @@ component "facter" do |pkg, settings, platform|
         #{special_flags} \
         -DBOOST_STATIC=ON \
         -DYAMLCPP_STATIC=ON \
-        -DRUBY_LIB_INSTALL=#{settings[:ruby_vendordir]} \
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -104,7 +104,7 @@ component "puppet" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.environment "FACTERDIR" => settings[:facter_root]
     pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
-    pkg.environment "RUBYLIB" => "#{settings[:hiera_libdir]}"
+    pkg.environment "RUBYLIB" => "#{settings[:hiera_libdir]};#{settings[:facter_root]}/lib"
   end
 
   if platform.is_windows?


### PR DESCRIPTION
due to the legacy build process, puppet-agent and the test suite expect
facter.rb to exist under facter/lib, not the vendor_ruby directory. This commit
uses the ruby_lib_install option of facter's cmake makefile to move that file.