### PR TITLE
(PA-1000) Update all component SHAs to tags

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "36e4f036cfab9e283f6b47bd5e3890a4de54c5ff"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.6.2"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "750562bbcb73c9df7154e23fe578ffbf795bdb6e"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.3.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "961b433f958fe202590baf3330eadb5f9e997df2"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.10.2"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "9e64c1417551facfd2c5b8ed724a952f1abdf79e"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.9.4"}


### PR DESCRIPTION
This commit updates Facter, Puppet, Hiera, and MCollective to point to
the correct tags for the PA 1.9.3 release.