### PR TITLE
(BUILD-17) Add support for Debian 9 i386 and amd64

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -5,9 +5,16 @@ component "cpp-hocon" do |pkg, settings, platform|
 
   make = platform[:make]
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
-  if platform.is_osx?
+  boost_static = "-DBOOST_STATIC=ON"
+
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=$(workdir)/debian-native-toolchain.cmake.txt" if platform.is_deb?
+    boost_static = "-DBOOST_STATIC=OFF"
+    cmake = "cmake"
+  elsif platform.is_osx?
+    # cmake on OSX is provided by brew
+    # a toolchain is not currently required for OSX since we're building with clang.
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
@@ -45,7 +52,7 @@ component "cpp-hocon" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        #{boost_static} \
         ."]
   end
 

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -14,7 +14,17 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   pkg.build_requires "openssl"
   pkg.build_requires "leatherman"
 
-  if platform.is_aix?
+  boost_static = "-DBOOST_STATIC=ON"
+
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires "gcc"
+    pkg.build_requires "cmake"
+    pkg.build_requires "libboost-all-dev" if platform.is_deb?
+    cmake = "cmake"
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=$(workdir)/debian-native-toolchain.cmake.txt" if platform.is_deb?
+    boost_static = "-DBOOST_STATIC=OFF"
+  elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
@@ -64,7 +74,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
-          -DBOOST_STATIC=ON \
+          #{boost_static} \
           ."
     ]
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -17,7 +17,9 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires 'openssl'
   pkg.build_requires 'leatherman'
-  pkg.build_requires 'runtime'
+  # Require runtime for all platforms except those built with OS
+  # vendor provided toolchain and build tools
+  pkg.build_requires 'runtime' unless platform.name =~ /^debian-9/
   pkg.build_requires 'cpp-hocon'
 
   if platform.is_linux? && !platform.is_huaweios?
@@ -35,8 +37,14 @@ component "facter" do |pkg, settings, platform|
     pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
   end
 
-  # OSX uses clang and system openssl.  cmake comes from brew.
-  if platform.is_osx?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires "gcc"
+    pkg.build_requires "cmake"
+    pkg.build_requires "libboost-all-dev" if platform.is_deb?
+    pkg.build_requires "libyaml-cpp-dev" if platform.is_deb?
+  elsif platform.is_osx?
+    # OSX uses clang and system openssl. cmake comes from brew.
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
     pkg.build_requires "yaml-cpp"
@@ -135,11 +143,19 @@ component "facter" do |pkg, settings, platform|
   make = platform[:make]
   cp = platform[:cp]
 
