### PR TITLE
(PA-729) Bump leatherman in stable to 0.9.4

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "0.9.2"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.9.4"}


### PR DESCRIPTION
Bump leatherman in stable to the 0.9.4 release which brings in the following fixes:
- Handle null characters in JSON strings (LTH-116)
- Explicitly pass release flag to pod2man