### PR TITLE
(MAINT) Use Homebrew env. vars to prevent 💩

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -3,6 +3,9 @@ platform "osx-10.12-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "sierra"
 
+  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
   plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'


### PR DESCRIPTION
Homebrew 1.1.0 removes SHA1 sums (fine, whatever), but it also removes
the ability to run `brew` as root. Yes, this is a good idea but we
have to refactor the entire macOS build process to fix that from our
end.

But "we don't upgrade Homebrew! We use a snapshot!" you say. Well,
true. But `brew` will automatically, and silently, upgrade itself in
the background when you tap a new Homebrew keg... unless you tell it
not to.

While I was in there, I also turned off emoji and turned up verbosity.
Might as well, right?

Yes, this is specific to macOS Sierra right now. It's a snowflake.