### PR TITLE
(PA-678) Cause puppet-agent to conflict with r10k versions less than 2.5.0

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,6 +1,11 @@
 project "puppet-agent" do |proj|
   platform = proj.get_platform
 
+  # (PA-678) pe-r10k versions later than 2.5.0 ship gettext gems.
+  # Since we also ship those gems as part of puppet-agent
+  # at present, we need to conflict with pe-r10k > 2.5.0
+  proj.conflicts "pe-r10k", "2.5.0"
+
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Puppet Inc")


### PR DESCRIPTION
After version 2.5.0, pe-r10k begins vendoring the gettext gems, which
puppet-agent also vendors as of 1.8.0, causing these packages to
conflict. This adds a conflicts statement, which prevents them from
being installed together and ensures upgrades are handled correctly.