### PR TITLE
(maint) bump cpp-hocon to 0.1.3

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.2"}
+{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.3"}


### PR DESCRIPTION
This updates cpp-hocon to version 0.1.3, which contains some new features required for fact caching via Facter's config file.