### PR TITLE
(maint) Update hiera config to not use --no-batch-files

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -29,7 +29,6 @@ component "hiera" do |pkg, settings, platform|
     --configdir=#{configdir} \
     --man \
     --mandir=#{settings[:mandir]} \
-    --no-batch-files \
     #{flags}"]
   end
 


### PR DESCRIPTION
This option was added in master hiera, but will not be available until after
the 1.5.3 release