### PR TITLE
(PA-545) Update all platforms to use scripts to run executables

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -250,8 +250,11 @@ component "facter" do |pkg, settings, platform|
     pkg.install_file "../facter.bat", "#{settings[:link_bindir]}/facter.bat"
     pkg.install_file "../facter_interactive.bat", "#{settings[:link_bindir]}/facter_interactive.bat"
     pkg.install_file "../run_facter_interactive.bat", "#{settings[:link_bindir]}/run_facter_interactive.bat"
+  else
+    pkg.add_source("file://resources/files/facter.sh")
+    pkg.install_file "../facter.sh", "#{settings[:link_bindir]}/facter", mode: "755", owner: "root", group: "root"
   end
-  pkg.link "#{settings[:bindir]}/facter", "#{settings[:link_bindir]}/facter" unless platform.is_windows?
+
   if platform.is_windows?
     pkg.directory File.join(settings[:sysconfdir], 'facter', 'facts.d')
   else

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -13,11 +13,8 @@ component "hiera" do |pkg, settings, platform|
   flags = " --bindir=#{settings[:bindir]} \
             --sitelibdir=#{settings[:ruby_vendordir]} \
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
-
   if platform.is_windows?
-    pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
-    pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
     flags = " --bindir=#{settings[:hiera_bindir]} \
               --sitelibdir=#{settings[:hiera_libdir]} \
               --ruby=#{File.join(settings[:ruby_bindir], 'ruby')} "
@@ -37,7 +34,13 @@ component "hiera" do |pkg, settings, platform|
 
   pkg.configfile File.join(configdir, 'hiera.yaml')
 
-  pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
+    pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
+  else
+    pkg.add_source("file://resources/files/hiera.sh")
+    pkg.install_file "../hiera.sh", "#{settings[:link_bindir]}/hiera", mode: "755", owner: "root", group: "root"
+  end
 
   if platform.is_windows?
     pkg.directory File.join(settings[:puppet_codedir], 'hieradata')

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -86,8 +86,6 @@ component "marionette-collective" do |pkg, settings, platform|
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
   if platform.is_windows?
-    pkg.add_source("file://resources/files/windows/mco.bat")
-    pkg.install_file "../mco.bat", "#{settings[:link_bindir]}/mco.bat"
     flags = " --bindir=#{settings[:mco_bindir]} \
               --sbindir=#{settings[:mco_bindir]} \
               --sitelibdir=#{settings[:mco_libdir]} \
@@ -120,5 +118,11 @@ component "marionette-collective" do |pkg, settings, platform|
   pkg.configfile File.join(configdir, 'facts.yaml')
   pkg.configfile "/etc/logrotate.d/mcollective" if platform.is_linux?
 
-  pkg.link "#{settings[:bindir]}/mco", "#{settings[:link_bindir]}/mco" unless platform.is_windows?
+  if platform.is_windows?
+    pkg.add_source("file://resources/files/windows/mco.bat")
+    pkg.install_file "../mco.bat", "#{settings[:link_bindir]}/mco.bat"
+  else
+    pkg.add_source("file://resources/files/mco.sh")
+    pkg.install_file "../mco.sh", "#{settings[:link_bindir]}/mco", mode: "755", owner: "root", group: "root"
+  end
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -161,18 +161,6 @@ component "puppet" do |pkg, settings, platform|
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
 
   if platform.is_windows?
-    # Install the appropriate .batch files to the INSTALLDIR/bin directory
-    pkg.add_source("file://resources/files/windows/environment.bat", sum: "810195e5fe09ce1704d0f1bf818b2d9a")
-    pkg.add_source("file://resources/files/windows/puppet.bat", sum: "002618e115db9fd9b42ec611e1ec70d2")
-    pkg.add_source("file://resources/files/windows/puppet_interactive.bat", sum: "4b40eb0df91d2ca8209302062c4940c4")
-    pkg.add_source("file://resources/files/windows/puppet_shell.bat", sum: "24477c6d2c0e7eec9899fb928204f1a0")
-    pkg.add_source("file://resources/files/windows/run_puppet_interactive.bat", sum: "d4ae359425067336e97e4e3a200027d5")
-    pkg.install_file "../environment.bat", "#{settings[:link_bindir]}/environment.bat"
-    pkg.install_file "../puppet.bat", "#{settings[:link_bindir]}/puppet.bat"
-    pkg.install_file "../puppet_interactive.bat", "#{settings[:link_bindir]}/puppet_interactive.bat"
-    pkg.install_file "../run_puppet_interactive.bat", "#{settings[:link_bindir]}/run_puppet_interactive.bat"
-    pkg.install_file "../puppet_shell.bat", "#{settings[:link_bindir]}/puppet_shell.bat"
-
     pkg.install_file "ext/windows/service/daemon.bat", "#{settings[:bindir]}/daemon.bat"
     pkg.install_file "ext/windows/service/daemon.rb", "#{settings[:service_dir]}/daemon.rb"
     pkg.install_file "../wix/icon/puppet.ico", "#{settings[:miscdir]}/puppet.ico"
