### PR TITLE
(maint) Update gettext-setup gem to 0.20

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.10"
-  pkg.md5sum "7723f66324fd7f2952d6649a5e4a2539"
+  pkg.version "0.20"
+  pkg.md5sum "53bbb01f01e68fbfa9f2ff11c466e60b"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"


### PR DESCRIPTION
This version of the gem introduces translation domain chaining, allowing
the tooling to behave properly when multiple nested project invoke
gettext (e.g. puppet followed by a module).