### PR TITLE
(PA-575) Disable curl builds for cisco-wrlinux platforms

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -206,7 +206,7 @@ project "puppet-agent" do |proj|
   # Then the dependencies
   proj.component "augeas" unless platform.is_windows?
   # Curl is only needed for compute clusters (GCE, EC2); so rpm, deb, and Windows
-  proj.component "curl" if (platform.is_linux? && !platform.is_huaweios?) || platform.is_windows?
+  proj.component "curl" if (platform.is_linux? && !platform.is_huaweios? && !platform.is_cisco_wrlinux?) || platform.is_windows?
   proj.component "ruby-#{proj.ruby_version}"
   proj.component "nssm" if platform.is_windows?
   proj.component "ruby-stomp"


### PR DESCRIPTION
cisco-wrlinux platforms are not compute clusters, so we can safely
disable curl builds for them.

Note: this reapplies these changes, as some of them were lost in the
merge from master to stable.