### PR TITLE
(PA-835) Gather a valid release candidate

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.3.0"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "872bfbb13d2f2e4e95c83489623d6a4a00177069"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "bd7faa83d66e2eb87f69b7362446d9a2500ba7eb"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.2.2"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "6eed61dba67f2801ef88b91f6d41f68292d4be12"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.9.1"}


### PR DESCRIPTION
This PR updates all puppet-agent components either to tags (non-updating components) or the SHAs we hope to tag for each component for the 1.8.3 release.

Update: no SHAs updating in this PR, will merge stable into this branch instead.