### PR TITLE
(maint) Update vanagon to 0.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.7.0')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.7.1')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This will update windows packages to be named puppet-agent-VERSION-ARCH.msi and
not puppet-agent-VERSION.RELEASE-ARCH.msi