### PR TITLE
libfacter specs fail when running 'bundle exec rspec' under scl.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'
 gem 'rubocop', "~> 0.34.2"
+gem 'rspec'

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -233,7 +233,7 @@ component "facter" do |pkg, settings, platform|
   # Make test will explode horribly in a cross-compile situation
   # Tests will be skipped on AIX until they are expected to pass
   if !platform.is_cross_compiled? && !platform.is_aix?
-    tests << "LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
+    tests << "LD_LIBRARY_PATH=#{settings[:libdir]}:#{ENV['LD_LIBRARY_PATH']} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
   end
 
   pkg.check do


### PR DESCRIPTION
This PR fixes the following issues.

When using SCL, the LD_LIBRARY_PATH gets overridden instead of being updated.

```
2: Test command: /opt/rh/rh-ruby22/root/usr/bin/bundle "exec" "rspec"
2: Test timeout computed to be: 9.99988e+06
2: /opt/rh/rh-ruby22/root/usr/bin/ruby: error while loading shared libraries: libruby.so.2.2: cannot open shared object file: No such file or directory
2/3 Test #2: libfacter specs ..................***Failed    0.00 sec
test 3
    Start 3: facter smoke
```

rspec seems to be needed? Added it to the gem requirements.

```
2: Test command: /opt/rh/rh-ruby22/root/usr/bin/bundle "exec" "rspec"
2: Test timeout computed to be: 9.99988e+06
2: bundler: command not found: rspec
2: Install missing gem executables with `bundle install`
```