### PR TITLE
(maint) Re-add the -j flag to make during ruby build

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -191,7 +191,7 @@ component "ruby" do |pkg, settings, platform|
   end
 
   pkg.build do
-    "#{platform[:make]}"
+    "#{platform[:make]} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
   end
 
   if platform.is_windows?


### PR DESCRIPTION
The removal of the parallel make was made during dev for ruby 2.3, and should
have been added back.