### PR TITLE
(maint) Add `needs :cxx14` support to older homebrew versions

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -8,6 +8,7 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with 'export HOMEBREW_VERBOSE=true'
 
   plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/homebrew_sierra.tar.gz | tar -x --strip 1 -C /usr/local -f -'
+  plat.provision_with 'curl http://pl-build-tools.delivery.puppetlabs.net/osx/patches/0001-Add-needs-cxx14.patch | patch -p0'
   plat.provision_with 'ssh-keyscan github.delivery.puppetlabs.net >> ~/.ssh/known_hosts; /usr/local/bin/brew tap puppetlabs/brew-build-tools gitmirror@github.delivery.puppetlabs.net:puppetlabs-homebrew-build-tools'
   plat.provision_with '/usr/local/bin/brew tap-pin puppetlabs/brew-build-tools'
   plat.provision_with 'curl -o /usr/local/bin/osx-deps http://pl-build-tools.delivery.puppetlabs.net/osx/osx-deps; chmod 755 /usr/local/bin/osx-deps'

--- a/resources/patches/osx/0001-Add-needs-cxx14.patch
+++ b/resources/patches/osx/0001-Add-needs-cxx14.patch
@@ -1,0 +1,36 @@
+From eab87f54b983957b4717b6ce8e78f1541d1a1cf6 Mon Sep 17 00:00:00 2001
+From: Shaun Jackman <sjackman@gmail.com>
+Date: Thu, 23 Feb 2017 09:40:57 -0800
+Subject: [PATCH] Add needs :cxx14
+
+---
+ Library/Homebrew/compilers.rb | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/Library/Homebrew/compilers.rb b/Library/Homebrew/compilers.rb
+index 51f0919..63e48db 100644
+--- /usr/local/Library/Homebrew/compilers.rb
++++ /usr/local/Library/Homebrew/compilers.rb
+@@ -67,7 +67,18 @@ class CompilerFailure
+       create(:gcc => "4.5"),
+       create(:gcc => "4.6"),
+     ],
+-    :openmp => [
++    cxx14: [
++      create(:clang) { build 600 },
++      create(:gcc_4_0),
++      create(:gcc_4_2),
++      create(gcc: "4.3"),
++      create(gcc: "4.4"),
++      create(gcc: "4.5"),
++      create(gcc: "4.6"),
++      create(gcc: "4.7"),
++      create(gcc: "4.8"),
++    ],
++    openmp: [
+       create(:clang),
+     ],
+   }
+-- 
+2.8.1
+


### PR DESCRIPTION
Prior to this commit, macOS 10.12 packaging is failing with the
following homebrew error when installing build dependencies:
```
 Error:` Invalid formula:
  /usr/local/Library/Taps/homebrew/homebrew-core/Formula/mame.rb
  Error: Cannot tap homebrew/core: invalid syntax in tap!
  "cxx14" is not a recognized standard
```
This appears to be related to an upstream change that landed recently at
https://github.com/Homebrew/homebrew-core/pull/12146/commits/3a830725fda3b63e7f2753a8de5d68079caf7b1b.

New versions of Homebrew add `needs :cxx14`, but don't allow execution
as root, which is typically how we currently build puppet-agent.

As a workaround, this commit patches our homebrew to backport support
for `needs :cxx14` in brew forumlae.

Shamelessly copypasta-ed from @geoffnichols 