### PR TITLE
(PA-540) retag all components not updating in 1.7.0

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "5ab97178029e20d033a7d3b8844821eb4f32ae65"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.4.1"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "26c5345e482fed7d12814f2fff336141db14cc88"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.2.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "388d0ec2cbd495a43b342aa6ca4f17d2abc9b400"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.9.0"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "06c710a2b227499d7d4710d5884a0f9d218e6467"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "010bdb9d3c14ad4055605790e11c40d8b758bd80"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "e99cd855726fad4e32d1338e1fa796d3dfa73204"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.2.1"}


### PR DESCRIPTION
This will also update the SHA of the puppet component to the latest of https://github.com/puppetlabs/puppet/tree/4.7.x