### PR TITLE
(PA-811) Update MCO and Hiera to tags for 1.7.2 release

### DIFF
--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "cbf727f2b5584dac10de9f74886fc606de707540"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.2.2"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "6eed61dba67f2801ef88b91f6d41f68292d4be12"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.9.1"}


### PR DESCRIPTION
These two components have already been released. So they can be pinned to tags
right now.