### PR TITLE
(PA-1251) Call puppet agent directly in AIX service

### DIFF
--- a/resources/aix/puppet.service
+++ b/resources/aix/puppet.service
@@ -1,1 +1,1 @@
-/opt/puppetlabs/puppet/bin/ruby -s puppet -u root -a '/opt/puppetlabs/bin/puppet agent --no-daemonize'
+/opt/puppetlabs/bin/puppet -s puppet -u root -a 'agent --no-daemonize'


### PR DESCRIPTION
Previously, the puppet-agent invocation in our service was
calling Ruby, with the path to puppet passed as the script.
Since PA-437, this no longer works, since the path to puppet
is a shell script now, not a ruby file.

There's no good reason for us to be calling puppet indirectly
this way, so we should instead simplify the service config.