### PR TITLE
(PA-676) Fix cross-compilation of ruby-selinux

### DIFF
--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -24,7 +24,7 @@ component "ruby-selinux" do |pkg, settings, platform|
   ruby = "#{settings[:bindir]}/ruby -rrbconfig"
   if platform.is_cross_compiled_linux?
     cc = "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    system_include = ""
+    system_include = "-I/opt/pl-build-tools/#{settings[:platform_triple]}/sysroot/usr/include"
     pkg.environment "RUBY" => settings[:host_ruby]
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   end
@@ -35,7 +35,7 @@ component "ruby-selinux" do |pkg, settings, platform|
      "export ARCHDIR=$${RUBYHDRDIR}/$(shell #{ruby} -e 'puts RbConfig::CONFIG[\"arch\"]')",
      "export INCLUDESTR=\"-I#{settings[:includedir]} -I$${RUBYHDRDIR} -I$${ARCHDIR}\"",
      "cp -pr src/{selinuxswig_ruby.i,selinuxswig.i}  .",
-     "swig -Wall -ruby -I/usr/include -o selinuxswig_ruby_wrap.c -outdir ./ selinuxswig_ruby.i",
+     "swig -Wall -ruby #{system_include} -o selinuxswig_ruby_wrap.c -outdir ./ selinuxswig_ruby.i",
      "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -DSHARED -c -o selinuxswig_ruby_wrap.lo selinuxswig_ruby_wrap.c",
      "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -shared -o _rubyselinux.so selinuxswig_ruby_wrap.lo -lselinux -Wl,-soname,_rubyselinux.so"]
   end


### PR DESCRIPTION
Prevent the cross-compiled builds of ruby-selinux from finding the selinux
include headers in /usr/include, and specify the sysroot includedir instead.