### PR TITLE
(PA-466) correct env_windows_installdir

### DIFF
--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -5,7 +5,7 @@ REM Avoid the nasty \..\ littering the paths.
 SET PL_BASEDIR=%PL_BASEDIR:\bin\..=%
 
 REM Set a fact so we can easily source the environment.bat file in the future.
-SET FACTER_env_windows_installdir=%PL_BASEDIR%\puppet
+SET FACTER_env_windows_installdir=%PL_BASEDIR%
 
 SET PUPPET_DIR=%PL_BASEDIR%\puppet
 REM Facter will load FACTER_ env vars as facts, so don't use FACTER_DIR


### PR DESCRIPTION
A previous commit incorrectly set the env_windows_installdir fact to be
suffixed with 'puppet'. This was tested with the aio_agent_build fact available
in PE, but it turns out that is actually incorrect and the combination of the
two returned a false positive. This commit updates the path to the correct
(pre-vanagon) path.