### PR TITLE
(PA-495) Set library paths for CMake projects explicitly

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -62,6 +62,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+          -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DBOOST_STATIC=ON \
           ."

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -206,20 +206,8 @@ component "facter" do |pkg, settings, platform|
         ."]
   end
 
-  # Make test will explode horribly in a cross-compile situation
-  # Tests will be skipped on AIX until they are expected to pass
-  if platform.is_cross_compiled? || platform.is_aix?
-    test = ":"
-  else
-    test = "LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
-  end
-
   pkg.build do
-    # Until a `check` target exists, run tests are part of the build.
-    [
-      "#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)",
-      test
-    ]
+    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
   end
 
   pkg.install do
@@ -232,15 +220,24 @@ component "facter" do |pkg, settings, platform|
     ldd = "ldd"
   end
 
+  tests = []
   unless platform.is_windows? || platform.is_cross_compiled_linux? || platform.architecture == 'sparc'
-    pkg.check do
-      [
-        # Check that we're not linking against system libstdc++ and libgcc_s
-        "#{ldd} lib/libfacter.so",
-        "[ $$(#{ldd} lib/libfacter.so | grep -c libstdc++) -eq 0 ] || #{ldd} lib/libfacter.so | grep libstdc++ | grep -v ' /lib'",
-        "[ $$(#{ldd} lib/libfacter.so | grep -c libgcc_s) -eq 0 ] || #{ldd} lib/libfacter.so | grep libgcc_s | grep -v ' /lib'"
-      ]
-    end
+    # Check that we're not linking against system libstdc++ and libgcc_s
+    tests = [
+      "#{ldd} lib/libfacter.so",
+      "[ $$(#{ldd} lib/libfacter.so | grep -c libstdc++) -eq 0 ] || #{ldd} lib/libfacter.so | grep libstdc++ | grep -v ' /lib'",
+      "[ $$(#{ldd} lib/libfacter.so | grep -c libgcc_s) -eq 0 ] || #{ldd} lib/libfacter.so | grep libgcc_s | grep -v ' /lib'",
+    ]
+  end
+
+  # Make test will explode horribly in a cross-compile situation
+  # Tests will be skipped on AIX until they are expected to pass
+  if !platform.is_cross_compiled? && !platform.is_aix?
+    tests << "LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
+  end
+
+  pkg.check do
+    tests
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -211,7 +211,7 @@ component "facter" do |pkg, settings, platform|
   if platform.is_cross_compiled? || platform.is_aix?
     test = ":"
   else
-    test = "#{make} test ARGS=-V"
+    test = "LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
   end
 
   pkg.build do

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -193,6 +193,7 @@ component "facter" do |pkg, settings, platform|
         -DLEATHERMAN_GETTEXT=OFF \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+        -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         #{special_flags} \
         -DBOOST_STATIC=ON \
         -DYAMLCPP_STATIC=ON \

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -36,6 +36,7 @@ component "leatherman" do |pkg, settings, platform|
     use_curl = 'TRUE'
   end
 
+  pkg.build_requires "runtime"
   pkg.build_requires "ruby"
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
@@ -98,7 +99,8 @@ component "leatherman" do |pkg, settings, platform|
   if platform.is_cross_compiled? || platform.is_aix?
     test = "/bin/true"
   else
-    test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') #{make} test ARGS=-V"
+    test = "LEATHERMAN_RUBY=#{settings[:libdir]}/$(shell #{ruby} -e 'print RbConfig::CONFIG[\"LIBRUBY_SO\"]') \
+           LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]}#{make} test ARGS=-V"
   end
 
   if platform.is_solaris? && platform.architecture != 'sparc'

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -85,6 +85,7 @@ component "leatherman" do |pkg, settings, platform|
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
+        -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         -DLEATHERMAN_SHARED=TRUE \
         #{special_flags} \
         -DBOOST_STATIC=ON \

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -65,6 +65,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DLEATHERMAN_GETTEXT=OFF \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
+          -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           #{special_flags} \


### PR DESCRIPTION
Previously facter and pxp-agent set CMAKE_INSTALL_RPATH to ensure rpath
is set when installing to non-default locations. Packaging relies on
this to get the correct rpath configuration. Leatherman was missing this
configuration, which was exposed when moving to dynamically linking
against `libstdc++`.

Fix link paths by explicitly setting RPATH for all CMake projects
(in conjunction with settings in the toolchain fails, in accordance with
https://cmake.org/Wiki/CMake_RPATH_handling's "Always full RPATH"
scenario). Also explicitly set LD_LIBRARY_PATH/LIBPATH for test
executables, as they won't have the correct rpath for `libstdc++`.