### PR TITLE
(maint) Use git protocol instead of ssh

### DIFF
--- a/configs/components/cfpropertylist.json
+++ b/configs/components/cfpropertylist.json
@@ -1,1 +1,1 @@
-{"url": "git@github.com:ckruse/CFPropertyList.git", "ref": "cfpropertylist-2.2.7"}
+{"url": "git://github.com/ckruse/CFPropertyList.git", "ref": "cfpropertylist-2.2.7"}


### PR DESCRIPTION
Previously, we were cloning cfpropertylist using ssh, which requires
ssh authentication and an entry in ~/.ssh/known_hosts. Since the
cfpropertylist repo is public, switch to the git protocol instead.