### PR TITLE
(maint) Update Facter and Puppet refs to include acceptance test changes

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.5.0"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "ea2f60e86c82b07ea76a9f2d362470906e629ef5"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.8.0"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "23b89129c3dbb797717bb7eb2011cb2dd8680818"}


### PR DESCRIPTION
Some of the acceptance tests for Puppet and Facter do not work correctly
on the eccentric platforms. This updates the SHAs for those components
to commits that include acceptance test changes which will allow
validation on the manual pipelines.