### PR TITLE
(RE-7338) Add Fedora 23 and 24 to 'foss_platforms'

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,6 +17,10 @@ foss_platforms:
   - eos-4-i386
   - fedora-f22-i386
   - fedora-f22-x86_64
+  - fedora-f23-i386
+  - fedora-f23-x86_64
+  - fedora-f24-i386
+  - fedora-f24-x86_64
   - huaweios-6-powerpc
   - osx-10.9-x86_64
   - osx-10.10-x86_64


### PR DESCRIPTION
This commit adds Fedora 23 and 24 to the 'foss_platforms' list, so we
can ship them to nightlies.