### PR TITLE
(PA-1059) Adjusting openssl configuration flags to disable weak ciphers

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -118,6 +118,7 @@ component "openssl" do |pkg, settings, platform|
     # --libdir ensures that we avoid the multilib (lib/ vs. lib64/) problem,
     # since configure uses the existence of a lib64 directory to determine
     # if it should install its own libs into a multilib dir. Yay OpenSSL!
+    # Below will disable: bf, camellia, des, 3des, gost, idea, md2/4, rc2/4/5, seed, srp
     "./Configure \
       --prefix=#{settings[:prefix]} \
       --libdir=lib \
@@ -127,19 +128,22 @@ component "openssl" do |pkg, settings, platform|
       #{target} \
       #{sslflags} \
       no-camellia \
-      enable-seed \
       enable-tlsext \
       enable-rfc3779 \
-      enable-cms \
       no-md2 \
       no-mdc2 \
-      no-rc5 \
+      no-weak-ssl-ciphers \
+      no-dtls \
+      no-dtls1 \
+      no-rc4 \
+      -DOPENSSL_NO_RC4 \
+      no-idea \
+      no-seed \
       no-ec2m \
-      no-gost \
-      no-srp \
       no-ssl2 \
       no-ssl2-method \
       no-ssl3 \
+      -DOPENSSL_NO_HEARTBEATS \
       #{cflags} \
       #{ldflags}"]
   end


### PR DESCRIPTION
Moved the ticket to PA. Corresponds to this earlier PR https://github.com/puppetlabs/puppet-agent/pull/1017 (which had the ticket in Security project). 