### PR TITLE
(MCO-783) Update logfile location for mcollective

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -109,6 +109,8 @@ component "marionette-collective" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.directory File.join(settings[:sysconfdir], 'mcollective', 'var', 'log')
+  else
+    pkg.directory File.join(settings[:logdir], 'mcollective')
   end
 
   # Bring in the client.cfg and server.cfg from ext/aio.


### PR DESCRIPTION
This updates the packaging to include the logfile location
for mcollective as proposed in https://github.com/puppetlabs/puppet-specifications/pull/89

Also related to https://github.com/puppetlabs/marionette-collective/pull/410

Adds a log directory for non-windows platforms in /var/log/puppetlabs/mcollective