### PR TITLE
(RE-8346) Add repo_location for Ubuntu 16.10

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -123,6 +123,10 @@ platform_repos:
     repo_location: repos/apt/xenial
   - name: ubuntu-16.04-amd64
     repo_location: repos/apt/xenial
+  - name: ubuntu-16.10-i386
+    repo_location: repos/apt/yakkety
+  - name: ubuntu-16.10-amd64
+    repo_location: repos/apt/yakkety
   - name: osx-10.10
     repo_location: repos/apple/10.10/**/x86_64/*.dmg
   - name: osx-10.11


### PR DESCRIPTION
Ubuntu 16.10 had previously been added to foss_platforms, but since
then we've started adding repo_location metadata as well, and this
completes this info for this platform.