### PR TITLE
(PA-783) Localise Administrators and Everyone ids

### DIFF
--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -10,6 +10,7 @@
     Permanent="yes" on each file/folder component.
   -->
   <Fragment>
+
     <DirectoryRef Id="TARGETDIR">
       <Directory Id="CommonAppDataFolder" Name="CommonAppData">
         <Directory Id="APPDATADIR" Name="PuppetLabs">
@@ -185,8 +186,8 @@
         Guid="4E7C234B-2837-4459-A20E-9503A922FCB9"
         Directory="FactsDotD">
         <CreateFolder>
-          <Permission GenericAll="yes" User="Administrators" />
-          <Permission GenericRead="yes" GenericExecute="yes" User="Everyone" />
+          <Permission GenericAll="yes" User="[PUP_LCL_ACCOUNT_ADMINISTRATORS]" />
+          <Permission GenericRead="yes" GenericExecute="yes" User="[PUP_LCL_ACCOUNT_EVERYONE]" />
         </CreateFolder>
       </Component>
       <Component

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -50,6 +50,29 @@ End If
       ]]>
     </CustomAction>
 
+    <!-- Custom action to get the localised name for the "Everyone" (or World) user as
+         WixUtil:OSInfo Custom action doesn't return this value.
+         Equivalent of     (Get-WmiObject Win32_Account | where { $_.SID -eq "S-1-1-0" }).name
+      -->
+    <CustomAction
+      Id="GetLocalisedAccountNames"
+      Script="vbscript"
+      Execute="firstSequence"
+      Return="check">
+        <![CDATA[
+      On Error Resume Next
+      Dim ojbLocator:  set objLocator = CreateObject("WbemScripting.SWbemLocator")
+      Dim objWMI:      set objWMI = objLocator.ConnectServer(".", "root/cimv2")
+      Dim sidEveryone: sidEveryone = "S-1-1-0"
+      Dim sidAdmins:   sidAdmins   = "S-1-5-32-544"
+      Dim objSIDEveryone: set objSIDEveryone = objWMI.Get("Win32_SID='" & sidEveryone & "'")
+      Dim objSIDAdmins:   set objSIDAdmins = objWMI.Get("Win32_SID='" & sidAdmins & "'")
+      Session.Property("PUP_LCL_ACCOUNT_EVERYONE") = objSIDEveryone.AccountName
+      Session.Property("PUP_LCL_ACCOUNT_ADMINISTRATORS") = objSIDAdmins.AccountName
+        ]]>
+    </CustomAction>
+
+
     <!-- Custom Actions to handle command line property values that override
          remembered property values -->
     <!-- INSTALLDIR -->

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -14,6 +14,7 @@
         CMDLINE_INSTALLDIR
       </Custom>
       <Custom Action='SetIniPropertyValues' After='AppSearch' />
+      <Custom Action='GetLocalisedAccountNames' After='AppSearch' />
       <!-- PUPPET_MASTER_SERVER -->
       <Custom Action='SetFromIniPuppetMasterServer' Before='FileCost'>
         INI_PUPPET_MASTER_SERVER

--- a/resources/windows/wix/users.wxs.erb
+++ b/resources/windows/wix/users.wxs.erb
@@ -10,8 +10,8 @@
       logon as a service and add the account to the local Administrators
       account. If the account doesn't exist, the install will fail.
     -->
-    <util:Group Id="AdminGroup" Name="Administrators"/>
-    
+    <util:Group Id="AdminGroup" Name="[PUP_LCL_ACCOUNT_ADMINISTRATORS]"/>
+
     <Component
       Id="PuppetServiceUser"
       Guid="0CCA1CDC-CD25-43A5-BE8A-0D455C63D1BE"


### PR DESCRIPTION
Localise the "Administrators" Group and "Everyone" User id using the
Wix OSInfo service and a custom action, so that file permissions and
user group associations are correct in a localised (e.g. German/Chinese)
environment.