### PR TITLE
(RE-7667) OSX: Update 'include/memory' header for libc++ bug

### DIFF
--- a/configs/platforms/osx-10.10-x86_64.rb
+++ b/configs/platforms/osx-10.10-x86_64.rb
@@ -8,6 +8,9 @@ platform "osx-10.10-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
   plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-libcxx_include_memory_fix.patch | patch -p0'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0002-libcxx_include_memory_fix.patch | patch -p0'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0003-libcxx_include_memory_fix.patch | patch -p0'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1010-x86_64"
   plat.output_dir File.join("apple", "10.10", "PC1", "x86_64")

--- a/configs/platforms/osx-10.11-x86_64.rb
+++ b/configs/platforms/osx-10.11-x86_64.rb
@@ -7,7 +7,7 @@ platform "osx-10.11-x86_64" do |plat|
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
-  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.2 pkg-config'
+  plat.provision_with '/usr/local/bin/osx-deps apple-clt-7.3.1 pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1011-x86_64"
   plat.output_dir File.join("apple", "10.11", "PC1", "x86_64")

--- a/configs/platforms/osx-10.9-x86_64.rb
+++ b/configs/platforms/osx-10.9-x86_64.rb
@@ -8,6 +8,9 @@ platform "osx-10.9-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'
   plat.provision_with '/usr/local/bin/osx-deps apple-clt-6.2 pkg-config'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-libcxx_include_memory_fix.patch | patch -p0'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0002-libcxx_include_memory_fix.patch | patch -p0'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0003-libcxx_include_memory_fix.patch | patch -p0'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-109-x86_64"
   plat.output_dir File.join("apple", "10.9", "PC1", "x86_64")

--- a/resources/patches/osx/0001-libcxx_include_memory_fix.patch
+++ b/resources/patches/osx/0001-libcxx_include_memory_fix.patch
@@ -1,0 +1,45 @@
+From c41133728d1a4197b8d0a366854b73d161788d20 Mon Sep 17 00:00:00 2001
+From: Marshall Clow <mclow.lists@gmail.com>
+Date: Fri, 19 Jun 2015 15:54:13 +0000
+Subject: [PATCH 1/3] Fix PR#18843. Thanks to Howard for the fix
+
+git-svn-id: https://llvm.org/svn/llvm-project/libcxx/trunk@240136 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/memory                                                       | 5 ++++-
+ .../util.smartptr.enab/enable_shared_from_this.pass.cpp              | 4 ++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/include/memory b/include/memory
+index 03897b1..4c3a18c 100644
+--- /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
++++ /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
+@@ -4073,7 +4073,10 @@ private:
+         __enable_weak_this(const enable_shared_from_this<_Yp>* __e) _NOEXCEPT
+         {
+             if (__e)
+-                __e->__weak_this_ = *this;
++            {
++                __e->__weak_this_.__ptr_ = const_cast<_Yp*>(static_cast<const _Yp*>(__e));
++                __e->__weak_this_.__cntrl_ = __cntrl_;
++            }
+         }
+ 
+     _LIBCPP_INLINE_VISIBILITY
+#diff --git a/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp b/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp
+#index 58686d6..77af13f 100644
+#--- a/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp
+#+++ b/test/std/utilities/memory/util.smartptr/util.smartptr.enab/enable_shared_from_this.pass.cpp
+#@@ -34,6 +34,10 @@ struct Z : Y {};
+# 
+# int main()
+# {
+#+    {  // https://llvm.org/bugs/show_bug.cgi?id=18843
+#+    std::shared_ptr<T const> t1(new T);
+#+    std::shared_ptr<T const> t2(std::make_shared<T>());
+#+    }
+#     {
+#     std::shared_ptr<Y> p(new Z);
+#     std::shared_ptr<T> q = p->shared_from_this();
+-- 
+2.2.1
+

--- a/resources/patches/osx/0002-libcxx_include_memory_fix.patch
+++ b/resources/patches/osx/0002-libcxx_include_memory_fix.patch
@@ -1,0 +1,25 @@
+From cb126215aa371c10e3b10fa70044d9edc385a768 Mon Sep 17 00:00:00 2001
+From: Marshall Clow <mclow.lists@gmail.com>
+Date: Fri, 19 Jun 2015 17:13:59 +0000
+Subject: [PATCH 2/3] Fix ASAN bot; missing bookkeeping in r240136.
+
+git-svn-id: https://llvm.org/svn/llvm-project/libcxx/trunk@240139 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/memory | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/memory b/include/memory
+index 4c3a18c..7763c19 100644
+--- /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
++++ /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
+@@ -4076,6 +4076,7 @@ private:
+             {
+                 __e->__weak_this_.__ptr_ = const_cast<_Yp*>(static_cast<const _Yp*>(__e));
+                 __e->__weak_this_.__cntrl_ = __cntrl_;
++                __cntrl_->__add_weak();
+             }
+         }
+ 
+-- 
+2.2.1
+

--- a/resources/patches/osx/0003-libcxx_include_memory_fix.patch
+++ b/resources/patches/osx/0003-libcxx_include_memory_fix.patch
@@ -1,0 +1,26 @@
+From 46d06b90c12482c6b62fff2b39dfbc7acc394deb Mon Sep 17 00:00:00 2001
+From: Marshall Clow <mclow.lists@gmail.com>
+Date: Fri, 19 Jun 2015 19:32:06 +0000
+Subject: [PATCH 3/3] Fix illegal chars that snuck into <memory>
+
+git-svn-id: https://llvm.org/svn/llvm-project/libcxx/trunk@240163 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ include/memory | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/memory b/include/memory
+index 7763c19..69702c6 100644
+--- /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
++++ /Library/Developer/CommandLineTools/usr/include/c++/v1/memory
+@@ -4076,7 +4076,7 @@ private:
+             {
+                 __e->__weak_this_.__ptr_ = const_cast<_Yp*>(static_cast<const _Yp*>(__e));
+                 __e->__weak_this_.__cntrl_ = __cntrl_;
+-                __cntrl_->__add_weak();
++                __cntrl_->__add_weak();
+             }
+         }
+ 
+-- 
+2.2.1
+


### PR DESCRIPTION
Prior to this commit, cpp-hocon builds fail on OS X due to a known issue
(https://llvm.org/bugs/show_bug.cgi?id=18843) in an earlier version of
the libc++ headers shipped with LLVM (in the Xcode Command Line Tools).

This issue is fixed in Xcode Command Line Tools 7.3.

This changeset updates the OS X 10.11 platform config to use Xcode Command
Line Tools 7.3.1, the current version for OS X 10.11.

Unfortunately, installation of Xcode CLT 7.3 is blocked on OS X 10.9 and 10.10. 
As a workaround, this changeset updates puppet-agent's OS X 10.9 and 10.10 
platform configurations to patch libc++'s 'include/memory' header as a
provisioning step before the build.