### PR TITLE
(PA-892) Add nats-pure gem to embedded library set

### DIFF
--- a/configs/components/rubygem-nats-pure.rb
+++ b/configs/components/rubygem-nats-pure.rb
@@ -1,0 +1,13 @@
+component "rubygem-nats-pure" do |pkg, settings, platform|
+  pkg.version "0.2.4"
+  pkg.md5sum "209d12d8a9b6be556e2748b0a243eb5d"
+  pkg.url "https://rubygems.org/downloads/nats-pure-#{pkg.get_version}.gem"
+
+  pkg.build_requires "ruby-#{settings[:ruby_version]}"
+  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+
+  pkg.install do
+    ["#{settings[:gem_install]} nats-pure-#{pkg.get_version}.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -229,6 +229,7 @@ project "puppet-agent" do |proj|
   proj.component "rubygem-gettext"
   proj.component "rubygem-fast_gettext"
   proj.component "rubygem-gettext-setup"
+  proj.component "rubygem-nats-pure"
   if platform.is_windows?
     proj.component "rubygem-ffi"
     proj.component "rubygem-win32-dir"


### PR DESCRIPTION
This commit adds the 'nats-pure' rubygem (a dependency for
http://choria.io/) to Puppet Agent's embedded library set.