### PR TITLE
(PA-696) Update components to tags for 1.8.1 release

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "e8a11caac43c9798912ee8b8f0ca8a0c412d27ce"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.5.0"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "bd7faa83d66e2eb87f69b7362446d9a2500ba7eb"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.2.2"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "6eed61dba67f2801ef88b91f6d41f68292d4be12"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.9.1"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "83909490a047b15f7fd4ca4f72490112740a7aec"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.8.1"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "74b58263dfb6ba1f37fb918934666ecca01203f2"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.3.0"}


### PR DESCRIPTION
This sets all the components to the tags slated for the 1.8.1 release.
All components except puppet are pinned to the versions released in
1.8.0, while puppet is updated to 4.8.1.