### PR TITLE
(PA-609) Add net-ssh-telnet2 rubygem for huaweios agents

### DIFF
--- a/configs/components/rubygem-net-ssh-telnet2.rb
+++ b/configs/components/rubygem-net-ssh-telnet2.rb
@@ -1,0 +1,22 @@
+component "rubygem-net-ssh-telnet2" do |pkg, settings, platform|
+  pkg.version "0.1.1"
+  pkg.md5sum "8fba7aada691a0c10caf5b74f57cfef2"
+  pkg.url "https://rubygems.org/downloads/net-ssh-telnet2-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby"
+  pkg.build_requires "rubygem-net-ssh"
+
+  # When cross-compiling, we can't use the rubygems we just built.
+  # Instead we use the host gem installation and override GEM_HOME. Yay?
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
+  pkg.install do
+    ["#{settings[:gem_install]} net-ssh-telnet2-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -250,6 +250,7 @@ project "puppet-agent" do |proj|
 
   # Components only applicable on HuaweiOS
   if platform.is_huaweios?
+    proj.component "rubygem-net-ssh-telnet2"
     proj.component "rubygem-net-scp"
     proj.component "rubygem-mini_portile2"
     proj.component "rubygem-pkg-config"


### PR DESCRIPTION
This is an API wrapper to allow ssh send/expect commands which
follows the Net::Telnet API.

Tested by building the huaweios agent and confirming the gem files exist in the package.
