### PR TITLE
(PA-620) Supply ssl cert for rubygems.org

### DIFF
--- a/configs/components/ruby.rb
+++ b/configs/components/ruby.rb
@@ -233,6 +233,12 @@ component "ruby" do |pkg, settings, platform|
     end
     pkg.directory settings[:ruby_dir]
   end
+
+  # This became necessary when rubygems.org updated its SSL cert. This patches the new cert into the Rubygems
+  # cert bundle in our vendored Ruby. See PA-620.
+  pkg.add_source "http://buildsources.delivery.puppetlabs.net/GlobalSignRootCA.pem", sum: "7872bab9a5e1a71e3d7f77836a841a04"
+  pkg.install_file "../GlobalSignRootCA.pem", "#{settings[:libdir]}/ruby/2.3.0/rubygems/ssl_certs"
+
   if platform.is_cross_compiled_linux? || platform.is_solaris? || platform.is_aix?
     # Here we replace the rbconfig from our ruby compiled with our toolchain
     # with an rbconfig from a ruby of the same version compiled with the system


### PR DESCRIPTION
Rubygems recently updated its ssl cert. This patches the new cert into the Rubygems cert bundle in our vendored Ruby.

I build a Windows MSI from this branch and installed it. The cert was dropped in the correct directory, and I was able to successfully add `https://rubygems.org` as a gem source.