### PR TITLE
(maint) Make puppet component depend on rubygem-win32-dir

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -4,6 +4,10 @@ component "puppet" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "facter"
   pkg.build_requires "hiera"
+  # Used to specify default directories when installing puppet
+  if platform.is_windows?
+    pkg.build_requires "rubygem-win32-dir"
+  end
 
   pkg.replaces 'puppet', '4.0.0'
   pkg.provides 'puppet', '4.0.0'


### PR DESCRIPTION
A recent refactor changed the way that Puppet's install script required
the `win32/dir` gem. However, this require was broken during a Vanagon
build, because the script required the `win32/dir` gem before Vanagon
installed that gem. This makes the new dependency explicit.