### PR TITLE
(PUP-6474) Specify install location for Puppet localedir

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -137,6 +137,7 @@ component "puppet" do |pkg, settings, platform|
         --vardir=#{vardir} \
         --rundir=#{piddir} \
         --logdir=#{logdir} \
+        --localedir=#{settings[:datadir]}/locale \
         --configs \
         --quick \
         --no-batch-files \
@@ -189,6 +190,7 @@ component "puppet" do |pkg, settings, platform|
 
   pkg.directory vardir, mode: '0750'
   pkg.directory configdir
+  pkg.directory File.join(settings[:datadir], "locale")
   pkg.directory settings[:puppet_codedir]
   pkg.directory File.join(settings[:puppet_codedir], "modules")
   pkg.directory File.join(settings[:prefix], "modules")


### PR DESCRIPTION
This passes a new flag to the puppet install script, which specifies the
correct location for translation files.