### PR TITLE
(PA-679) Allow optional attributes on DOCTYPE ENTITY

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -6,6 +6,7 @@ component 'augeas' do |pkg, settings, platform|
   pkg.replaces 'pe-augeas'
   pkg.apply_patch 'resources/patches/augeas/osx-stub-needed-readline-functions.patch'
   pkg.apply_patch 'resources/patches/augeas/sudoers-negated-command-alias.patch'
+  pkg.apply_patch 'resources/patches/augeas/entitys-allow-system-public-option.patch'
   if platform.is_sles? && platform.os_version == '10'
     pkg.apply_patch 'resources/patches/augeas/augeas-1.2.0-fix-services-sles10.patch'
   end

--- a/resources/patches/augeas/entitys-allow-system-public-option.patch
+++ b/resources/patches/augeas/entitys-allow-system-public-option.patch
@@ -1,0 +1,17 @@
+--- a/lenses/xml.aug	2016-11-09 15:18:34.000000000 -0800
++++ b/lenses/xml.aug	2016-11-09 15:19:19.000000000 -0800
+@@ -78,9 +78,12 @@
+ 
+ let att_list_def = decl_def /!ATTLIST/ att_def
+ 
+-let entity_def    = decl_def /!ENTITY/ ([sep_spc . label "#decl" . sto_dquote ])
++let entity_ext_def    = decl_def /!ENTITY/ (([ sep_spc . key /SYSTEM/ . [ sep_spc . label "#systemliteral" . sto_dquote ] ] |
++                                         [ sep_spc . key /PUBLIC/ . [ sep_spc . label "#pubidliteral" . sto_dquote ] . [ sep_spc . label "#systemliteral" . sto_dquote ] ]) )
+ 
+-let decl_def_item = elem_def | entity_def | att_list_def | notation_def
++let entity_int_def = decl_def /!ENTITY/ ([sep_spc . label "#decl" . sto_dquote ])
++
++let decl_def_item = elem_def | entity_int_def | entity_ext_def | att_list_def | notation_def
+ 
+ let decl_outer    = sep_osp . del /\[[ \n\t\r]*/ "[\n" .
+                     (decl_def_item . sep_osp )* . dels "]"


### PR DESCRIPTION
Prior to this patch, the Xml augeas lens would fail to parse
a file containing a DOCTYPE with an ENTITY using the "SYSTEM" or
"PUBLIC" optional parameters.  With this patch in place, those
files are parsed successfully, with the optional attributes stored
as the label.