### PR TITLE
(PA-1139) Move Hiera config to puppet

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -30,12 +30,11 @@ component "hiera" do |pkg, settings, platform|
     --man \
     --mandir=#{settings[:mandir]} \
     --no-batch-files \
+    --no-configs \
     #{flags}"]
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec" unless platform.is_windows?
-
-  pkg.configfile File.join(configdir, 'hiera.yaml')
 
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?
 
@@ -45,6 +44,4 @@ component "hiera" do |pkg, settings, platform|
     pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'hieradata')
   end
 
-  pkg.add_preinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml')} ]; then cp #{File.join(settings[:puppet_codedir], 'hiera.yaml')} #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')}; fi"]
-  pkg.add_postinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} ]; then mv #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} #{File.join(settings[:puppet_codedir], 'hiera.yaml')}; fi"]
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -236,4 +236,9 @@ component "puppet" do |pkg, settings, platform|
   if platform.is_eos?
     pkg.link "#{settings[:sysconfdir]}", "#{settings[:link_sysconfdir]}"
   end
+
+  pkg.configfile File.join(configdir, 'hiera.yaml')
+  pkg.add_preinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml')} ]; then cp #{File.join(settings[:puppet_codedir], 'hiera.yaml')} #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')}; fi"]
+  pkg.add_postinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} ]; then mv #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} #{File.join(settings[:puppet_codedir], 'hiera.yaml')}; fi"]
+
 end


### PR DESCRIPTION
*tentative - working on this*
Hiera now lives in puppet, so hiera.yaml is pulled in from the puppet
component/repo instead of hiera.