### PR TITLE
Mergeup stable -> 1.10.x plus SHA fixes

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "01db924ecfb06c115077966f75f3aee6a3c3499d"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "9b223311436737b890b3dc9f2486fbf95aea8a21"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "01d2859d73d802cde000833aacb460d6e28959d6"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.3.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "263702fec64725144ed316941c94d96f7f3efca2"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.10.2"}


### PR DESCRIPTION
This updates the SHAs in 1.10.x to what they are in the stable branch for Facter, Hiera, and MCO. Since these components do not have any branches automatically promoting into 1.10.x, it is necessary to update them manually.