### PR TITLE
(PA-466) Correct env_windows_installdir

### DIFF
--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -5,7 +5,7 @@ REM Avoid the nasty \..\ littering the paths.
 SET PL_BASEDIR=%PL_BASEDIR:\bin\..=%
 
 REM Set a fact so we can easily source the environment.bat file in the future.
-SET FACTER_env_windows_installdir=%PL_BASEDIR%\facter
+SET FACTER_env_windows_installdir=%PL_BASEDIR%\puppet
 
 SET PUPPET_DIR=%PL_BASEDIR%\puppet
 REM Facter will load FACTER_ env vars as facts, so don't use FACTER_DIR


### PR DESCRIPTION
In commit 24f8e0d we introduced a different path for
FACTER_env_windows_installdir - it used to "C:\\Program Files\\Puppet
Labs\\Puppet" but now goes to "C:\\Program Files\\Puppet Labs\\Puppet\\facter".
This commit fixes this. The impact is that in PE, the aio_agent_build fact uses
this fact to create the path to the VERSION file - without it, no
aio_agent_build fact is reported, causing CI pipelines to fail.