### PR TITLE
(maint) Use upstream URLs for semantic_puppet and libxslt

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,7 +1,7 @@
 component "libxslt" do |pkg, settings, platform|
   pkg.version "1.1.29"
   pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -1,7 +1,7 @@
 component "rubygem-semantic_puppet" do |pkg, settings, platform|
   pkg.version "0.1.2"
   pkg.md5sum "192ae7729997cb5d5364f64b99b13121"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/semantic_puppet-#{pkg.get_version}.gem"
+  pkg.url "https://rubygems.org/downloads/semantic_puppet-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
 


### PR DESCRIPTION
We recently started using upstream component sources in puppet-agent
component source configs.

This commit updates the component configs for `semantic_puppet` and
`libxslt` to use the upstream source URLs.