### PR TITLE
(maint) Use upstream URLs for libxml2, pkg-config, and mini_portile2.

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -1,7 +1,7 @@
 component "libxml2" do |pkg, settings, platform|
   pkg.version "2.9.4"
   pkg.md5sum "ae249165c173b1ff386ee8ad676815f5"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -1,7 +1,7 @@
 component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.version "2.1.0"
   pkg.md5sum "d771975a58cef82daa6b0ee03522293f"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/mini_portile2-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/mini_portile2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 

--- a/configs/components/rubygem-pkg-config.rb
+++ b/configs/components/rubygem-pkg-config.rb
@@ -1,7 +1,7 @@
 component "rubygem-pkg-config" do |pkg, settings, platform|
   pkg.version "1.1.7"
   pkg.md5sum "2767d4620b32f2a4ccddc18c353e5385"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/pkg-config-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/pkg-config-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 


### PR DESCRIPTION
We recently started using upstream component sources in puppet-agent
component source configs.

This commit updates the component configs for `libxml2`,
`mini_portile2`, and `pkg-config` to use the upstream source URLs.