### PR TITLE
(PA-890) Revert conflicts on (pe-)puppetserver

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -6,12 +6,6 @@ project "puppet-agent" do |proj|
   # at present, we need to conflict with pe-r10k < 2.5.0.0
   proj.conflicts "pe-r10k", "2.5.0.0"
 
-  # (PA-621) puppetserver versions prior to 2.7.2 do not ship
-  # up-to-date version of several gems that puppet depends on,
-  # such as gettext-setup and hocon. We need to conflict with
-  # puppetserver < 2.7.2.
-  proj.conflicts "puppetserver", "2.7.2"
-
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Puppet Inc")

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -9,9 +9,8 @@ project "puppet-agent" do |proj|
   # (PA-621) puppetserver versions prior to 2.7.2 do not ship
   # up-to-date version of several gems that puppet depends on,
   # such as gettext-setup and hocon. We need to conflict with
-  # puppetserver < 2.7.2 and pe-puppetserver < 2017.1.0.3.
+  # puppetserver < 2.7.2.
   proj.conflicts "puppetserver", "2.7.2"
-  proj.conflicts "pe-puppetserver", "2017.1.0.3"
 
   # Project level settings our components will care about
   if platform.is_windows?


### PR DESCRIPTION
(PA-890)
We have decided to delay/rethink these package conflicts to avoid unanticipated
breakage in a minor version and consequences thereof. In the interim, we will
vendor libs in question, per PA-890 and PUP-7114.