### PR TITLE
(maint) Fix XCC of curl for arm platforms

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -10,6 +10,7 @@ component 'curl' do |pkg, settings, platform|
     pkg.build_requires 'runtime'
     pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
   end
 
   if platform.is_windows?


### PR DESCRIPTION
Prior to this commit debian-8-arm* platforms were getting a recv error
during configure on curl. This was due to using system pkg-config and
not the one found in /opt/pl-build-tools. This commit simply adjusts
PATH to prefer /opt/pl-build-tools/bin for cross_compiled_linux
platforms in the curl component.

This was a new problem introduced with the recent upgrade of curl.



![](http://cdn.skim.gs/image/upload/v1456342884/msi/GIF_Heatless_Hair_Curl_TwistUP_Step02_FINAL02_f7e6jt.gif)
