### PR TITLE
 (PA-537) Upgrade to new signing key

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -57,7 +57,7 @@ pe_platforms:
   - ubuntu-10.04-amd64
   - ubuntu-10.04-i386
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '4BD6EC30'
+gpg_key: '7F438280EF8D349F'
 deb_targets: 'lucid-i386 lucid-amd64 precise-i386 precise-amd64 squeeze-i386 squeeze-amd64 trusty-i386 trusty-amd64 wheezy-i386 wheezy-amd64 xenial-i386 xenial-amd64'
 rpm_targets: 'el-5-i386 el-5-x86_64 el-6-i386 el-6-x86_64 el-7-x86_64 sles-11-i386 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE


### PR DESCRIPTION
This commit updates the key that is used to sign packages. We are
in the process of introducing a new signing key to verify our packages.
As a part of this effort, we need to actually switch over to this new
key for our individual projects.