### PR TITLE
(PA-1019) Vendor minitar on solaris

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -230,12 +230,14 @@ project "puppet-agent" do |proj|
   proj.component "rubygem-gettext-setup"
   if platform.is_windows?
     proj.component "rubygem-ffi"
-    proj.component "rubygem-minitar"
     proj.component "rubygem-win32-dir"
     proj.component "rubygem-win32-eventlog"
     proj.component "rubygem-win32-process"
     proj.component "rubygem-win32-security"
     proj.component "rubygem-win32-service"
+  end
+  if platform.is_windows? || platform.is_solaris?
+    proj.component "rubygem-minitar"
   end
   proj.component "ruby-shadow" unless platform.is_aix? || platform.is_windows?
   proj.component "ruby-augeas" unless platform.is_windows?


### PR DESCRIPTION
Previously, we only vendored minitar on Windows, which completely lacks a `tar` command. As it turns out, the version of `tar` on Solaris doesn't support all the options that the PMT wants to use, so we also need minitar there.