### PR TITLE
Bump component SHAs for hiera and puppet

### DIFF
--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "d71dfd3a4d1c0a7bb7af53bf16bdd09938d0d0a0"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "322a61555e4240a1e04306da1a8dd4009ad7963d"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "76ea81dcb6ed010bfd68efbd83ee9056133b6ebc"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "fdb0991c3280ff081a3564c778fe6016c1f46c1c"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "c4e7825af4ced060b0bae625206b81457d50d8ca"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "ce5500dd660019b2be6d132b14f70baff4c553fa"}


### PR DESCRIPTION
These are needed to ensure we get the hiera version bump (kinda important!) and the puppet fix for PUP-6925.