### PR TITLE
(PUP-6459) Test updated win32-service 0.8.8

### DIFF
--- a/configs/components/windows_ruby.json
+++ b/configs/components/windows_ruby.json
@@ -1,7 +1,7 @@
 {
   "url": "git://github.delivery.puppetlabs.net/puppetlabs-puppet-win32-ruby.git",
   "ref": {
-    "x86": "refs/tags/2.1.9.0-x86",
-    "x64": "refs/tags/2.1.9.0-x64"
+    "x86": "c149fb402d4908bbbf028eb13a287b7ec6038f05",
+    "x64": "8da43da0fd93160afec85b86adf67f8e7841e659"
   }
 }


### PR DESCRIPTION
 - Though future packaging should change to Vanagon based, current
   pipelines are still testing with packages produced with the older
   process that rely on the puppet-win32-ruby repository.

   To verify that the updated win32-service 0.8.8 gem passes through
   acceptance properly, update to the latest SHAs at the head of the
   2.1.x-x{86|64} branches of puppet-win32-ruby that include
   win32-service 0.8.8

   Once validated, these SHAs can be turned into tags, and this
   component configuration can be updated.