### PR TITLE
(PA-1166) Create mcollective log directory

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -109,6 +109,8 @@ component "marionette-collective" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.directory File.join(settings[:sysconfdir], 'mcollective', 'var', 'log')
+  else
+    pkg.directory File.join(settings[:logdir], 'mcollective'), mode: "0750"
   end
 
   # Bring in the client.cfg and server.cfg from ext/aio.


### PR DESCRIPTION
MCO-783 moved the default *nix mcollective log location from /var/log to
/var/log/mcollective. That directory is not guaranteed to exist, and
mcollective will fail rather than try to create it if it's absent.
Ensure the directory exists via packaging.