### PR TITLE
(PA-790) fix arm builds for Debian

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -21,7 +21,7 @@ component 'curl' do |pkg, settings, platform|
   end
 
   pkg.configure do
-    ["CFLAGS='#{settings[:cflags]}' \
+    ["CPPFLAGS='#{settings[:cppflags]}' \
       LDFLAGS='#{settings[:ldflags]}' \
      ./configure --prefix=#{settings[:prefix]} \
         --with-ssl=#{settings[:prefix]} \

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -8,6 +8,7 @@ component 'curl' do |pkg, settings, platform|
 
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'runtime'
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
     pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -9,7 +9,6 @@ component 'curl' do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'runtime'
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
   end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -170,7 +170,8 @@ project "puppet-agent" do |proj|
 
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
-  proj.setting(:cflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+  proj.setting(:cflags, "#{proj.cppflags}")
   proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
 
   # Platform specific overrides or settings, which may override the defaults
@@ -179,7 +180,8 @@ project "puppet-agent" do |proj|
     proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
     proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
     proj.setting(:tools_root, "C:/tools/pl-build-tools")
-    proj.setting(:cflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
+    proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
+    proj.setting(:cflags, "#{proj.cppflags}")
     proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
   end
@@ -191,7 +193,8 @@ project "puppet-agent" do |proj|
     # Additionally, OS X doesn't use RPATH for linking. We shouldn't
     # define it or try to force it in the linker, because this might
     # break gcc or clang if they try to use the RPATH values we forced.
-    proj.setting(:cflags, "-march=core2 -msse4 -I#{proj.includedir}")
+    proj.setting(:cppflags, "-I#{proj.includedir}")
+    proj.setting(:cflags, "-march=core2 -msse4 #{proj.cppflags}")
     proj.setting(:ldflags, "-L#{proj.libdir} ")
   end
 


### PR DESCRIPTION
Puppet Agent 1.8.x cross compiles fail while attempting to build Curl. The root cause is that Curl is picking up the wrong compiler and trying to use the upstream Debian cross-compiler. This winds up including a local x86_64 library path, which means that curl crosslinks against the wrong zlib during configuration and fails. I'm working up a PR to address this, and as a side-effect I may have sussed out some other cross-compilation wonkiness related to the environment variables we're setting.