### PR TITLE
(maint) Bump vanagon to 0.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.7.1')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.8.2')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This is needed to fix PA-569, by enabling the brp strip scripts
on Cisco RPM platforms.