### PR TITLE
Pull in leatherman fix for pxp-agent hang issues and fedora 25 build_defaults.

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "c4e7825af4ced060b0bae625206b81457d50d8ca"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "ce5500dd660019b2be6d132b14f70baff4c553fa"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "4065ed08d62dd369b039b82117835dc4354226b4"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "32bd177902a881f78734c484696a183a699d1e56"}


### PR DESCRIPTION
This also includes a pxp-agent SHA update that simply reflects a trivial README update.