### PR TITLE
(PUP-6474) Update gettext-setup gem to 0.8

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.6"
-  pkg.md5sum "0e96a7add84e0bc1609684f720ed377e"
+  pkg.version "0.8"
+  pkg.md5sum "acc1f3d226fb94bbf3d7f672ebfb75c0"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"


### PR DESCRIPTION
This bumps the gettext-setup gem version to 0.8, which allows the gem
user to specify which file format to expect for translation files.

This will need to go in before https://github.com/puppetlabs/puppet/pull/5366.