### PR TITLE
(RE-7570) Add fakeroot to Ubuntu 12.04 and 14.04

### DIFF
--- a/configs/platforms/ubuntu-12.04-amd64.rb
+++ b/configs/platforms/ubuntu-12.04-amd64.rb
@@ -5,7 +5,7 @@ platform "ubuntu-12.04-amd64" do |plat|
   plat.codename "precise"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1204-x86_64"
 end

--- a/configs/platforms/ubuntu-12.04-i386.rb
+++ b/configs/platforms/ubuntu-12.04-i386.rb
@@ -5,7 +5,7 @@ platform "ubuntu-12.04-i386" do |plat|
   plat.codename "precise"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1204-i386"
 end

--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -5,7 +5,7 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.codename "trusty"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-x86_64"
 end

--- a/configs/platforms/ubuntu-14.04-i386.rb
+++ b/configs/platforms/ubuntu-14.04-i386.rb
@@ -5,7 +5,7 @@ platform "ubuntu-14.04-i386" do |plat|
   plat.codename "trusty"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-i386"
 end


### PR DESCRIPTION
We require fakeroot to build Puppet Agent.  The templates for Ubuntu 12.04 and 14.04 were previously handcrafted and included this package.  By default it is not installed and needs to be explicitly called out to support moving to packer based templates.