### PR TITLE
(PA-1139) Move Hiera config to puppet

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -30,21 +30,12 @@ component "hiera" do |pkg, settings, platform|
     --man \
     --mandir=#{settings[:mandir]} \
     --no-batch-files \
+    --no-configs \
     #{flags}"]
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec" unless platform.is_windows?
 
-  pkg.configfile File.join(configdir, 'hiera.yaml')
-
   pkg.link "#{settings[:bindir]}/hiera", "#{settings[:link_bindir]}/hiera" unless platform.is_windows?
 
-  if platform.is_windows?
-    pkg.directory File.join(settings[:puppet_codedir], 'hieradata')
-  else
-    pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'hieradata')
-  end
-
-  pkg.add_preinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml')} ]; then cp #{File.join(settings[:puppet_codedir], 'hiera.yaml')} #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')}; fi"]
-  pkg.add_postinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} ]; then mv #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} #{File.join(settings[:puppet_codedir], 'hiera.yaml')}; fi"]
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -198,6 +198,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'manifests')
   pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'modules')
+  pkg.directory File.join(settings[:puppet_codedir], 'environments', 'production', 'data')
   pkg.install_configfile 'conf/environment.conf', File.join(settings[:puppet_codedir], 'environments', 'production', 'environment.conf')
 
   if platform.is_windows?
@@ -211,4 +212,9 @@ component "puppet" do |pkg, settings, platform|
   if platform.is_eos?
     pkg.link "#{settings[:sysconfdir]}", "#{settings[:link_sysconfdir]}"
   end
+
+  pkg.install_file "ext/hiera/hiera.yaml", File.join(settings[:puppet_codedir], 'environments', 'production', 'hiera.yaml')
+  pkg.configfile File.join(settings[:puppet_codedir], 'environments', 'production', 'hiera.yaml')
+  pkg.configfile File.join(configdir, 'hiera.yaml')
+
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -217,4 +217,8 @@ component "puppet" do |pkg, settings, platform|
   pkg.configfile File.join(settings[:puppet_codedir], 'environments', 'production', 'hiera.yaml')
   pkg.configfile File.join(configdir, 'hiera.yaml')
 
+  # This is a copy of the code from hiera.rb to make a backup of an existing hiera.yaml file in :puppet_codedir (even though the new file(s) aren't put there).
+  # A new ticket https://tickets.puppetlabs.com/browse/PA-1169 has been raised to address upgrade handling of hiera.yaml, so this will be dealt with in that ticket.
+  pkg.add_preinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml')} ]; then cp #{File.join(settings[:puppet_codedir], 'hiera.yaml')} #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')}; fi"]
+  pkg.add_postinstall_action ["upgrade"], ["if [ -e #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} ]; then mv #{File.join(settings[:puppet_codedir], 'hiera.yaml.pkg-old')} #{File.join(settings[:puppet_codedir], 'hiera.yaml')}; fi"]
 end

--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -37,12 +37,12 @@
             <Directory Id="FactsDotD" Name="facts.d"/>
           </Directory>
           <Directory Id="CodeDir" Name="code">
-            <Directory Id="HieraDataDir" Name="hieradata"/>
             <Directory Id="CodeModulesDir" Name="modules"/>
             <Directory Id="EnvironmentsDir" Name="environments">
               <Directory Id="ProductionDir" Name="production">
                 <Directory Id="ManifestsDir" Name="manifests"/>
                 <Directory Id="ModulesDir" Name="modules"/>
+                <Directory Id="Hiera5DataDir" Name="data"/>
               </Directory>
             </Directory>
           </Directory>
@@ -82,13 +82,9 @@
       <Component
         Id="PuppetConfUnconditionalSettings"
         Permanent="yes"
-        Guid="B9179A60-483F-4F32-8E3F-AD632B0DEBB4"
+        Guid="6753F049-CA11-43E2-854E-B467026F9A2F"
         Directory="PuppetConfDir">
         <CreateFolder />
-        <File
-          Id="HieraConf"
-          KeyPath="yes"
-          Source="SourceDir\CommonAppDataFolder\Puppetlabs\puppet\etc\hiera.yaml" />
         <IniFile
           Id="PuppetConfServer" Name="puppet.conf"
           Action="addLine"
@@ -159,6 +155,28 @@
           Directory="PuppetConfDir" />
       </Component>
       <Component
+        Id="PuppetConfHiera"
+        Permanent="yes"
+        Guid="998A7670-BF42-4F03-B144-4528EADD0CE3"
+        Directory="PuppetConfDir">
+        <CreateFolder />
+        <File
+          Id="HieraConf"
+          KeyPath="yes"
+          Source="SourceDir\CommonAppDataFolder\Puppetlabs\puppet\etc\hiera.yaml" />
+      </Component>
+      <Component
+        Id="PuppetProductionHiera"
+        Permanent="yes"
+        Guid="8384543A-F693-45B3-92E3-E0CB879A78E0"
+        Directory="ProductionDir">
+        <CreateFolder />
+        <File
+          Id="HieraProductionConf"
+          KeyPath="yes"
+          Source="SourceDir\CommonAppDataFolder\Puppetlabs\code\environments\production\hiera.yaml" />
+      </Component>
+      <Component
         Id="PuppetVarDir"
         Permanent="yes"
         Guid="B95A17F3-CF5E-4EC7-859E-F10C0965645F"
@@ -197,10 +215,10 @@
         <CreateFolder />
       </Component>
       <Component
-        Id="HieraDataDir"
+        Id="Hiera5DataDir"
         Permanent="yes"
         Guid="2438387C-BEA5-47C1-8B43-46FE30E14BEA"
-        Directory="HieraDataDir">
+        Directory="Hiera5DataDir">
         <CreateFolder />
       </Component>
       <Component


### PR DESCRIPTION
Hiera now lives in puppet, so hiera.yaml is pulled in from the puppet
component/repo instead of hiera.

This is #1058 retargeted at ```stable```