### PR TITLE
(PA-920) Pin non-updating components to tags for 1.9.1 release

### DIFF
--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "31e605003442784a6970ed83b6d1c91b217376c9"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.3.0"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "bc490cf4929e49d5f2094520acd96de70a6b8a71"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.4.0"}


### PR DESCRIPTION
This commit pins hiera and pxp-agent back to the tags released in 1.9.0
in preparation for the release of 1.9.1