### PR TITLE
(PA-1168) Patch STOMP to detect failed connections and reconnect

### DIFF
--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -23,6 +23,7 @@ component "ruby-stomp" do |pkg, settings, platform|
 
   base = 'resources/patches/ruby-stomp'
   pkg.apply_patch "#{base}/verify_client_certs.patch", destination: "#{settings[:gem_home]}/gems/stomp-#{pkg.get_version}", after: "install"
+  pkg.apply_patch "#{base}/connection_loss_reconnect_fix.patch", destination: "#{settings[:gem_home]}/gems/stomp-#{pkg.get_version}", after: "install"
 
   pkg.install do
     ["#{settings[:gem_install]} stomp-#{pkg.get_version}.gem"]

--- a/resources/patches/ruby-stomp/connection_loss_reconnect_fix.patch
+++ b/resources/patches/ruby-stomp/connection_loss_reconnect_fix.patch
@@ -1,0 +1,125 @@
+From ed5da4d1d857c427bf995e50c9baa25befaa3175 Mon Sep 17 00:00:00 2001
+From: Reid Vandewiele <reid@puppetlabs.com>
+Date: Thu, 1 Jun 2017 16:22:08 -0700
+Subject: [PATCH] Ensure IO#gets exits in a reasonable time
+
+According to the notes on heartbeats, `max_hbrlck_fails` should be
+enabled in order to determine when heartbeats stop arriving. This is
+required because the receive thread of the MCO daemon spends most of its
+time waiting for something to come in over the wire. That ties up the
+"read lock" used to provide exclusive access to the underlying network
+socket.
+
+However, the blocking receive should consume heartbeats and update the
+"last received" timestamp (`@lr`). The heartbeat read thread also
+consumes pings coming in over the wire in case the process is not
+blocking on receive.
+
+Normal operation means that a missed hbrlck is normal, but two in a row
+should be abnormal (the heartbeat thread may try to read and get locked,
+but the receive thread should read the heartbeat before the heartbeat
+thread resumes - networking timing could impact this in bad ways - and
+reset the "last received" timestamp which will trigger resetting the
+`read_lock_count` and `lock_fail_count` the next time the heartbeat
+thread wakes).
+
+When the `lock_fail_count` exceeds `@max_hbrlck_fails`, the heartbeat
+thread closes the socket and kills the heartbeat threads. The
+expectation is that this should cause the `IO#gets` call in the receive
+call to return. That doesn't happen until TCP timeouts occur, which can
+take minutes or hours. When the TCP timeout occurs, it appears to leave
+the main thread in an unexpected state that sometimes results in SIGABRT
+and is unreachable via the broker.
+
+To exit `gets` early, trigger an exception in the `receive` thread.
+That interrupts the `gets` call and is caught in the `transmit` or
+`__old_receive` method and initiates a reconnect.
+---
+ lib/connection/heartbeats.rb |  6 +++---
+ lib/connection/netio.rb      | 19 +++++++++++++++----
+ lib/stomp/connection.rb      |  1 +
+ 3 files changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/lib/connection/heartbeats.rb b/lib/connection/heartbeats.rb
+index ae350dd..dc0cb15 100644
+--- a/lib/connection/heartbeats.rb
++++ b/lib/connection/heartbeats.rb
+@@ -232,9 +232,9 @@ module Stomp
+             # Retry on max lock fails.  Different logic in order to avoid a deadlock.
+             if (@max_hbrlck_fails > 0 && lock_fail_count >= @max_hbrlck_fails)
+               # This is an attempt at a connection retry.
+-              begin
+-                @socket.close # Attempt a forced close
+-              rescue
++              @gets_semaphore.synchronize do
++                @getst.raise(Errno::EBADF.new) if @getst rescue nil # kill the socket reading thread if exists
++                @socket.close rescue nil # Attempt a forced close
+               end
+               @st.kill if @st   # Kill the sender thread if one exists
+               Thread.exit       # This receiver thread is done            
+diff --git a/lib/connection/netio.rb b/lib/connection/netio.rb
+index f9e84be..d0e2d2f 100644
+--- a/lib/connection/netio.rb
++++ b/lib/connection/netio.rb
+@@ -11,6 +11,17 @@ module Stomp
+ 
+     private
+ 
++    def _interruptible_gets(read_socket)
++      # The gets thread may be interrupted by the heartbeat thread. Ensure that
++      # if so interrupted, a new gets cannot start until after the heartbeat
++      # thread finishes its work. This is PURELY to avoid a segfault bug
++      # involving OpenSSL::Buffer.
++      @gets_semaphore.synchronize { @getst = Thread.current }
++      read_socket.gets
++    ensure
++      @gets_semaphore.synchronize { @getst = nil }
++    end
++
+     # Really read from the wire.
+     def _receive(read_socket, connread = false)
+       @read_semaphore.synchronize do
+@@ -40,7 +51,7 @@ module Stomp
+           message_header = ''
+           begin
+             message_header += line
+-            line = read_socket.gets
++            line = _interruptible_gets(read_socket)
+             # p [ "wiredatain_02", line ]
+             raise Stomp::Error::StompServerError if line.nil?
+             line = _normalize_line_end(line) if @protocol >= Stomp::SPL_12
+@@ -382,16 +393,16 @@ module Stomp
+           if @jruby
+             # Handle JRuby specific behavior.
+             while true
+-              line = read_socket.gets # Data from wire
++              line = _interruptible_gets(read_socket) # Data from wire
+               break unless line == "\n"
+               line = ''
+             end
+           else
+-            line = read_socket.gets # The old way
++            line = _interruptible_gets(read_socket) # The old way
+           end
+         else # We are >= 1.1 *AND* receiving heartbeats.
+           while true
+-            line = read_socket.gets # Data from wire
++            line = _interruptible_gets(read_socket) # Data from wire
+             break unless line == "\n"
+             line = ''
+             @lr = Time.now.to_f
+diff --git a/lib/stomp/connection.rb b/lib/stomp/connection.rb
+index bd690f0..729fc95 100644
+--- a/lib/stomp/connection.rb
++++ b/lib/stomp/connection.rb
+@@ -135,6 +135,7 @@ module Stomp
+       @transmit_semaphore = Mutex.new
+       @read_semaphore = Mutex.new
+       @socket_semaphore = Mutex.new
++      @gets_semaphore = Mutex.new
+ 
+       @subscriptions = {}
+       @failure = nil
+-- 
+2.13.1
+


### PR DESCRIPTION
Previously failed connections would take minutes or hours to detect,
then leave MCO in an unusable state. Patch STOMP to handle failed
connections as soon as the timeout limits are reached and reconnect
cleanly.

The specific problem is an issue with Ruby/OpenSSL interaction, where
it's not thread-safe to close a socket while reading from it (which is
precisely what the Stomp gem does). A simple reproduction of that issue
can be found at https://gist.github.com/richardc/b5a1d4d28c8bbae24cd5.