### PR TITLE
(PA-621) Conflict with puppetserver < 2.7.2

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -9,8 +9,9 @@ project "puppet-agent" do |proj|
   # (PA-621) puppetserver versions prior to 2.7.2 do not ship
   # up-to-date version of several gems that puppet depends on,
   # such as gettext-setup and hocon. We need to conflict with
-  # puppetserver < 2.7.2.
+  # puppetserver < 2.7.2 and pe-puppetserver < 2017.1.0.3.
   proj.conflicts "puppetserver", "2.7.2"
+  proj.conflicts "pe-puppetserver", "2017.1.0.3"
 
   # Project level settings our components will care about
   if platform.is_windows?

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -6,6 +6,12 @@ project "puppet-agent" do |proj|
   # at present, we need to conflict with pe-r10k < 2.5.0.0
   proj.conflicts "pe-r10k", "2.5.0.0"
 
+  # (PA-621) puppetserver versions prior to 2.7.2 do not ship
+  # up-to-date version of several gems that puppet depends on,
+  # such as gettext-setup and hocon. We need to conflict with
+  # puppetserver < 2.7.2.
+  proj.conflicts "puppetserver", "2.7.2"
+
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Puppet Inc")


### PR DESCRIPTION
Puppetserver versions below 2.7.2 do not vendor certain gems that puppet
depends on (e.g. gettext-setup, hocon). This commit adds a conflict
statement which will prevent this version of puppet-agent from being
installed with old puppetservers.

Please double check my logic and comment language on this one, I got the conflict backwards last time...