### PR TITLE
(PA-1084) Add path to readlink command to $PATH for Solaris runtime builds

### DIFF
--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -26,6 +26,9 @@ component "runtime" do |pkg, settings, platform|
     libdir = "/opt/pl-build-tools/lib64"
   end
 
+  # The runtime script uses readlink, which is in an odd place on Solaris systems:
+  pkg.environment "PATH" => "$$PATH:/opt/csw/gnu" if platform.is_solaris?
+
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"


### PR DESCRIPTION
This removes the error: "runtime.sh: line 35: readlink: command not found"
seen when building runtime for Solaris build targets.