### PR TITLE
(maint) Use exec in command wrapper scripts

### DIFF
--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -8,4 +8,4 @@ COMMAND=`basename "${0}"`
 BIN_PATH=`dirname "${0}"`
 INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"

--- a/resources/files/osx-wrapper.sh
+++ b/resources/files/osx-wrapper.sh
@@ -7,4 +7,4 @@ COMMAND=`basename "${0}"`
 BIN_PATH=`dirname "${0}"`
 INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -7,4 +7,4 @@ COMMAND=`basename "${0}"`
 BIN_PATH=`dirname "${0}"`
 INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"


### PR DESCRIPTION
Without using exec, the shell process for the wrapper script
will just hang around. Using exec replaces the shell process,
saving a bit of memory and cleaning up `ps` output.