### PR TITLE
(PA-466) Update packaging to copy VERSION to installdir

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -137,7 +137,13 @@ component "puppet" do |pkg, settings, platform|
         --quick \
         --no-batch-files \
         --man \
-        --mandir=#{settings[:mandir]}"]
+        --mandir=#{settings[:mandir]}",]
+  end
+
+  if platform.is_windows?
+    pkg.install do
+      ["cp #{settings[:prefix]}/VERSION #{settings[:install_root]}",]
+    end
   end
 
   #The following will add the vim syntax files for puppet


### PR DESCRIPTION
The Version file for puppet-agent needs to exist under Puppet Labs\Puppet\ not
Puppet Labs\Puppet\puppet. Update packaging to copy the file there.