### PR TITLE
(PA-544) Fix solaris sparc cross-builds of ruby socket library

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -152,7 +152,10 @@ component "ruby" do |pkg, settings, platform|
         pkg.build_requires 'pl-ruby'
       end
 
-      special_flags += " --with-baseruby=#{settings[:host_ruby]} "
+      # During Ruby 2.3.1's configure step on a cross-compiled host, the system cannot
+      # determine whether recvmsg requires peek when closing fds, so we must set it
+      # manually. Without this, we were getting builds missing the socket library (PA-544).
+      special_flags += " --with-baseruby=#{settings[:host_ruby]} --enable-close-fds-by-recvmsg-with-peek "
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'


### PR DESCRIPTION
When cross-compiling ruby 2.3.1 on solaris sparc, the socket library
will not be built unless you specify a close-fds-by-recvmsg-with-peek
configure option.

Note: This commit got reverted back when we decided to release 1.7.0 with ruby 2.2 instead of ruby 2.3.1, so this PR is to restore it with clearer commenting.