### PR TITLE
(PA-1023) Add step to generate MO files for puppet-agent components

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -51,14 +51,12 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     end
   end
 
-  # Until we build our own gettext packages, disable using locales.
-  # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     [
       "#{cmake} \
       #{toolchain} \
       #{platform_flags} \
-          -DLEATHERMAN_GETTEXT=OFF \
+          -DLEATHERMAN_GETTEXT=ON \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -184,13 +184,11 @@ component "facter" do |pkg, settings, platform|
                        -DRUBY_LIB_INSTALL=#{settings[:ruby_vendordir]}"
   end
 
-  # Until we build our own gettext packages, disable using locales.
-  # gettext 0.17 is required to compile .mo files with msgctxt.
   # FACTER_RUBY Needs bindir
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
-        -DLEATHERMAN_GETTEXT=OFF \
+        -DLEATHERMAN_GETTEXT=ON \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -56,13 +56,11 @@ component "pxp-agent" do |pkg, settings, platform|
     end
   end
 
-  # Until we build our own gettext packages, disable using locales.
-  # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     [
       "#{cmake}\
       #{toolchain} \
-          -DLEATHERMAN_GETTEXT=OFF \
+          -DLEATHERMAN_GETTEXT=ON \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
           -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \


### PR DESCRIPTION
This PR contains 3 commits enabling i18n in the major puppet-agent components.
The first affects puppet, the second enables Leatherman's i18n, and the third updates the configuration of the other C++ project to use Leatherman's i18n tooling.