### PR TITLE
(PA-1117) Update libxstl with patches

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -5,6 +5,9 @@ component "libxslt" do |pkg, settings, platform|
 
   pkg.build_requires "libxml2"
 
+  pkg.apply_patch 'resources/patches/libxslt/fix-heap-overread.patch'
+  pkg.apply_patch 'resources/patches/libxslt/check-for-integer-overflow.patch'
+
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -5,9 +5,9 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     # including its dependencies (mini_portile2), installing it on the target, and
     # installing the nokogiri gem using our gem command. The added files from
     # :gem_home were then tar'ed up and packed into this container tarball.
-    pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-precompiled-huaweios-#{pkg.get_version}-for-ruby-#{settings[:ruby_version]}.tar.gz"
+    pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-precompiled-huaweios-#{pkg.get_version}-patch1-for-ruby-#{settings[:ruby_version]}.tar.gz"
     if settings[:ruby_version] == "2.1.9"
-      pkg.md5sum "4bf7a53bbfa5593041f7698f4e56a8d1"
+      pkg.md5sum "016db16f78d9e6d0c3ead89093e610a2"
     elsif settings[:ruby_version] == "2.3.1"
       pkg.md5sum "d11bcd650dc4942aa198586f4ff04247"
     end

--- a/resources/patches/libxslt/check-for-integer-overflow.patch
+++ b/resources/patches/libxslt/check-for-integer-overflow.patch
@@ -1,0 +1,64 @@
+## FROM https://git.gnome.org/browse/libxslt/commit/?id=08ab2774b870de1c7b5a48693df75e8154addae5
+##
+## Limit buffer size in xsltAddTextString to INT_MAX. The issue can be
+## exploited to trigger an out of bounds write on 64-bit systems.
+##
+## Originally reported to Chromium:
+##
+## https://crbug.com/676623
+
+diff --git a/libxslt/transform.c b/libxslt/transform.c
+index 519133f..02bff34 100644
+--- a/libxslt/transform.c
++++ b/libxslt/transform.c
+@@ -813,13 +813,32 @@ xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
+         return(target);
+
+     if (ctxt->lasttext == target->content) {
++        int minSize;
+
+-	if (ctxt->lasttuse + len >= ctxt->lasttsize) {
++        /* Check for integer overflow accounting for NUL terminator. */
++        if (len >= INT_MAX - ctxt->lasttuse) {
++            xsltTransformError(ctxt, NULL, target,
++                "xsltCopyText: text allocation failed\n");
++            return(NULL);
++        }
++        minSize = ctxt->lasttuse + len + 1;
++
++        if (ctxt->lasttsize < minSize) {
+ 	    xmlChar *newbuf;
+ 	    int size;
++            int extra;
++
++            /* Double buffer size but increase by at least 100 bytes. */
++            extra = minSize < 100 ? 100 : minSize;
++
++            /* Check for integer overflow. */
++            if (extra > INT_MAX - ctxt->lasttsize) {
++                size = INT_MAX;
++            }
++            else {
++                size = ctxt->lasttsize + extra;
++            }
+
+-	    size = ctxt->lasttsize + len + 100;
+-	    size *= 2;
+ 	    newbuf = (xmlChar *) xmlRealloc(target->content,size);
+ 	    if (newbuf == NULL) {
+ 		xsltTransformError(ctxt, NULL, target,
+diff --git a/libxslt/xsltInternals.h b/libxslt/xsltInternals.h
+index 060b178..5ad1771 100644
+--- a/libxslt/xsltInternals.h
++++ b/libxslt/xsltInternals.h
+@@ -1754,8 +1754,8 @@ struct _xsltTransformContext {
+      * Speed optimization when coalescing text nodes
+      */
+     const xmlChar  *lasttext;		/* last text node content */
+-    unsigned int    lasttsize;		/* last text node size */
+-    unsigned int    lasttuse;		/* last text node use */
++    int             lasttsize;		/* last text node size */
++    int             lasttuse;		/* last text node use */
+     /*
+      * Per Context Debugging
+      */

--- a/resources/patches/libxslt/fix-heap-overread.patch
+++ b/resources/patches/libxslt/fix-heap-overread.patch
@@ -1,0 +1,22 @@
+## FROM https://git.gnome.org/browse/libxslt/commit/?id=eb1030de31165b68487f288308f9d1810fed6880
+##
+## An empty decimal-separator could cause a heap overread. This can be
+## exploited to leak a couple of bytes after the buffer that holds the
+## pattern string.
+##
+## Found with afl-fuzz and ASan.
+
+diff --git a/libxslt/numbers.c b/libxslt/numbers.c
+index d1549b4..e78c46b 100644
+--- a/libxslt/numbers.c
++++ b/libxslt/numbers.c
+@@ -1090,7 +1090,8 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
+     }
+
+     /* We have finished the integer part, now work on fraction */
+-    if (xsltUTF8Charcmp(the_format, self->decimalPoint) == 0) {
++    if ( (*the_format != 0) &&
++         (xsltUTF8Charcmp(the_format, self->decimalPoint) == 0) ) {
+         format_info.add_decimal = TRUE;
+ 	the_format += xsltUTF8Size(the_format);	/* Skip over the decimal */
+     }


### PR DESCRIPTION
We need to patch libxslt with patches from upstream:
https://git.gnome.org/browse/libxslt/commit/?id=08ab2774b870de1c7b5a48693df75e8154addae5
https://git.gnome.org/browse/libxslt/commit/?id=eb1030de31165b68487f288308f9d1810fed6880

Nokogiri tarballs have been updated with the vendored libxslt changes.
tarballs for nokogiri have been updated with the addition of {version}-patch1
to the name so we don't have to overwrite the old tarballs

**Note** This PR does not contain updates to any nokogiri tarballs for other versions of ruby. Those will come in a separate PR.
