### PR TITLE
Merge 1.8.3-release to stable

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.3.0"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.3.1"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "abd20cd7fce0ec65082dffb264f5cfd2d69519bf"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.8.2"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "1dac1f6caa3a3c007c92dc89eae6039ad3c3d530"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.3.2"}


### PR DESCRIPTION
For the components that we pinned back to previous tags (hiera, mcollective), I had to go in and edit the merge to prefer the SHAs in stable over the tags in 1.8.3-release. For Facter, I preferred the updated SHA which didn't make it into the release. Puppet and pxp-agent were tagged at their most recent stable SHA.