### PR TITLE
(PA-475) Update windows platform triple to include w64

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -19,7 +19,7 @@ platform "windows-2012r2-x64" do |plat|
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
 
-  plat.platform_triple "x86_64-unknown-mingw32"
+  plat.platform_triple "x86_64-w64-mingw32"
 
   plat.package_type "msi"
   plat.output_dir "windows"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -19,7 +19,7 @@ platform "windows-2012r2-x86" do |plat|
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
 
-  plat.platform_triple "i686-unknown-mingw32"
+  plat.platform_triple "i686-w64-mingw32"
 
   plat.package_type "msi"
   plat.output_dir "windows"


### PR DESCRIPTION
This updates the platform triple of windows builds to be:

i686-w64-mingw32
or
x86_64-w64-mingw32

instead of: i686/x86_64-unknown-migw32

This is meant to fix some gem loading for gems that expect this platform triple
inside ruby.