### PR TITLE
(MAINT) Add a maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
+  "issues": "https://tickets.puppetlabs.com/browse/PA",
+  "people": [
+
+  ]
+}


### PR DESCRIPTION
This commit adds an empty maintainers file to puppet-agent in the specification
described by https://github.com/puppetlabs/maintainers. This file will be used
to record the active maintainers of the repository.

Signed-off-by: Moses Mendoza <moses@puppet.com>