### PR TITLE
(PA-247) Don't halt pxp-agent child processes

### DIFF
--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.3.0"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "6c04e9e7612c6db63a13156fd29842a462bc410d"}

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -22,7 +22,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes" />
-        <!-- Various registry keys documented at https://nssm.cc/usage -->
+        <!-- Various registry keys documented at https://nssm.cc/usage and https://github.com/kirillkovalenko/nssm -->
         <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\pxp-agent\Parameters">
           <RegistryValue Name="AppDirectory"
                          Value="[INSTALLDIR]pxp-agent\bin"
@@ -37,9 +37,13 @@
                          Value="PATH=[INSTALLDIR]pxp-agent\bin;[INSTALLDIR]puppet\bin;[INSTALLDIR]sys\ruby\bin;%PATH%"
                          Type="multiString"
                          Action="append" />
-          <!-- Skip responding to WM_QUIT and WM_CLOSE -->
+          <!-- Skip responding to WM_QUIT and WM_CLOSE; don't use TerminateProcess to prevent killing the entire process tree (PCP-276) -->
           <RegistryValue Name="AppStopMethodSkip"
-                         Value="6"
+                         Value="14"
+                         Type="integer" />
+          <!-- Set the flag for not killing the entire process tree (PCP-276) -->
+          <RegistryValue Name="AppKillProcessTree"
+                         Value="0"
                          Type="integer" />
           <RegistryKey Key="AppExit">
             <!-- Stop the service completely on exit(2) (Invalid configuration) otherwise restart with NSSM service throttling -->


### PR DESCRIPTION
Disables halting pxp-agent child processes when restarting or stopping
the service. This makes behavior consistent with all other platforms for
pxp-agent.

Pickup pxp-agent fix from PCP-276 required for this to work.