### PR TITLE
(maint) Update rbconfigs to have correct teeny version

### DIFF
--- a/resources/files/ruby_241/rbconfig/rbconfig-arm-linux-gnueabihf.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-arm-linux-gnueabihf.rb
@@ -11,8 +11,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-i386-pc-solaris2.10.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-i386-pc-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-i386-pc-solaris2.11.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-i386-pc-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/ccs/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix5.3.0.0.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix5.3.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix6.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc-ibm-aix7.1.0.0.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = ''
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc-linux-gnu.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc-linux-gnu.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc64le-linux-gnu.rb
@@ -11,8 +11,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-ppc64le-redhat-linux.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-ppc64le-redhat-linux.rb
@@ -11,8 +11,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-s390x-linux-gnu.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-s390x-linux-gnu.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-sparc-sun-solaris2.10.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/opt/csw/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")

--- a/resources/files/ruby_241/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-sparc-sun-solaris2.11.rb
@@ -12,8 +12,8 @@ module RbConfig
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
   CONFIG["MINOR"] = "4"
-  CONFIG["TEENY"] = "0"
-  CONFIG["PATCHLEVEL"] = "112"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
   CONFIG["INSTALL"] = '/usr/bin/ginstall -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")


### PR DESCRIPTION
Ruby 2.4 expects the TEENY field in the rbconfig to be the minor version
of the Ruby installed, not 0. This updates our custom configs to set the
TEENY version to 1 accordingly.