### PR TITLE
(PA-1189) Add GetLocalisedAccountNames to ex Seq

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -57,7 +57,7 @@ End If
     <CustomAction
       Id="GetLocalisedAccountNames"
       Script="vbscript"
-      Execute="firstSequence"
+      Execute="immediate"
       Return="check">
         <![CDATA[
       On Error Resume Next

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -14,7 +14,6 @@
         CMDLINE_INSTALLDIR
       </Custom>
       <Custom Action='SetIniPropertyValues' After='AppSearch' />
-      <Custom Action='GetLocalisedAccountNames' After='AppSearch' />
       <!-- PUPPET_MASTER_SERVER -->
       <Custom Action='SetFromIniPuppetMasterServer' Before='FileCost'>
         INI_PUPPET_MASTER_SERVER
@@ -69,6 +68,7 @@
 
     <InstallExecuteSequence>
       <Custom Action='SetIniPropertyValues' After='AppSearch' />
+      <Custom Action='GetLocalisedAccountNames' After='AppSearch' />
       <!-- INSTALLDIR -->
       <Custom Action='SaveCmdLineInstallDir' Before='AppSearch' />
       <Custom Action='SetFromCmdLineInstallDir' After='AppSearch'>


### PR DESCRIPTION
Ensure that this Custom Action is regardless of whether UI is used, i.e.
runs in execute sequence if it hasn't already run in the UI sequence.

Otherwise the properties for localised Admin/Everyone aren't set during
unattended installs causing incorrect permission on the facts.d
directory.