### PR TITLE
(PA-920) Update components to tags for 1.9.1 release

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "fb690a9ffd135c9be79f1ee283471b414550cb1b"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.6.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "e3bcf9e388179d6e0db7473c49cf48fc874cc0ce"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.10.1"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "7b2930ca553baeecb7d7c8ea47be78eccb869dcd"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.9.2"}


### PR DESCRIPTION
This commit updates Puppet, Facter, and MCollective to new tags for the
1.9.1 release.