### PR TITLE
(PA-999) Pin pxp-agent to 1.4.1 tag

### DIFF
--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "7c45d170271ed70663214939acd4e331604ff6b6"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.4.1"}


### PR DESCRIPTION
The commits on pxp-agent's stable branch beyond the 1.4.1 tag are
completely irrelevant to the puppet-agent 1.9.3 release, so this commit
pins that components back to its last released tag.