### PR TITLE
(PA-390) On AIX, restart services on upgrade

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -55,7 +55,7 @@ component "marionette-collective" do |pkg, settings, platform|
     service_statefile = "#{rpm_statedir}/service.pp"
     pkg.add_preinstall_action ["upgrade"],
       [<<-HERE.undent
-        install --owner root --mode 0700 --directory #{rpm_statedir} || :
+        mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :
         if [ -x #{puppet_bin} ] ; then
           #{puppet_bin} resource service mcollective > #{service_statefile} || :
         fi

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -52,7 +52,7 @@ component "puppet" do |pkg, settings, platform|
     service_statefile = "#{rpm_statedir}/service.pp"
     pkg.add_preinstall_action ["upgrade"],
       [<<-HERE.undent
-        install --owner root --mode 0700 --directory #{rpm_statedir} || :
+        mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :
         if [ -x #{puppet_bin} ] ; then
           #{puppet_bin} resource service puppet > #{service_statefile} || :
         fi


### PR DESCRIPTION
Prior to this, services on AIX are not restarted on upgrade, so
the old puppet and mcollective services may be left running.

This updates puppet-agent's puppet and mcollective component
configurations to save and apply the pre-upgrade service state
for puppet and mcollective (as is done for other RPM platforms 
not using systemd)

Also, on AIX, the system default `install` utility does not create
directories. This commit updates the puppet and mcollective preinstall
actions to use a more portable way of creating the `rpm_statedir`
directories.