### PR TITLE
(PUP-6459) Update win32-service to 0.8.8

### DIFF
--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -1,6 +1,6 @@
 component "rubygem-win32-service" do |pkg, settings, platform|
-  pkg.version "0.8.6"
-  pkg.md5sum "b9b410177485069f5e4c3e1afac0779c"
+  pkg.version "0.8.8"
+  pkg.md5sum "24cc05fed398eb931e14b8ee22196634"
   pkg.url "https://rubygems.org/downloads/win32-service-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"


### PR DESCRIPTION
 - Version 0.8.7 of the win32-service gem had a bug that prevented it
   from properly retrieving all services on Windows 10 with the
   Win32::Service.services call.

   In particular, the services pvhdparser and vhdparser don't have
   delayed start info on Windows 10, which would previously cause
   errors.

   This is fixed in the 0.8.8 version of the gem