### PR TITLE
(maint) Bump vanagon to 0.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.6.3')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.7.0')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'

--- a/configs/platforms/cumulus-2.2-amd64.rb
+++ b/configs/platforms/cumulus-2.2-amd64.rb
@@ -23,4 +23,5 @@ apt-get install -qy --no-install-recommends build-essential make quilt pkg-confi
 
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-7-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/debian-7-amd64.rb
+++ b/configs/platforms/debian-7-amd64.rb
@@ -8,4 +8,5 @@ platform "debian-7-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-7-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/debian-7-i386.rb
+++ b/configs/platforms/debian-7-i386.rb
@@ -8,4 +8,5 @@ platform "debian-7-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-7-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -8,4 +8,5 @@ platform "debian-8-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/debian-8-armhf.rb
+++ b/configs/platforms/debian-8-armhf.rb
@@ -9,4 +9,5 @@ platform "debian-8-armhf" do |plat|
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qq -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
   plat.cross_compiled "true"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -8,4 +8,5 @@ platform "debian-8-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -10,4 +10,5 @@ platform "osx-10.10-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1010-x86_64"
+  plat.output_dir File.join("apple", "10.10", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -10,4 +10,5 @@ platform "osx-10.11-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1011-x86_64"
+  plat.output_dir File.join("apple", "10.11", "PC1", "x86_64")
 end

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -10,4 +10,5 @@ platform "osx-10.9-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/osx-deps apple-clt-6.2 pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-109-x86_64"
+  plat.output_dir File.join("apple", "10.9", "PC1", "x86_64")
 end

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -50,4 +50,6 @@ basedir=default" > /var/tmp/vanagon-noask;
   tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{base_url}/${pkg} && gunzip -c ${pkg} | pkgadd -d /dev/stdin -a /var/tmp/vanagon-noask all); \
   done
   ntpdate pool.ntp.org]
+
+  plat.output_dir File.join("solaris", "10", "PC1")
 end

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -54,4 +54,6 @@ basedir=default" > /var/tmp/vanagon-noask;
   tmpdir=$(mktemp -p /var/tmp -d); (cd ${tmpdir} && curl -O #{base_url}/${pkg} && gunzip -c ${pkg} | pkgadd -d /dev/stdin -a /var/tmp/vanagon-noask all); \
   done
   ntpdate pool.ntp.org]
+
+  plat.output_dir File.join("solaris", "10", "PC1")
 end

--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -5,4 +5,5 @@ platform "solaris-11-i386" do |plat|
   plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
+  plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -6,4 +6,5 @@ platform "solaris-11-sparc" do |plat|
   plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
+  plat.output_dir File.join("solaris", "11", "PC1")
 end

--- a/configs/platforms/ubuntu-10.04-amd64.rb
+++ b/configs/platforms/ubuntu-10.04-amd64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-10.04-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1004-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-10.04-i386.rb
+++ b/configs/platforms/ubuntu-10.04-i386.rb
@@ -8,4 +8,5 @@ platform "ubuntu-10.04-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1004-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-12.04-amd64.rb
+++ b/configs/platforms/ubuntu-12.04-amd64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-12.04-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1204-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-12.04-i386.rb
+++ b/configs/platforms/ubuntu-12.04-i386.rb
@@ -8,4 +8,5 @@ platform "ubuntu-12.04-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1204-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-14.04-i386.rb
+++ b/configs/platforms/ubuntu-14.04-i386.rb
@@ -8,4 +8,5 @@ platform "ubuntu-14.04-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-15.10-amd64.rb
+++ b/configs/platforms/ubuntu-15.10-amd64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-15.10-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1510-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-15.10-i386.rb
+++ b/configs/platforms/ubuntu-15.10-i386.rb
@@ -8,4 +8,5 @@ platform "ubuntu-15.10-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1510-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-16.04-amd64.rb
+++ b/configs/platforms/ubuntu-16.04-amd64.rb
@@ -8,4 +8,5 @@ platform "ubuntu-16.04-amd64" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1604-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/ubuntu-16.04-i386.rb
+++ b/configs/platforms/ubuntu-16.04-i386.rb
@@ -8,4 +8,5 @@ platform "ubuntu-16.04-i386" do |plat|
   plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1604-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
 end

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -22,4 +22,5 @@ platform "windows-2012r2-x64" do |plat|
   plat.platform_triple "x86_64-unknown-mingw32"
 
   plat.package_type "msi"
+  plat.output_dir "windows"
 end

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -22,4 +22,5 @@ platform "windows-2012r2-x86" do |plat|
   plat.platform_triple "i686-unknown-mingw32"
 
   plat.package_type "msi"
+  plat.output_dir "windows"
 end


### PR DESCRIPTION
This vanagon release includes a change to output directories that creates a
default output directory for all platforms with a choice to override the
default. Infrastructure requirements forces us to override the default for:

* Debian based platforms
* solaris platforms
* windows platforms