### PR TITLE
(PA-575) Disable curl builds for cisco-wrlinux platforms

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -125,7 +125,7 @@ component "facter" do |pkg, settings, platform|
 
   # curl is only used for compute clusters (GCE, EC2); so rpm, deb, and Windows
   skip_curl = 'ON'
-  if (platform.is_linux? && !platform.is_huaweios?) || platform.is_windows?
+  if (platform.is_linux? && !platform.is_huaweios? && !platform.is_cisco_wrlinux?) || platform.is_windows?
     pkg.build_requires "curl"
     skip_curl = 'OFF'
   end

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -31,7 +31,7 @@ component "leatherman" do |pkg, settings, platform|
 
   # curl is only used for compute clusters (GCE, EC2); so rpm, deb, and Windows
   use_curl = 'FALSE'
-  if (platform.is_linux? && !platform.is_huaweios?) || platform.is_windows?
+  if (platform.is_linux? && !platform.is_huaweios? && !platform.is_cisco_wrlinux?) || platform.is_windows?
     pkg.build_requires "curl"
     use_curl = 'TRUE'
   end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -205,7 +205,7 @@ project "puppet-agent" do |proj|
   # Then the dependencies
   proj.component "augeas" unless platform.is_windows?
   # Curl is only needed for compute clusters (GCE, EC2); so rpm, deb, and Windows
-  proj.component "curl" if (platform.is_linux? && !platform.is_huaweios?) || platform.is_windows?
+  proj.component "curl" if (platform.is_linux? && !platform.is_huaweios? && !platform.is_cisco_wrlinux?) || platform.is_windows?
   proj.component "ruby"
   proj.component "nssm" if platform.is_windows?
   proj.component "ruby-stomp"


### PR DESCRIPTION
cisco-wrlinux platforms are not compute clusters, so we can safely
disable curl builds for them.