### PR TITLE
(maint) Add explanation about elevate.exe

### DIFF
--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -201,6 +201,10 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
+    # Elevate.exe is simply used when one of the run_facter.bat or
+    # run_puppet.bat files are called. These set up the required environment
+    # for the program, and elevate.exe gives the program the elevated
+    # privileges it needs to run
     pkg.install_file "../elevate.exe", "#{settings[:windows_tools]}/elevate.exe"
     pkg.install_file "../elevate.exe.config", "#{settings[:windows_tools]}/elevate.exe.config"
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -218,6 +218,10 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
+    # Elevate.exe is simply used when one of the run_facter.bat or
+    # run_puppet.bat files are called. These set up the required environment
+    # for the program, and elevate.exe gives the program the elevated
+    # privileges it needs to run
     pkg.install_file "../elevate.exe", "#{settings[:windows_tools]}/elevate.exe"
     pkg.install_file "../elevate.exe.config", "#{settings[:windows_tools]}/elevate.exe.config"
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"


### PR DESCRIPTION
I always forget why we have elevate.exe in puppet-agent. Since many new
projects use puppet-agent as a template, we should have a little more
detail as to why we include it. This way we'll know if we do or do not
want to include it in future projects.