### PR TITLE
(maint) Update gettext-setup gem to 0.24

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.20"
-  pkg.md5sum "53bbb01f01e68fbfa9f2ff11c466e60b"
+  pkg.version "0.24"
+  pkg.md5sum "f766a5e12bbad9f85905638c500e08f6"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"


### PR DESCRIPTION
This version includes the `negotiate_locale!` method that we would like
to use in Puppet to detect the user's locale.