### PR TITLE
(PA-1023) Update LEATHERMAN_LOCALE_VAR to leatherman install root

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -76,7 +76,7 @@ component "leatherman" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
 
     # Use environment variable set in environment.bat to find locale files
-    leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PL_BASEDIR' -DLEATHERMAN_LOCALE_INSTALL='puppet/share/locale'"
+    leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"


### PR DESCRIPTION
Improvements to the Leatherman tooling around installing and using
locale files require the LEATHERMAN_LOCALE_VAR point to the Leatherman
install root, which on Windows corresponds to `<user-defined install
location>/puppet`. In `environment.bat` we set an environment variable
PUPPET_DIR, which points to this directory (`$PL_BASEDIR/puppet`). This
commit updates the leatherman config to use that environment variable
when determine where to install and load locale files.