### PR TITLE
(PA-1254) Remove huaweios from foss_platforms

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -20,7 +20,6 @@ foss_platforms:
   - fedora-f24-x86_64
   - fedora-f25-i386
   - fedora-f25-x86_64
-  - huaweios-6-powerpc
   - osx-10.10-x86_64
   - osx-10.11-x86_64
   - osx-10.12-x86_64


### PR DESCRIPTION
HuaweiOS is only being supported in our LTS series of puppet-agent.