### PR TITLE
(PA-768) Mark puppetres.dll permanent

### DIFF
--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
+  <!-- https://ahordijk.wordpress.com/2013/03/26/automatically-add-references-and-content-to-the-wix-installer/ -->
+  <!-- http://www.chriskonces.com/using-xslt-with-heat-exe-wix-to-create-windows-service-installs/ -->
+  <xsl:output method="xml" indent="yes" />
+  <!--<xsl:strip-space elements="*"/>-->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- Filter out all Service File Executables from the Harvest (heat) run as these are specified in the transformed service.components.wxs file -->
+  <!-- The list of component service files are collected in an array so that a set of unique names can be extracted -->
+  <!-- we have to substitue the SourceDir\\etc. etc. for $(var.ProjectSourcePath) in order to facilitate heat -->
+  <!--   being run in two different places, specifically it no longer runs from SourceDir so we needed to pass -->
+  <!--   in ProjectSourcePath to the heat runs. Thus when this filter does its work the source attribute will -->
+  <!--   look like $(var.ProjectSourcePath)/puppet/bin/rubyw.exe for example, not  -->
+  <!--   SourceDir/Program64FilesFolder/Puppet/puppet/bin/ruby.exe -->
+  <%- service_files = Array.new -%>
+  <%- get_services.each do |service| -%>
+
+    <%- service_files << service.service_file.sub("SourceDir\\#{self.settings[:base_dir]}\\#{self.settings[:company_id]}\\#{self.settings[:product_id]}", "$(var.AppSourcePath)") -%>
+  <%- end -%>
+  <%- service_files.uniq.each do |service_file| -%>
+    <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />
+  <%- end -%>
+
+  <!-- Above directly copies Vanagons default filter.xslt.erb as Vanagon does not provide a
+       way to perform additional transforms against heat harvested file list -->
+
+  <!-- (PA-768) Modify puppetres.dll component as permanent -->
+  <xsl:template match="wix:Component[wix:File[@Source='$(var.AppSourcePath)\puppet\bin\puppetres.dll']]">
+    <!-- Copy original component with all attributes, marking "Permanent" -->
+    <xsl:copy>
+      <xsl:apply-templates select="@*" />
+      <xsl:attribute name="Permanent">yes</xsl:attribute>
+      <xsl:apply-templates select="node()" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -47,6 +47,13 @@
             Type="string"
             Value="[PUPPET_AGENT_STARTUP_MODE]" />
         </RegistryKey>
+      </Component>
+
+      <Component Id="EventLogRegistryEntries"
+        Guid="3A4E2A16-1919-4BAF-A4CF-9FA3543BB27C"
+        Directory="TARGETDIR"
+        Win64="no"
+        Permanent="yes">
 
         <RegistryKey
             Root="HKLM"


### PR DESCRIPTION
 - Provide an XSLT transform that modifies the puppetres.dll component
   harvested by heat.exe.  Simply add the "Permanent" attribute to
   prevent the file from being removed on upgrade.

   When the event log service is open, it may hold a lock on this DLL
   message file.  Typically the event log service may be hosted in the
   same process as other important Windows processes (often the
   network stack).  To successfully replace this file requires taking
   down the event log service process, which also takes down all other
   services in the same process - which can lead to disruption of
   network based services.  In the wild, this has been observed to
   cause Exchange Server service to bounce, which is unacceptable.

 - Further mark the registry entries associated with the event log
   as "Permanent", so that even after Puppet is removed, event log
   messages are still readable.  This required moving these keys and
   values to their own component.

 - Since the component GUID for puppetres.dll is deterministic, this
   will ensure that the GUID for the component is shared during each
   rebuild - but it will change if the message file should ever
   change, which is desirable behavior.

Paired-with: Glenn Sarti <glenn.sarti@puppet.com>