### PR TITLE
(PA-461) Configure OpenSSL cert bundle on Windows

### DIFF
--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -28,5 +28,5 @@ SET RUBYOPT=rubygems
 REM Now return to the caller.
 
 REM Set SSL variables to ensure trusted locations are used
-SET SSL_CERT_FILE=%PL_BASEDIR%\ssl\cert.pem
-SET SSL_CERT_DIR=%PL_BASEDIR%\ssl\certs
+SET SSL_CERT_FILE=%PUPPET_DIR%\ssl\cert.pem
+SET SSL_CERT_DIR=%PUPPET_DIR%\ssl\certs


### PR DESCRIPTION
 - Previously, the SSL directory was configured improperly in the
   environment.bat that was in the package.  The resulting values were:

   SSL_CERT_DIR=C:\Program Files\Puppet Labs\Puppet\ssl\certs
   SSL_CERT_FILE=C:\Program Files\Puppet Labs\Puppet\ssl\cert.pem

  This is not the location of the cert.pem file.  The actual location is:

  C:\Program Files\Puppet Labs\Puppet\puppet\ssl\cert.pem

 - Adjust the batch file to use the appropriate directory