### PR TITLE
(PUP-7425) bump net-ssh to 4.1.0

### DIFF
--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -1,6 +1,6 @@
 component "rubygem-net-ssh" do |pkg, settings, platform|
-  pkg.version "2.9.2"
-  pkg.md5sum "ac7574a89e2b422468d98f5387ceb41e"
+  pkg.version "4.1.0"
+  pkg.md5sum "6af1ff8c42a07b11203058c9b74cbaef"
   pkg.url "https://rubygems.org/downloads/net-ssh-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-rubygem-net-ssh'


### PR DESCRIPTION
 - Note that net-ssh 3.3.0beta1 became a dependency of Beaker 3
   (see BKR-40) to address some UTF-8 issues. When that version was
   found to cause issues with bundler (based on its version) number,
   Beaker updated to 4.0+ in Beaker 3.11.0+.

   Given the problems with Unicode handling in the 2.9.2 version of
   this gem, bump the dependency before anything is reported by users.

 - Note that net-ssh 3 and higher require Ruby 2.  This has no bearing
   on agent packages which already ship Ruby 2.1, but could be
   problematic for gem installs - therefore only update packages here.
   The puppet ext/project_data.yaml has not been updated.

   This new requirement will not be a problem within Puppet server as
   the loading of the library is guarded behind a feature in the Puppet
   code. When net-ssh fails to load there due to a Ruby incompatibility
   the :ssh feature will be set to false inside Puppet.