### PR TITLE
(RE-8343) Add repo_location for Fedora 25 platforms

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -116,6 +116,10 @@ platform_repos:
     repo_location: repos/fedora/f24/**/i386
   - name: fedora-24-x86_64
     repo_location: repos/fedora/f24/**/x86_64
+  - name: fedora-25-i386
+    repo_location: repos/fedora/f25/**/i386
+  - name: fedora-25-x86_64
+    repo_location: repos/fedora/f25/**/x86_64
   - name: debian-7-i386
     repo_location: repos/apt/wheezy
   - name: debian-7-amd64


### PR DESCRIPTION
We already had fedora-25 in the list of foss_platforms. This just
adds the new repo_location field to the file.