### PR TITLE
Revert "(RE-7301) Update stomp gem to 1.4.1"

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -1,6 +1,6 @@
 component "ruby-stomp" do |pkg, settings, platform|
-  pkg.version "1.4.1"
-  pkg.md5sum "f1b8574adf47aa9d8945b5e0089de91b"
+  pkg.version "1.3.3"
+  pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
   pkg.url "https://rubygems.org/downloads/stomp-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-ruby-stomp'


### PR DESCRIPTION
Reverts puppetlabs/puppet-agent#735

Causing problems with PE tests. Patch to come shortly.