### PR TITLE
(PA-390) Bump vanagon to 0.6.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.6.2')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.6.3')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This commit bumps the pinned vanagon version to 0.6.3 to pick up a
change for AIX service handling on upgrade.