### PR TITLE
(PA-544) Fix solaris sparc cross-builds of ruby socket library

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -162,7 +162,8 @@ component "ruby" do |pkg, settings, platform|
         pkg.build_requires 'pl-ruby'
       end
 
-      special_flags += " --with-baseruby=#{settings[:host_ruby]} "
+      # The rcvmsg flag is needed to cross-compile the socket library
+      special_flags += " --with-baseruby=#{settings[:host_ruby]} --enable-close-fds-by-recvmsg-with-peek "
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'


### PR DESCRIPTION
When cross-compiling ruby 2.3.1 on solaris sparc, the socket library
will not be built unless you specify a close-fds-by-recvmsg-with-peek
configure option.