### PR TITLE
(RE-7449) libxslt component refactor

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -38,16 +38,8 @@ component "libxslt" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc-#{platform.architecture}"
   end
 
-  if platform.is_linux?
-    if platform.architecture =~ /powerpc$/
-      target = 'powerpc-linux-gnu'
-    elsif platform.architecture =~ /ppc64le$/
-      target = 'powerpc64le-unknown-linux-gnu'
-    end
-  end
-
   pkg.configure do
-    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]} #{settings[:host]} #{disable_crypto} #{build} #{target}"]
+    ["./configure --prefix=#{settings[:prefix]} --docdir=/tmp --with-libxml-prefix=#{settings[:prefix]} #{settings[:host]} #{disable_crypto} #{build}"]
   end
 
   pkg.build do

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -91,6 +91,7 @@ project "puppet-agent" do |proj|
 
   # Cross-compiled Linux platforms
   platform_triple = "powerpc-linux-gnu" if platform.is_huaweios?
+  platform_triple = "powerpc64le-unknown-linux-gnu" if platform.architecture == "ppc64le"
   platform_triple = "s390x-linux-gnu" if platform.architecture == "s390x"
   platform_triple = "arm-linux-gnueabihf" if platform.name == 'debian-8-armhf'
 


### PR DESCRIPTION
This removes unused code from the libxslt component that was intended
to specify the target build architecture, but actually does nothing. The
correct way to specify the target is with the --host flag, which is
already set via the settings[:host] option.