### PR TITLE
(PA-901) Remove EOL platforms from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -15,8 +15,6 @@ foss_platforms:
   - el-6-x86_64
   - el-7-x86_64
   - eos-4-i386
-  - fedora-f22-i386
-  - fedora-f22-x86_64
   - fedora-f23-i386
   - fedora-f23-x86_64
   - fedora-f24-i386
@@ -24,7 +22,6 @@ foss_platforms:
   - fedora-f25-i386
   - fedora-f25-x86_64
   - huaweios-6-powerpc
-  - osx-10.9-x86_64
   - osx-10.10-x86_64
   - osx-10.11-x86_64
   - osx-10.12-x86_64
@@ -35,8 +32,6 @@ foss_platforms:
   - ubuntu-12.04-i386
   - ubuntu-14.04-amd64
   - ubuntu-14.04-i386
-  - ubuntu-15.10-amd64
-  - ubuntu-15.10-i386
   - ubuntu-16.04-amd64
   - ubuntu-16.04-i386
   - ubuntu-16.10-amd64
@@ -51,16 +46,12 @@ pe_platforms:
   - el-4-x86_64
   - el-6-s390x
   - el-7-s390x
-  - sles-10-i386
-  - sles-10-x86_64
   - sles-11-s390x
   - sles-12-s390x
   - solaris-10-i386
   - solaris-10-sparc
   - solaris-11-i386
   - solaris-11-sparc
-  - ubuntu-10.04-amd64
-  - ubuntu-10.04-i386
 platform_repos:
   - name: aix-5.3-power
     repo_location: repos/aix/5.3/**/ppc
@@ -90,10 +81,6 @@ platform_repos:
     repo_location: repos/el/7/**/x86_64
   - name: el-7-s390x
     repo_location: repos/el/7/**/s390x
-  - name: sles-10-i386
-    repo_location: repos/sles/10/**/i386
-  - name: sles-10-x86_64
-    repo_location: repos/sles/10/**/x86_64
   - name: sles-11-s390x
     repo_location: repos/sles/11/**/s390x
   - name: sles-11-i386
@@ -104,10 +91,6 @@ platform_repos:
     repo_location: repos/sles/12/**/s390x
   - name: sles-12-x86_64
     repo_location: repos/sles/12/**/x86_64
-  - name: fedora-22-i386
-    repo_location: repos/fedora/f22/**/i386
-  - name: fedora-22-x86_64
-    repo_location: repos/fedora/f22/**/x86_64
   - name: fedora-23-i386
     repo_location: repos/fedora/f23/**/i386
   - name: fedora-23-x86_64
@@ -128,10 +111,6 @@ platform_repos:
     repo_location: repos/apt/jessie
   - name: debian-8-amd64
     repo_location: repos/apt/jessie
-  - name: ubuntu-10.04-i386
-    repo_location: repos/apt/lucid
-  - name: ubuntu-10.04-amd64
-    repo_location: repos/apt/lucid
   - name: ubuntu-12.04-i386
     repo_location: repos/apt/precise
   - name: ubuntu-12.04-amd64
@@ -140,16 +119,10 @@ platform_repos:
     repo_location: repos/apt/trusty
   - name: ubuntu-14.04-amd64
     repo_location: repos/apt/trusty
-  - name: ubuntu-15.10-i386
-    repo_location: repos/apt/wily
-  - name: ubuntu-15.10-amd64
-    repo_location: repos/apt/wily
   - name: ubuntu-16.04-i386
     repo_location: repos/apt/xenial
   - name: ubuntu-16.04-amd64
     repo_location: repos/apt/xenial
-  - name: osx-10.9
-    repo_location: repos/apple/10.9/**/x86_64/*.dmg
   - name: osx-10.10
     repo_location: repos/apple/10.10/**/x86_64/*.dmg
   - name: osx-10.11


### PR DESCRIPTION
The following platforms have gone EOL and will no longer be shipped with the
agent:

SLES 10
OSX 10.9
Fedora 22
Ubuntu 10.04
Ubuntu 15.10