@@ -200,9 +188,24 @@ component "puppet" do |pkg, settings, platform|
   else
     pkg.directory File.join(settings[:logdir], 'puppet'), mode: "0750"
   end
-
-  pkg.link "#{settings[:bindir]}/puppet", "#{settings[:link_bindir]}/puppet" unless platform.is_windows?
-  if platform.is_eos?
-    pkg.link "#{settings[:sysconfdir]}", "#{settings[:link_sysconfdir]}"
+  if platform.is_windows?
+    # Install the appropriate .batch files to the INSTALLDIR/bin directory
+    pkg.add_source("file://resources/files/windows/environment.bat", sum: "810195e5fe09ce1704d0f1bf818b2d9a")
+    pkg.add_source("file://resources/files/windows/puppet.bat", sum: "002618e115db9fd9b42ec611e1ec70d2")
+    pkg.add_source("file://resources/files/windows/puppet_interactive.bat", sum: "4b40eb0df91d2ca8209302062c4940c4")
+    pkg.add_source("file://resources/files/windows/puppet_shell.bat", sum: "24477c6d2c0e7eec9899fb928204f1a0")
+    pkg.add_source("file://resources/files/windows/run_puppet_interactive.bat", sum: "d4ae359425067336e97e4e3a200027d5")
+    pkg.install_file "../environment.bat", "#{settings[:link_bindir]}/environment.bat"
+    pkg.install_file "../puppet.bat", "#{settings[:link_bindir]}/puppet.bat"
+    pkg.install_file "../puppet_interactive.bat", "#{settings[:link_bindir]}/puppet_interactive.bat"
+    pkg.install_file "../run_puppet_interactive.bat", "#{settings[:link_bindir]}/run_puppet_interactive.bat"
+    pkg.install_file "../puppet_shell.bat", "#{settings[:link_bindir]}/puppet_shell.bat"
+  elsif platform.is_eos?
+    pkg.add_source("file://resources/files/puppet.sh")
+    pkg.install_file "../puppet.sh", "#{settings[:sysconfdir]}", mode: "755", owner: "root", group: "root"
+    pkg.link "", "#{settings[:link_sysconfdir]}"
+  else
+    pkg.add_source("file://resources/files/puppet.sh")
+    pkg.install_file "../puppet.sh", "#{settings[:link_bindir]}/puppet", mode: "755", owner: "root", group: "root"
   end
 end

--- a/resources/files/facter.sh
+++ b/resources/files/facter.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+unset LD_PRELOAD
+unset LD_LIBRARY_PATH
+
+exec /opt/puppetlabs/puppet/bin/facter $@
+

--- a/resources/files/hiera.sh
+++ b/resources/files/hiera.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+unset LD_PRELOAD
+unset LD_LIBRARY_PATH
+
+exec /opt/puppetlabs/puppet/bin/hiera $@
+

--- a/resources/files/mco.sh
+++ b/resources/files/mco.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+unset LD_PRELOAD
+unset LD_LIBRARY_PATH
+
+exec /opt/puppetlabs/puppet/bin/mco $@
+

--- a/resources/files/puppet.sh
+++ b/resources/files/puppet.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+unset LD_PRELOAD
+unset LD_LIBRARY_PATH
+
+exec /opt/puppetlabs/puppet/bin/puppet $@
+


### PR DESCRIPTION
This will update the files under /opt/puppetlabs/bin to be bash scripts
instead of symlinks. This allows us to set the environment in a specific way
to get around issues with LD_PRELOAD