### PR TITLE
(PA-768) Make puppetres.dll permanent

### DIFF
--- a/resources/windows/wix/componentgroup.wxs.erb
+++ b/resources/windows/wix/componentgroup.wxs.erb
@@ -13,6 +13,7 @@
       <%- get_services.each do |service| -%>
       <ComponentGroupRef Id="<%= service.component_group_id %>" />
       <%- end -%>
+      <ComponentGroupRef Id="PuppetResComponentGroup" />
       <!-- All of these Include refs are expected to be present -->
       <ComponentGroupRef Id="FragmentProperties" />
       <ComponentGroupRef Id="FragmentSequences" />

--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
+  <!-- https://ahordijk.wordpress.com/2013/03/26/automatically-add-references-and-content-to-the-wix-installer/ -->
+  <!-- http://www.chriskonces.com/using-xslt-with-heat-exe-wix-to-create-windows-service-installs/ -->
+  <xsl:output method="xml" indent="yes" />
+  <!--<xsl:strip-space elements="*"/>-->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- Filter out all Service File Executables from the Harvest (heat) run as these are specified in the transformed service.components.wxs file -->
+  <!-- The list of component service files are collected in an array so that a set of unique names can be extracted -->
+  <!-- we have to substitue the SourceDir\\etc. etc. for $(var.ProjectSourcePath) in order to facilitate heat -->
+  <!--   being run in two different places, specifically it no longer runs from SourceDir so we needed to pass -->
+  <!--   in ProjectSourcePath to the heat runs. Thus when this filter does its work the source attribute will -->
+  <!--   look like $(var.ProjectSourcePath)/puppet/bin/rubyw.exe for example, not  -->
+  <!--   SourceDir/Program64FilesFolder/Puppet/puppet/bin/ruby.exe -->
+  <%- service_files = Array.new -%>
+  <%- get_services.each do |service| -%>
+
+    <%- service_files << service.service_file.sub("SourceDir\\#{self.settings[:base_dir]}\\#{self.settings[:company_id]}\\#{self.settings[:product_id]}", "$(var.AppSourcePath)") -%>
+  <%- end -%>
+  <%- service_files.uniq.each do |service_file| -%>
+    <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />
+  <%- end -%>
+  <!-- This statement filters out the puppetres.dll file from the component harvest as it needs to be made permanent (PA-768) -->
+  <!-- If a "filter_file" method is added to Vanagon this change could be removed -->
+  <!-- John OC 23-Feb-2017  -->
+  <xsl:template match="wix:Component[wix:File[@Source='$(var.AppSourcePath)\puppet\bin\puppetres.dll']]" />
+
+</xsl:stylesheet>

--- a/resources/windows/wix/puppetres.wxs
+++ b/resources/windows/wix/puppetres.wxs
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <!--
+    This file was introduced to resolve PA-768, where the puppetres.dll file needs
+    be made a permanenent component along with its associated registry entry.
+
+    A corresponding filter line is also included in a project specific filter.xslt.erb file in this
+    resources/windows/wix directory which replaces the generic vanagon provided filter file.
+
+    The directory location for puppetres.dll also needs to be defined in a directory fragment.
+  -->
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Directory Id="PUPPETRESPUPPETDIR" Name="puppet">
+        <Directory Id="PUPPETRESPUPPETBINDIR" Name="bin" />
+      </Directory>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="PuppetResComponentGroup">
+      <Component Id="PuppetResRegistryEntries"
+          Guid="AAD2F7FE-2953-4D58-B4BD-28E1888D7798"
+          Permanent="yes"
+          Directory="TARGETDIR"
+          Win64="no">
+
+        <RegistryKey
+            Root="HKLM"
+            Key="SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet"
+            ForceCreateOnInstall="yes">
+          <RegistryValue
+            Type="string"
+            Name="EventMessageFile"
+            Value="[INSTALLDIR]puppet\bin\puppetres.dll"/>
+        </RegistryKey>
+      </Component>
+
+      <Component
+          Id="PuppetResDllFileComp"
+          Directory="PUPPETRESPUPPETBINDIR"
+          Guid="A8032753-9CC7-45DF-815A-EBF17D48BE3F"
+          Permanent="yes">
+        <File
+            Id="PuppetResDllFile"
+            KeyPath="yes"
+            Source="$(var.AppSourcePath)\puppet\bin\puppetres.dll" />
+      </Component>
+    </ComponentGroup>
+
+  </Fragment>
+</Wix>

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -50,12 +50,7 @@
 
         <RegistryKey
             Root="HKLM"
-            Key="SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet"
-            Action="createAndRemoveOnUninstall">
-          <RegistryValue
-            Type="string"
-            Name="EventMessageFile"
-            Value="[INSTALLDIR]puppet\bin\puppetres.dll"/>
+            Key="SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet">
           <RegistryValue
             Type="integer"
             Name="TypesSupported"


### PR DESCRIPTION
puppetres.dll is managed and installed using the default file harvest
function, so make a separate puppetres.wxs file to define this as a
permanent component along with its registry entry.

The puppetres.dll file also needs to be filtered out of the harvest
operation. This is achieved by using the "install_service" method in
puppet.rb which adds it to the filter xslt file.

A future implemntation of vanagon could add a "filter_file" method which
would better describe this use of the function.