### PR TITLE
(maint) Update ruby congifuration for windows

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -12,6 +12,7 @@ component "ruby" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
     pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
+    pkg.add_source "file://resources/files/ruby/windows_ruby_gem_wrapper.bat"
   end
 
   pkg.replaces 'pe-ruby'
@@ -100,6 +101,7 @@ component "ruby" do |pkg, settings, platform|
     pkg.apply_patch "#{base}/windows_remove_DL_deprecated_warning.patch"
     pkg.apply_patch "#{base}/windows_ruby_2.1_update_to_rubygems_2.4.5.1.patch"
     pkg.apply_patch "#{base}/libyaml_cve-2014-9130.patch"
+    pkg.apply_patch "#{base}/update_rbinstall_for_windows.patch"
   end
 
 
@@ -206,6 +208,16 @@ component "ruby" do |pkg, settings, platform|
     "#{platform[:make]}"
   end
 
+  if platform.is_windows?
+    pkg.install do
+      ["cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/irb.bat",
+       "cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/gem.bat",
+       "cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/rake.bat",
+       "cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/erb.bat",
+       "cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/rdoc.bat",
+       "cp ../windows_ruby_gem_wrapper.bat #{settings[:ruby_bindir]}/ri.bat",]
+    end
+  end
   pkg.install do
     ["#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",]
   end

--- a/resources/files/ruby/windows_ruby_gem_wrapper.bat
+++ b/resources/files/ruby/windows_ruby_gem_wrapper.bat
@@ -1,0 +1,11 @@
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+ECHO.This version of Ruby has not been built with support for Windows 95/98/Me.
+GOTO :EOF
+:WinNT
+IF EXIST "%~dp0ruby.exe" (
+  SET RUBY_EXE_PATH="%~dp0ruby.exe"
+) ELSE (
+  SET RUBY_EXE_PATH="ruby.exe"
+)
+@%RUBY_EXE_PATH% "%~dpn0" %*

--- a/resources/patches/ruby/update_rbinstall_for_windows.patch
+++ b/resources/patches/ruby/update_rbinstall_for_windows.patch
@@ -1,0 +1,69 @@
+From 7be64d42e09b75cf19f541e15890e769a8a561ee Mon Sep 17 00:00:00 2001
+From: "Sean P. McDonald" <sean.mcdonald@puppet.com>
+Date: Fri, 29 Jul 2016 14:37:38 -0700
+Subject: [PATCH] update rbinstall for windows
+
+---
+ tool/rbinstall.rb | 45 +++++++++++++++++++++++----------------------
+ 1 file changed, 23 insertions(+), 22 deletions(-)
+
+diff --git a/tool/rbinstall.rb b/tool/rbinstall.rb
+index b3dad0e..7d4124d 100755
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -482,29 +482,30 @@ install?(:local, :comm, :bin, :'bin-comm') do
+     shebang.sub!(/\r$/, '')
+     body.gsub!(/\r$/, '')
+ 
+-    cmd << ".#{$cmdtype}" if $cmdtype
++    #cmd << ".#{$cmdtype}" if $cmdtype
+     open_for_install(cmd, $script_mode) do
+-      case $cmdtype
+-      when "exe"
+-        stub + shebang + body
+-      when "bat"
+-        [<<-"EOH".gsub(/^\s+/, ''), shebang, body, "__END__\n:endofruby\n"].join.gsub(/$/, "\r")
+-          @echo off
+-          @if not "%~d0" == "~d0" goto WinNT
+-          #{ruby_bin} -x "#{cmd}" %1 %2 %3 %4 %5 %6 %7 %8 %9
+-          @goto endofruby
+-          :WinNT
+-          "%~dp0#{ruby_install_name}" -x "%~f0" %*
+-          @goto endofruby
+-        EOH
+-      when "cmd"
+-        <<"/EOH" << shebang << body
+-@"%~dp0#{ruby_install_name}" -x "%~f0" %*
+-@exit /b %ERRORLEVEL%
+-/EOH
+-      else
+-        shebang + body
+-      end
++#       case $cmdtype
++#       when "exe"
++#         stub + shebang + body
++#       when "bat"
++#         [<<-"EOH".gsub(/^\s+/, ''), shebang, body, "__END__\n:endofruby\n"].join.gsub(/$/, "\r")
++#           @echo off
++#           @if not "%~d0" == "~d0" goto WinNT
++#           #{ruby_bin} -x "#{cmd}" %1 %2 %3 %4 %5 %6 %7 %8 %9
++#           @goto endofruby
++#           :WinNT
++#           "%~dp0#{ruby_install_name}" -x "%~f0" %*
++#           @goto endofruby
++#         EOH
++#       when "cmd"
++#         <<"/EOH" << shebang << body
++# @"%~dp0#{ruby_install_name}" -x "%~f0" %*
++# @exit /b %ERRORLEVEL%
++# /EOH
++#       else
++#         shebang + body
++#       end
++      body
+     end
+   end
+ end
+-- 
+2.7.4 (Apple Git-66)
+


### PR DESCRIPTION
Windows builds of the vendored ruby will incorrectly create batch files using
old legacy rbinstall code. This commit patches out the old legacy code and
keeps creation of ruby wrappers in line with what rubygems will do.