### PR TITLE
Merge LTS to stable

### DIFF
--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -24,7 +24,7 @@ component "ruby-selinux" do |pkg, settings, platform|
   ruby = "#{settings[:bindir]}/ruby -rrbconfig"
   if platform.is_cross_compiled_linux?
     cc = "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    system_include = ""
+    system_include = "-I/opt/pl-build-tools/#{settings[:platform_triple]}/sysroot/usr/include"
     pkg.environment "RUBY" => settings[:host_ruby]
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   end
@@ -35,7 +35,7 @@ component "ruby-selinux" do |pkg, settings, platform|
      "export ARCHDIR=$${RUBYHDRDIR}/$(shell #{ruby} -e 'puts RbConfig::CONFIG[\"arch\"]')",
      "export INCLUDESTR=\"-I#{settings[:includedir]} -I$${RUBYHDRDIR} -I$${ARCHDIR}\"",
      "cp -pr src/{selinuxswig_ruby.i,selinuxswig.i}  .",
-     "swig -Wall -ruby -I/usr/include -o selinuxswig_ruby_wrap.c -outdir ./ selinuxswig_ruby.i",
+     "swig -Wall -ruby #{system_include} -o selinuxswig_ruby_wrap.c -outdir ./ selinuxswig_ruby.i",
      "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -DSHARED -c -o selinuxswig_ruby_wrap.lo selinuxswig_ruby_wrap.c",
      "#{cc} $${INCLUDESTR} #{system_include} -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -shared -o _rubyselinux.so selinuxswig_ruby_wrap.lo -lselinux -Wl,-soname,_rubyselinux.so"]
   end

--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -3,6 +3,10 @@ platform "osx-10.12-x86_64" do |plat|
   plat.servicedir '/Library/LaunchDaemons'
   plat.codename "sierra"
 
+  plat.provision_with 'export HOMEBREW_NO_AUTO_UPDATE=true'
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
   plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'


### PR DESCRIPTION
This brings the following fixes to stable:
- (PA-676) Fix cross-compilation of ruby-selinux on s390x
- prevent Homebrew auto-updating on macOS Sierra