### PR TITLE
(PCP-677) Bump Leatherman to 0.11.1 for logging fix on AIX

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.11.0"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.11.1"}


### PR DESCRIPTION
LTH-128 fixes a logging issue on AIX that prevented pxp-agent from
logging successfully. That fix is included in Leatherman 0.11.1.