### PR TITLE
(maint) Update windows to complete revert back to ruby 2.1.9

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -80,6 +80,7 @@ component "ruby" do |pkg, settings, platform|
 
   special_flags = " --prefix=#{settings[:prefix]} --with-opt-dir=#{settings[:prefix]} "
 
+
   if platform.is_aix?
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
@@ -98,6 +99,7 @@ component "ruby" do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_fixup_generated_batch_files.patch"
     pkg.apply_patch "#{base}/windows_remove_DL_deprecated_warning.patch"
     pkg.apply_patch "#{base}/windows_ruby_2.1_update_to_rubygems_2.4.5.1.patch"
+    pkg.apply_patch "#{base}/libyaml_cve-2014-9130.patch"
   end
 
 

--- a/resources/patches/ruby/windows_fixup_generated_batch_files.patch
+++ b/resources/patches/ruby/windows_fixup_generated_batch_files.patch
@@ -27,12 +27,12 @@ Subject: [PATCH] (PUP-4077) Use Ruby in CWD, but fallback to PATH
  2 files changed, 18 insertions(+), 8 deletions(-)
 
 diff --git a/lib/rubygems/commands/setup_command.rb b/lib/rubygems/commands/setup_command.rb
-index d3ef9ef..3faafbc 100644
+index 6617396..604f894 100644
 --- a/lib/rubygems/commands/setup_command.rb
 +++ b/lib/rubygems/commands/setup_command.rb
-@@ -242,14 +242,19 @@ def install_executables(bin_dir)
+@@ -241,14 +241,19 @@ By default, this RubyGems will install gem as:
            bin_cmd_file = File.join Dir.tmpdir, "#{bin_file}.bat"
-
+ 
            File.open bin_cmd_file, 'w' do |file|
 -            file.puts <<-TEXT
 +            file.puts <<-SCRIPT
@@ -52,16 +52,16 @@ index d3ef9ef..3faafbc 100644
 +@%RUBY_EXE_PATH% "%~dpn0" %*
 +SCRIPT
            end
-
+ 
            install bin_cmd_file, "#{dest_file}.bat", :mode => 0755
 diff --git a/lib/rubygems/installer.rb b/lib/rubygems/installer.rb
-index 7b4979d..2489713 100644
+index 877cb21..fd959d1 100644
 --- a/lib/rubygems/installer.rb
 +++ b/lib/rubygems/installer.rb
-@@ -722,14 +722,19 @@ def app_script_text(bin_file_name)
-
+@@ -682,14 +682,19 @@ TEXT
+ 
    def windows_stub_script(bindir, bin_file_name)
-     ruby = Gem.ruby.gsub(/^\"|\"$/, "").tr(File::SEPARATOR, "\\")
+     ruby = Gem.ruby.chomp('"').tr(File::SEPARATOR, "\\")
 -    return <<-TEXT
 +    return <<-SCRIPT
  @ECHO OFF
@@ -80,7 +80,7 @@ index 7b4979d..2489713 100644
 +@%RUBY_EXE_PATH% "%~dpn0" %*
 +SCRIPT
    end
-
+ 
    ##
---
+-- 
 2.4.9 (Apple Git-60)


### PR DESCRIPTION
Some missing patch invocations and different patches are out of band with the
original 2.1.9 build. This commit remedies that by reverting to using all the
correct patches for ruby 2.1.9 with windows.