### PR TITLE
(packaging) Add windows to `platform_repos`

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -141,6 +141,8 @@ platform_repos:
     repo_location: repos/solaris/11/**/*.i386.p5p
   - name: solaris-11-sparc
     repo_location: repos/solaris/11/**/*.sparc.p5p
+  - name: windows-2012-x86
+  - name: windows-2012-x64
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 deb_targets: 'precise-amd64 trusty-amd64 xenial-amd64'


### PR DESCRIPTION
Beaker will be using the list of `platform_repos` for testing, so this commit adds windows so that we have a complete list of platforms.