### PR TITLE
(PA-682) Bump curl to 7.51.0

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.50.3'
-  pkg.md5sum '870e16fd88a88b52e26a4f04dfc161db'
+  pkg.version '7.51.0'
+  pkg.md5sum '490e19a8ccd1f4a244b50338a0eb9456'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"


### PR DESCRIPTION
This updates the version of curl used in our builds to 7.51.0, in
response to a recent security update.