### PR TITLE
(maint) Bump cpp-hocon to 0.1.4 tag

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.2"}
+{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.4"}


### PR DESCRIPTION
This version includes string externalization, duration parsing, and some
minor API changes used in the fact caching work.