### PR TITLE
(Maint) Fix up pkg-config dependency for cross compiles

### DIFF
--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -24,6 +24,10 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "CFLAGS" => settings[:cflags]
   end
 
+  if platform.is_cross_compiled? && platform.is_deb?
+    pkg.build_requires "pl-pkg-config"
+  end
+
   if platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
     pkg.build_requires "pl-gcc-#{platform.architecture}"
   end


### PR DESCRIPTION
Previously, cross compiled Debians required pl-pkg-config to build
libxml2 but was only referenced in augeas. This commit places the build
requirement in the correct spot (libxml2) and ensures that anything
cross compiled as a Debian system will require pl-pkg-config.

If you just use system pkg-config, the cross compile will fail on some
platforms as the flags returned are incorrect.