### PR TITLE
(maint) Update cp to use full path

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -142,7 +142,7 @@ component "puppet" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.install do
-      ["cp #{settings[:prefix]}/VERSION #{settings[:install_root]}",]
+      ["/usr/bin/cp #{settings[:prefix]}/VERSION #{settings[:install_root]}",]
     end
   end
 


### PR DESCRIPTION
For some reason, the environment is preventing cygwin from seeing the cp
command while building puppet, update the copy command for the windows build to
use the full path