### PR TITLE
(PA-1044) Update all component SHAs to tags

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "22f77f4e05b014d0fe08d35dc9e47a85622e8e16"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.5.0"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "194e2f2f324aba6a1262f37ad02841383ab7f961"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.6.3"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "6889738ca8c55516f48ea4f7511082492743aed4"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/0.11.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "04b79916af37fde6f24de6d15ec5863f96020556"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.10.3"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "8afedd0110aa1655f88bcbdd13a71f96a13c9518"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.10.0"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "1662d9bafefbe7a529b0ed6b51ad097ade5ebc14"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.5.0"}


### PR DESCRIPTION
This updates cpp-pcp-client, facter, leatherman,
marionette-collective, puppet, and pxp-agent to their tagged versions
for the agent 1.10.1 release.