+  boost_static = "-DBOOST_STATIC=ON"
+  yamlcpp_static = "-DYAMLCPP_STATIC=ON"
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
-  if platform.is_osx?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    cmake = "cmake"
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=$(workdir)/debian-native-toolchain.cmake.txt" if platform.is_deb?
+    boost_static = "-DBOOST_STATIC=OFF"
+    yamlcpp_static = "-DYAMLCPP_STATIC=OFF"
+  elsif platform.is_osx?
+    # cmake on OSX is provided by brew
+    # a toolchain is not currently required for OSX since we're building with clang.
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
@@ -195,8 +211,8 @@ component "facter" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
-        -DYAMLCPP_STATIC=ON \
+        #{boost_static} \
+        #{yamlcpp_static} \
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \
@@ -221,7 +237,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   tests = []
-  unless platform.is_windows? || platform.is_cross_compiled_linux? || platform.architecture == 'sparc'
+  unless platform.is_windows? || platform.is_cross_compiled_linux? || platform.architecture == 'sparc' || platform.name =~ /^debian-9/
     # Check that we're not linking against system libstdc++ and libgcc_s
     tests = [
       "#{ldd} lib/libfacter.so",

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -3,23 +3,23 @@ component "libxml2" do |pkg, settings, platform|
   pkg.md5sum "ae249165c173b1ff386ee8ad676815f5"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
 
-  if platform.is_aix?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires "gcc"
+    pkg.build_requires "make"
+  elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
   elsif platform.is_cross_compiled_linux?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
   elsif platform.is_solaris?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-  elsif platform.is_osx?
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
+  end
+
+  unless platform.is_aix?
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   end

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -5,13 +5,15 @@ component "libxslt" do |pkg, settings, platform|
 
   pkg.build_requires "libxml2"
 
-  if platform.is_aix?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires "gcc"
+    pkg.build_requires "make"
+  elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
   elsif platform.is_cross_compiled_linux?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
 
     # libxslt is picky about manually specifying the build host
     build = "--build x86_64-linux-gnu"
@@ -19,17 +21,15 @@ component "libxslt" do |pkg, settings, platform|
     disable_crypto = "--without-crypto"
   elsif platform.is_solaris?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
     pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'
-  elsif platform.is_osx?
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
+  end
+
+  unless platform.is_aix?
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   end

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -5,8 +5,11 @@ component "openssl" do |pkg, settings, platform|
 
   pkg.replaces 'pe-openssl'
 
-  # Use our toolchain on linux systems (it's not available on osx)
-  if platform.is_cross_compiled_linux?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires 'binutils'
+    pkg.build_requires 'gcc'
+  elsif platform.is_cross_compiled_linux?
     pkg.build_requires "pl-binutils-#{platform.architecture}"
     pkg.build_requires "pl-gcc-#{platform.architecture}"
     pkg.build_requires 'runtime'

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -18,7 +18,15 @@ component "pxp-agent" do |pkg, settings, platform|
 
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
 
-  if platform.is_aix?
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    pkg.build_requires "gcc"
+    pkg.build_requires "cmake"
+    pkg.build_requires "libboost-all-dev" if platform.is_deb?
+
+    cmake = "cmake"
+    toolchain = "-DCMAKE_TOOLCHAIN_FILE=$(workdir)/debian-native-toolchain.cmake.txt" if platform.is_deb?
+  elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"

--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,0 +1,11 @@
+platform "debian-9-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "stretch"
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot ruby-dev libboost-all-dev libyaml-cpp-dev"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "debian-9-x86_64"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end

--- a/configs/platforms/debian-9-i386.rb
+++ b/configs/platforms/debian-9-i386.rb
@@ -1,0 +1,11 @@
+platform "debian-9-i386" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "stretch"
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot ruby-dev libboost-all-dev libyaml-cpp-dev"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "debian-9-i386"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -170,9 +170,18 @@ project "puppet-agent" do |proj|
 
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
-  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, "#{proj.cppflags}")
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+  if platform.name =~ /^debian-9/
+    # These platforms use the OS vendor provided toolchain and build tools
+    proj.setting(:cppflags, "-I#{proj.includedir}")
+    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
+  else
+    # Set defaults to make use toolchain and build tools packages built
+    # from pl-build-tools-vanagon: https://github.com/puppetlabs/pl-build-tools-vanagon
+    proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+  end
 
   # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?
@@ -251,7 +260,9 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime"
+  # Require runtime for all platforms except those built with OS
+  # vendor provided toolchain and build tools
+  proj.component "runtime" unless platform.name =~ /^debian-9/
 
   # Needed to avoid using readline on solaris and aix
   if platform.is_solaris? || platform.is_aix?

--- a/resources/files/debian-native-toolchain.cmake.txt
+++ b/resources/files/debian-native-toolchain.cmake.txt
@@ -1,0 +1,19 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+#this one not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+
+SET(CMAKE_C_FLAGS "-fPIC -pthread ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+
+# update RPATH so our custom libraries can be found
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
Debian 9.0 is currently in alpha, but these changes can be used to
generate puppet agents for both of the x86 architectures. Additionally,
building this agent no longer requires packages from pl-build-tools,
and uses the distro provided gcc, boost, and libyaml-cpp packages.