### PR TITLE
Adjusting openssl configuration flags to disable following ciphers: D…

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -118,6 +118,7 @@ component "openssl" do |pkg, settings, platform|
     # --libdir ensures that we avoid the multilib (lib/ vs. lib64/) problem,
     # since configure uses the existence of a lib64 directory to determine
     # if it should install its own libs into a multilib dir. Yay OpenSSL!
+    # Disabled: rc4, bf, 
     "./Configure \
       --prefix=#{settings[:prefix]} \
       --libdir=lib \
@@ -127,19 +128,22 @@ component "openssl" do |pkg, settings, platform|
       #{target} \
       #{sslflags} \
       no-camellia \
-      enable-seed \
       enable-tlsext \
       enable-rfc3779 \
-      enable-cms \
       no-md2 \
       no-mdc2 \
-      no-rc5 \
+      no-weak-ssl-ciphers \
+      no-dtls \
+      no-dtls1 \
+      no-rc4 \
+      -DOPENSSL_NO_RC4 \
+      no-idea \
+      no-seed \
       no-ec2m \
-      no-gost \
-      no-srp \
       no-ssl2 \
       no-ssl2-method \
       no-ssl3 \
+      -DOPENSSL_NO_HEARTBEATS \
       #{cflags} \
       #{ldflags}"]
   end


### PR DESCRIPTION
Security enhancement: Updated flags to openssl Configure to disable following ciphers - DES/3DES, RC2/4/5, CAMELLIA, IDEA, SEED, GOST, CAST, MD2/4, BF.
The above list, of ciphers to be disabled, come from the SSL Implementation Reference located here (Recommended Ciphersuites section): https://docs.google.com/document/d/1KonBlqNY9pGY01PfjidPk3PAgKJG85huoOQW_LQ_tME/edit#heading=h.t17jjgd88ew7.

**Note**: With these switches ECDHE is getting enabled. Pl let know if that needs to be disabled as well though I would wonder why it need to be.

This was tested using nogotofail to ensure none of the above ciphers were presented by puppet-agent when establishing TLS connection. Expect a PR on nogotofail to enable checks for unacceptable ciphers and then on pe_acceptance_tests to have it use the puppetlabs/nogotofail. 

@joshcooper 