### PR TITLE
(PA-1057) Update vanagon default version to 0.11.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.8.2')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '0.11.3')
 gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This commit updates puppet-agent to use version 0.11.3 of vanagon, which
is fully compatible with the previously used version, but offers
additional tools and functionality.