### PR TITLE
(PA-765) Limit make of cpp-pcp-client to one thread

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -70,10 +70,10 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   end
 
   pkg.build do
-    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"]
+    ["#{make}"]
   end
 
   pkg.install do
-    ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
+    ["#{make} install"]
   end
 end


### PR DESCRIPTION
I fully appreciate this avoids a real problem rather than
a fix.

Using myown build of pl-gcc-4.8.2-9.el7.x86_64 on CentOS7
my compile of pl-cpp-client master =>
01015c0c1baa4f1df8cb6cfe876ed78213a34680
referenced from puppet-agent 1.8.2 always failed
as below in the same place.

Reducing threads to 1 and it built okay.

```
[ 50%] Building CXX object
lib/CMakeFiles/libcpp-pcp-client.dir/src/connector/connection.cc.o
cd /var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib &&
/opt/pl-build-tools/bin/g++   -DBOOST_LOG_WITHOUT_WCHAR_T
-DBOOST_SYSTEM_NO_DEPRECATED
-DCPP_PCP_CLIENT_LOGGING_PREFIX=\"puppetlabs.cpp_pcp_client\"
-DLEATHERMAN_LOGGING_LINE_NUMBERS -DLEATHERMAN_USE_LOCALES
-DOPENSSL_NO_SSL2 -DOPENSSL_NO_SSL3
-DPROJECT_DIR=\"/var/tmp/tmp.iytw5I03GO/cpp-pcp-client\"
-DPROJECT_NAME=\"cpp-pcp-client\" -Dlibcpp_pcp_client_EXPORTS -fPIC
-pthread -fPIC -pthread  -fPIC -pthread   -Wno-maybe-uninitialized
-std=c++11 -Wall -Werror -Wno-unused-parameter
-Wno-unused-local-typedefs -Wno-unknown-pragmas
-Wno-missing-field-initializers -Wextra -Wno-deprecated-declarations
-Wno-reorder -Wno-sign-compare -O3 -DNDEBUG -fPIC
-fvisibility-inlines-hidden
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/generated
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/inc
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/src/valijson/include
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/src/websocketpp
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/../vendor/nowide/include
-I/opt/pl-build-tools/include -I/opt/puppetlabs/puppet/include
-I/opt/puppetlabs/puppet/include/leatherman/vendor    -o
CMakeFiles/libcpp-pcp-client.dir/src/connector/connection.cc.o -c
/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/src/connector/connection.cc
/opt/pl-build-tools/bin/cmake -E cmake_progress_report
/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/CMakeFiles 29
[ 52%] Building CXX object
lib/tests/CMakeFiles/pcp-chunks.dir/__/src/validator/validator.cc.o
cd /var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/tests &&
/opt/pl-build-tools/bin/g++   -DBOOST_LOG_WITHOUT_WCHAR_T
-DBOOST_SYSTEM_NO_DEPRECATED
-DCPP_PCP_CLIENT_LOGGING_PREFIX=\"puppetlabs.cpp_pcp_client\"
-DLEATHERMAN_LOGGING_LINE_NUMBERS -DLEATHERMAN_USE_LOCALES
-DOPENSSL_NO_SSL2 -DOPENSSL_NO_SSL3
-DPROJECT_DIR=\"/var/tmp/tmp.iytw5I03GO/cpp-pcp-client\"
-DPROJECT_NAME=\"cpp-pcp-client\" -Dlibcpp_pcp_client_EXPORTS
-Dpcp_chunks_EXPORTS -fPIC -pthread -fPIC -pthread  -fPIC -pthread
-Wno-maybe-uninitialized -std=c++11 -Wall -Werror -Wno-unused-parameter
-Wno-unused-local-typedefs -Wno-unknown-pragmas
-Wno-missing-field-initializers -Wextra -Wno-deprecated-declarations
-Wno-reorder -Wno-sign-compare -O3 -DNDEBUG -fPIC
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/generated
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/inc
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/src/valijson/include
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/src/websocketpp
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/../vendor/nowide/include
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/tests/..
-I/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/tests/../src
-I/opt/pl-build-tools/include -I/opt/puppetlabs/puppet/include
-I/opt/puppetlabs/puppet/include/leatherman/vendor    -o
CMakeFiles/pcp-chunks.dir/__/src/validator/validator.cc.o -c
/var/tmp/tmp.iytw5I03GO/cpp-pcp-client/lib/src/validator/validator.cc
g++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <http://gcc.gnu.org/bugs.html> for instructions.
```