### PR TITLE
(maint) Revert ffi to 1.9.10 for windows

### DIFF
--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -1,12 +1,12 @@
 component "rubygem-ffi" do |pkg, settings, platform|
-  pkg.version "1.9.14"
+  pkg.version "1.9.10"
 
   if platform.is_windows?
     if platform.architecture == "x64"
-      pkg.md5sum "6d78ae5b2378513d3fc68600981366e9"
+      pkg.md5sum "e3ba1afc17b47ad261bf290b31ce46d7"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
     else
-      pkg.md5sum "54a20f0f73d03c06adf63789faa53746"
+      pkg.md5sum "e83fb2971a03e52ab3b00e8662ac20ea"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
     end
 


### PR DESCRIPTION
windows is still operating with ruby 2.1.9, which requires ffi 1.9.10, not
1.9.14. revert back to 1.9.10