### PR TITLE
(PA-786) Update md5sum for rubygem-nokogiri

### DIFF
--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -9,7 +9,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     pkg.md5sum "8a783bdda33cf5f10afe84cf6fd8f28c"
   else
     pkg.url "https://rubygems.org/downloads/nokogiri-#{pkg.get_version}.gem"
-    pkg.md5sum "3e2169ebd67863a8a992289e2a887366"
+    pkg.md5sum "51402a536f389bfcef0ff1600b8acff5"
   end
 
   pkg.build_requires "ruby"


### PR DESCRIPTION
Because we do not build nokogiri as part of puppet-agent (only
precompiled on one platform), we missed updating the source md5sum when
we revved to 1.6.8.