### PR TITLE
(PA-793) Acceptance test fixes for Suite Pipeline

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,4 +1,4 @@
-# Specifies a gem mirror; duplicated in acceptance setup
+# Specifies a gem mirror; duplicated in acceptance setup 
 # to ensure a similar environment on acceptance hosts.
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
@@ -12,11 +12,17 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.1.0')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.10')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake", "~> 10.1"
+gem "httparty", :require => false
+gem 'uuidtools', :require => false
 
+group(:test) do
+  gem "rspec", "~> 2.14.0", :require => false
+  gem "mocha", "~> 0.10.5", :require => false
+end
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -4,7 +4,7 @@ test_name "Install Packages"
 
 step "Install puppet-agent..." do
   opts = {
-    :puppet_agent_version => ENV['SHA'],
+    :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA'],
     :default_action => 'gem_install'
   }
   agents.each do |agent|


### PR DESCRIPTION
Supporting work for the new PA tests in the CI Pipeline.

1. Relax Beaker version restriction to allow latest Beaker Version.
2. Fix puppet Version handling in package name (for osx, sles etc).
