### PR TITLE
(maint) Fedora 23 i386 needs an updated libnghttp2

### DIFF
--- a/configs/platforms/fedora-f23-i386.rb
+++ b/configs/platforms/fedora-f23-i386.rb
@@ -3,7 +3,7 @@ platform "fedora-f23-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs libnghttp2"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-23.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-23-i386"


### PR DESCRIPTION
apache fails to start unless it's updated