### PR TITLE
(PA-970) Update minitar to 0.6.1

### DIFF
--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -1,6 +1,6 @@
 component "rubygem-minitar" do |pkg, settings, platform|
-  pkg.version "0.5.4"
-  pkg.md5sum "f5bd734fb3eda7b979d1485ba48fc0ea"
+  pkg.version "0.6.1"
+  pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
   pkg.url "https://rubygems.org/downloads/minitar-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"


### PR DESCRIPTION
Update the rubygem-minitar component to version 0.6.1