### PR TITLE
(maint) Hardcode /opt/puppetlabs in command wrapper scripts

### DIFF
--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -5,7 +5,5 @@ unset LDR_PRELOAD
 unset LDR_PRELOAD64
 
 COMMAND=`basename "${0}"`
-BIN_PATH=`dirname "${0}"`
-INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"

--- a/resources/files/osx-wrapper.sh
+++ b/resources/files/osx-wrapper.sh
@@ -4,7 +4,5 @@ unset DYLD_LIBRARY_PATH
 unset DYLD_INSERT_LIBRARIES
 
 COMMAND=`basename "${0}"`
-BIN_PATH=`dirname "${0}"`
-INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -4,7 +4,5 @@ unset LD_LIBRARY_PATH
 unset LD_PRELOAD
 
 COMMAND=`basename "${0}"`
-BIN_PATH=`dirname "${0}"`
-INSTALL_PATH=`dirname "${BIN_PATH}"`
 
-exec ${INSTALL_PATH}/puppet/bin/${COMMAND} "$@"
+exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"


### PR DESCRIPTION
Previously, the wrapper scripts tried to calculate where they
were based on $0. Unfortuntely, executing them via a symlink
in an arbitrary path would break this heuristic. Since
we have no plans to change our paths any time soon, this hardcoding
is better than adding even more complex logic to try to track
down the path of the agent.