### PR TITLE
(PA-1128) Switch to building with Ruby 2.4.1

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -91,8 +91,8 @@ project "puppet-agent" do |proj|
     proj.setting(:libdir, File.join(proj.prefix, "lib"))
   end
 
-  proj.setting(:ruby_version, "2.3.3")
-  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.3.0"))
+  proj.setting(:ruby_version, "2.4.1")
+  proj.setting(:gem_home, File.join(proj.libdir, "ruby", "gems", "2.4.0"))
   proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))
 
   # Cross-compiled Linux platforms


### PR DESCRIPTION
The config files for Ruby 2.4.1 were adding in a previous commit. This
commit switches to building and using Ruby 2.4.