### PR TITLE
(maint) Reset puppet to a pre-corrective-change-reporting SHA

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "2ebbe8f2998ddb27f6bee9ab45513889cda485b0"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "6933ab99bd40122b765b8603bd601786286a7010"}


### PR DESCRIPTION
This resets the Puppet SHA to a version before corrective change
landed. This will let us get a clean build to the PE integration team
while we sort out what we're going to do in corrective change land.

This can't be our final shipping SHA since it's missing some other
fixes, but it should be good enough to unblock the integration team.