### PR TITLE
(maint) Cherry-pick server installation changes

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -171,17 +171,6 @@ def set_environment_variables_for_install(install_released_packages)
   ENV['SERVER_DOWNLOAD_URL'] ||= DEFAULT_NIGHTLIES_DOWNLOAD_URL
   ENV['SERVER_VERSION'] ||= 'latest'
 
-  # We can only use a SHAs of "latest" if we're downloading from nightlies, as
-  # our other options, such as 'builds.delivery.puppetlabs.net', do not have
-  # "latest" directories.
-  if ENV['SHA'] == 'latest' and ENV['AGENT_DOWNLOAD_URL'] != DEFAULT_NIGHTLIES_DOWNLOAD_URL
-    fail "Can only use ENV['SHA'] == 'latest' if ENV['AGENT_DOWNLOAD_URL'] == '#{DEFAULT_NIGHTLIES_DOWNLOAD_URL}'"
-  end
-
-  if ENV['SERVER_VERSION'] == 'latest' and ENV['SERVER_DOWNLOAD_URL'] != DEFAULT_NIGHTLIES_DOWNLOAD_URL
-    fail "Can only use ENV['SERVER_VERSION'] == 'latest' if ENV['SERVER_DOWNLOAD_URL'] == '#{DEFAULT_NIGHTLIES_DOWNLOAD_URL}'"
-  end
-
   # If this is a test of public / final release packages,
   # TESTING_RELEASED_PACKAGES is a string value we use to tell the
   # puppet agent pre-suite that we're testing public release packages, not dev

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -33,7 +33,14 @@ step "Install puppetserver..." do
   else
     # the dev repos have only a single package, so we need one for both server
     # and agent to satisfy server's dep on agent
-    install_puppetlabs_dev_repo(master, 'puppetserver', ENV['SERVER_VERSION'], nil, :dev_builds_url => ENV['SERVER_DOWNLOAD_URL'])
+    if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
+      server_version = 'latest'
+      server_download_url = "http://nightlies.puppet.com"
+    else
+      server_version = ENV['SERVER_VERSION']
+      server_download_url = "http://builds.delivery.puppetlabs.net"
+    end
+    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
     install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'], nil, :dev_builds_url => ENV['AGENT_DOWNLOAD_URL'])
   end
   master.install_package('puppetserver')


### PR DESCRIPTION
Cherry-pick 5988b05ffeb1fa01ba318da9197640e3250df84f and a4c2a3f0ec77a1e64cf208beb69c85ba7bfc8897 from master to pick up acceptance suite changes to download puppetserver from nightlies if requested