### PR TITLE
(PA-793) Correct PA package selection

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -4,7 +4,7 @@ test_name "Install Packages"
 
 step "Install puppet-agent..." do
   opts = {
-    :puppet_agent_version => ENV['SHA'],
+    :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA'],
     :default_action => 'gem_install'
   }
   agents.each do |agent|


### PR DESCRIPTION
Some platforms (e.g. osx, sles), use the SUITE_VERSION instead of SHA in
package name - update package_version to use this.

This is the Commit for Stable to match master