### PR TITLE
(FACT-1624) Update Leatherman and Facter to include Ruby 2.4 fixes

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "14a8f4925922f09352167f03ab5d89c8062e7c4a"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "7ec7dc4e9bb6387e39f15e20e8e284820576c370"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "cdb5a694a38d25d68bf4b1ef7211061b42eeda8e"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "17829c2ac37eb391ab0d3a7262eebc614893b7ee"}


### PR DESCRIPTION
In order to support Ruby 2.4, leatherman removed references to Bignum
and Fixnum (see LTH-124) in favor of Integer, which necessitated
changes in Facter. Since this was an API break, these updates need
to be brought into PA together for validation, so this commit updates
both components simultaneously, instead of via the separate component
pipelines.