### PR TITLE
(PA-630) Update Puppet-Agent to use ruby 2.1.9

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -86,8 +86,8 @@ project "puppet-agent" do |proj|
     proj.setting(:libdir, File.join(proj.prefix, "lib"))
   end
 
-  proj.setting(:ruby_version, "2.3.1")
-  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.3.0"))
+  proj.setting(:ruby_version, "2.1.9")
+  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.1.0"))
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   # Cross-compiled Linux platforms


### PR DESCRIPTION
For the upcoming puppet-agent 1.8.0 release, we will need vendor ruby 2.1.9


blocked on https://github.com/puppetlabs/puppet-agent/pull/883