### PR TITLE
(maint) move the puppet component SHA to stable

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "010bdb9d3c14ad4055605790e11c40d8b758bd80"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "be4bbe92d222164abc76bd1ab5dc91d6c652aa4c"}


### PR DESCRIPTION
The old SHA was from the 4.7.x branch, which contained the correct commits,
however during the mergup after the release will dirty up the commit history.
Stable has been cleaned up and is ready to go in to the RC