### PR TITLE
(PA-785) Remove EL5 platforms from 'rpm_targets' list

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -60,7 +60,7 @@ pe_platforms:
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 deb_targets: 'lucid-i386 lucid-amd64 precise-i386 precise-amd64 squeeze-i386 squeeze-amd64 trusty-i386 trusty-amd64 wheezy-i386 wheezy-amd64 xenial-i386 xenial-amd64'
-rpm_targets: 'el-5-i386 el-5-x86_64 el-6-i386 el-6-x86_64 el-7-x86_64 sles-11-i386 sles-11-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-i386 el-6-x86_64 el-7-x86_64 sles-11-i386 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"


### PR DESCRIPTION
Puppet-agent "PEZ" promotions are failing with this error:
```
  Directory /opt/enterprise/2017.1/feature/repos//el-5-* must exist
  Remote ssh command failed.
  Failed to ship promoted rpms or debs. Reverting packages.json commit.
```

This commit removes EL5 platforms from puppet-agent's `rpm_targets` list,
so the PEZ promotion job won't look for el-5-* repos in the PEZ feature
branch.