### PR TITLE
(maint) Set facter and pxp-agent SHA to release branch HEADs

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "6d9d8ffd4840dca376b4247c6ebacd8622b14284"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "cac039f1e4eddc90a69e3979973021cf8780a78c"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "229a84bffeb61f988ec880f83934e25ca31ebda6"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "e61ff1ec7e2f66efaa3fb692f8f8f4244b7d3c17"}


### PR DESCRIPTION
An additional commit had landed on Facter and pxp-agent beyond what
should go out for the 5.0.0 release. This commit sets those component
SHAs to the correct branching point for the release.