### PR TITLE
(RE-7544) patch missing script for libxslt and bump to libxslt 1.1.29

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,13 +1,7 @@
 component "libxslt" do |pkg, settings, platform|
-  if platform.is_solaris?
-    pkg.version "1.1.28"
-    pkg.md5sum "9667bf6f9310b957254fdcf6596600b7"
-    pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  else
-    pkg.version "1.1.29"
-    pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
-    pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  end
+  pkg.version "1.1.29"
+  pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
+  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 
@@ -29,6 +23,7 @@ component "libxslt" do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
+    pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'
   elsif platform.is_osx?
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]

--- a/resources/patches/libxslt/Update-missing-script-to-return-0.patch
+++ b/resources/patches/libxslt/Update-missing-script-to-return-0.patch
@@ -1,0 +1,25 @@
+From ad1177bc54cac2de0672d7188760ecf2d142e029 Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppet.com>
+Date: Tue, 28 Jun 2016 13:24:22 -0700
+Subject: [PATCH] Update missing script to return 0
+
+---
+ missing | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/missing b/missing
+index f62bbae..4ef2bca 100755
+--- a/missing
++++ b/missing
+@@ -204,7 +204,7 @@ give_advice "$1" | sed -e '1s/^/WARNING: /' \
+ 
+ # Propagate the correct exit status (expected to be 127 for a program
+ # not found, 63 for a program that failed due to version mismatch).
+-exit $st
++exit 0
+ 
+ # Local variables:
+ # eval: (add-hook 'write-file-hooks 'time-stamp)
+-- 
+2.7.4 (Apple Git-66)
+


### PR DESCRIPTION
Patching the missing script is currently the only way to build on solaris for
1.1.29. This patch will add many warnings on solaris builds, but these seem
harmless and "make check" does not fail, so indications point to clean builds
with this patch.