### PR TITLE
(PA-1124) Add Nano Server Ruby 2.4 patch

### DIFF
--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -107,6 +107,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_fixup_generated_batch_files.patch"
     pkg.apply_patch "#{base}/update_rbinstall_for_windows.patch"
+    pkg.apply_patch "#{base}/PA-1124_add_nano_server_com_support-8feb9779182bd4285f3881029fe850dac188c1ac.patch"
   end
 
 

--- a/resources/patches/ruby_241/PA-1124_add_nano_server_com_support-8feb9779182bd4285f3881029fe850dac188c1ac.patch
+++ b/resources/patches/ruby_241/PA-1124_add_nano_server_com_support-8feb9779182bd4285f3881029fe850dac188c1ac.patch
@@ -1,0 +1,94 @@
+commit e37ab5a673c9d121208d80a0a1128de346f46a19
+Author: suke <suke@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date:   Sat Feb 25 22:28:22 2017 +0000
+
+    ext/win32ole/win32ole.c(ole_initialize): avoid to fail in Windows nano server.
+    This is experimental. Thanks to mwrock, Ethan Brown.
+    
+    git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@57715 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+    
+    Original patch at 8feb9779182bd4285f3881029fe850dac188c1ac was errant
+    and included an additional line.
+    
+    This one has been updated to be correct
+
+diff --git a/ext/win32ole/win32ole.c b/ext/win32ole/win32ole.c
+index 9518e2f..41e70a2 100644
+--- a/ext/win32ole/win32ole.c
++++ b/ext/win32ole/win32ole.c
+@@ -50,6 +50,7 @@ static volatile DWORD g_ole_initialized_key = TLS_OUT_OF_INDEXES;
+ static BOOL g_uninitialize_hooked = FALSE;
+ static BOOL g_cp_installed = FALSE;
+ static BOOL g_lcid_installed = FALSE;
++static BOOL g_running_nano = FALSE;
+ static HINSTANCE ghhctrl = NULL;
+ static HINSTANCE gole32 = NULL;
+ static FNCOCREATEINSTANCEEX *gCoCreateInstanceEx = NULL;
+@@ -169,6 +170,7 @@ static VALUE fole_activex_initialize(VALUE self);
+ static void com_hash_free(void *ptr);
+ static void com_hash_mark(void *ptr);
+ static size_t com_hash_size(const void *ptr);
++static void check_nano_server(void);
+ 
+ static const rb_data_type_t ole_datatype = {
+     "win32ole",
+@@ -817,16 +819,22 @@ ole_initialize(void)
+     }
+ 
+     if(g_ole_initialized == FALSE) {
+-        hr = OleInitialize(NULL);
++        if(g_running_nano) {
++            hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
++        } else {
++            hr = OleInitialize(NULL);
++        }
+         if(FAILED(hr)) {
+             ole_raise(hr, rb_eRuntimeError, "fail: OLE initialize");
+         }
+         g_ole_initialized_set(TRUE);
+ 
+-        hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
+-        if(FAILED(hr)) {
+-            previous_filter = NULL;
+-            ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
++        if (g_running_nano == FALSE) {
++            hr = CoRegisterMessageFilter(&imessage_filter, &previous_filter);
++            if(FAILED(hr)) {
++                previous_filter = NULL;
++                ole_raise(hr, rb_eRuntimeError, "fail: install OLE MessageFilter");
++            }
+         }
+     }
+ }
+@@ -3891,11 +3899,31 @@ com_hash_size(const void *ptr)
+     return st_memsize(tbl);
+ }
+ 
++static void
++check_nano_server(void)
++{
++    HKEY hsubkey;
++    LONG err;
++    const char * subkey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Server\\ServerLevels";
++    const char * regval = "NanoServer";
++
++    err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &hsubkey);
++    if (err == ERROR_SUCCESS) {
++        err = RegQueryValueEx(hsubkey, regval, NULL, NULL, NULL, NULL);
++        if (err == ERROR_SUCCESS) {
++            g_running_nano = TRUE;
++        }
++        RegCloseKey(hsubkey);
++    }
++}
++
++
+ void
+ Init_win32ole(void)
+ {
+     cWIN32OLE_lcid = LOCALE_SYSTEM_DEFAULT;
+     g_ole_initialized_init();
++    check_nano_server();
+ 
+     com_vtbl.QueryInterface = QueryInterface;
+     com_vtbl.AddRef = AddRef;


### PR DESCRIPTION
 - This patch is from Ruby and has landed on their "trunk", but has
   not been added to the 2.4 source tree.  It's possible that it may
   not see the light of day until 2.5.

 - In earlier technical preview versions of Microsoft Nano Server,
   the COM internals were setup to allow calls to OleInitialize to
   succeed, despite it being unsupported on Nano Server, for the sake
   of vendors recompiling / testing their code with Nano.

   OleInitialize, according to MDSN documentation always calls
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED) per
   https://msdn.microsoft.com/en-us/library/windows/desktop/ms690134%28v=vs.85%29.aspx
   given OLE is not thread-safe.

   All COINIT values are specified at:
   https://msdn.microsoft.com/en-us/library/windows/desktop/ms678505

 - Ruby has traditionally initialized COM by calling OleInitialize,
   which is unsupported on Nano given only the MTA is supported on
   Nano. The solution is to instead call CoInitializeEx with
   COINIT_MULTITHREADED when initializing the COM subsystem.

   This necessarily means Nano won't support some OLE functions, but
   general purpose COM calls can still go through the WIN32OLE class
   in Ruby, as long as they conform to other rules with Nano and
   actually exist.

 - Should this functionality ever be ported to Ruby 2.4 this patch can
   be removed.

   See:

   Filed Ruby bug - https://bugs.ruby-lang.org/issues/12371
   MWrock PR for Chef patch - https://github.com/ruby/ruby/pull/1423
   Nobu commit to Ruby trunk -
   https://github.com/ruby/ruby/commit/8feb9779182bd4285f3881029fe850dac188c1ac