### PR TITLE
(PA-1274) Fix deprecation warnings from the vanagon upgrade

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -73,7 +73,7 @@ component 'augeas' do |pkg, settings, platform|
       pkg.environment "PKG_CONFIG_PATH" => "/usr/lib/pkgconfig"
       pkg.environment "PKG_CONFIG" => "/opt/pl-build-tools/bin/pkg-config"
     end
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     pkg.environment "PATH" => "$$PATH:/usr/local/bin"
     pkg.environment "CFLAGS" => settings[:cflags]
   end

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -11,14 +11,14 @@ component 'augeas' do |pkg, settings, platform|
   pkg.build_requires "libxml2"
 
   # Ensure we're building against our own libraries when present
-  pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
+  pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => "-I/opt/puppetlabs/puppet/include/"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", "-I/opt/puppetlabs/puppet/include/"
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
   end
@@ -35,47 +35,47 @@ component 'augeas' do |pkg, settings, platform|
 
     if platform.architecture =~ /ppc64le|s390x/
       pkg.build_requires 'runtime'
-      pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-      pkg.environment "CFLAGS" => settings[:cflags]
-      pkg.environment "LDFLAGS" => settings[:ldflags]
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+      pkg.environment "CFLAGS", settings[:cflags]
+      pkg.environment "LDFLAGS", settings[:ldflags]
     end
   elsif platform.is_huaweios?
     pkg.build_requires 'runtime'
     pkg.build_requires 'pl-pkg-config'
 
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "PKG_CONFIG" => "/opt/pl-build-tools/bin/pkg-config"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "PKG_CONFIG", "/opt/pl-build-tools/bin/pkg-config"
   elsif platform.is_deb?
     pkg.build_requires 'libreadline-dev'
     pkg.requires 'libreadline6'
 
     pkg.build_requires 'pkg-config'
     if platform.is_cross_compiled_linux?
-      pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-      pkg.environment "CFLAGS" => settings[:cflags]
-      pkg.environment "LDFLAGS" => settings[:ldflags]
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+      pkg.environment "CFLAGS", settings[:cflags]
+      pkg.environment "LDFLAGS", settings[:ldflags]
     end
 
   elsif platform.is_solaris?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
     if platform.os_version == "10"
       pkg.build_requires 'pkgconfig'
-      pkg.environment "PKG_CONFIG_PATH" => "/opt/csw/lib/pkgconfig"
-      pkg.environment "PKG_CONFIG" => "/opt/csw/bin/pkg-config"
+      pkg.environment "PKG_CONFIG_PATH", "/opt/csw/lib/pkgconfig"
+      pkg.environment "PKG_CONFIG", "/opt/csw/bin/pkg-config"
     else
       pkg.build_requires 'pl-pkg-config'
-      pkg.environment "PKG_CONFIG_PATH" => "/usr/lib/pkgconfig"
-      pkg.environment "PKG_CONFIG" => "/opt/pl-build-tools/bin/pkg-config"
+      pkg.environment "PKG_CONFIG_PATH", "/usr/lib/pkgconfig"
+      pkg.environment "PKG_CONFIG", "/opt/pl-build-tools/bin/pkg-config"
     end
   elsif platform.is_macos?
-    pkg.environment "PATH" => "$$PATH:/usr/local/bin"
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "PATH", "$$PATH:/usr/local/bin"
+    pkg.environment "CFLAGS", settings[:cflags]
   end
 
   pkg.configure do

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -35,7 +35,7 @@ component 'augeas' do |pkg, settings, platform|
 
     if platform.architecture =~ /ppc64le|s390x/
       pkg.build_requires 'runtime'
-      pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
       pkg.environment "CFLAGS", settings[:cflags]
       pkg.environment "LDFLAGS", settings[:ldflags]
     end
@@ -43,7 +43,7 @@ component 'augeas' do |pkg, settings, platform|
     pkg.build_requires 'runtime'
     pkg.build_requires 'pl-pkg-config'
 
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "PKG_CONFIG", "/opt/pl-build-tools/bin/pkg-config"
@@ -53,13 +53,13 @@ component 'augeas' do |pkg, settings, platform|
 
     pkg.build_requires 'pkg-config'
     if platform.is_cross_compiled_linux?
-      pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+      pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
       pkg.environment "CFLAGS", settings[:cflags]
       pkg.environment "LDFLAGS", settings[:ldflags]
     end
 
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.build_requires 'libedit'
@@ -74,7 +74,7 @@ component 'augeas' do |pkg, settings, platform|
       pkg.environment "PKG_CONFIG", "/opt/pl-build-tools/bin/pkg-config"
     end
   elsif platform.is_macos?
-    pkg.environment "PATH", "$$PATH:/usr/local/bin"
+    pkg.environment "PATH", "$(PATH):/usr/local/bin"
     pkg.environment "CFLAGS", settings[:cflags]
   end
 

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -22,8 +22,8 @@ component "cpp-hocon" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -7,7 +7,7 @@ component "cpp-hocon" do |pkg, settings, platform|
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
-  if platform.is_osx?
+  if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -22,7 +22,7 @@ component "cpp-hocon" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -6,9 +6,9 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   make = platform[:make]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
   end
 
   pkg.build_requires "openssl"
@@ -37,7 +37,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "pl-boost-#{platform.architecture}"
 
     make = "#{settings[:gcc_root]}/bin/mingw32-make"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -6,9 +6,9 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   make = platform[:make]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
   pkg.build_requires "openssl"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -21,7 +21,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
     # This should be moved to the toolchain file
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
     toolchain = ""

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -8,16 +8,16 @@ component 'curl' do |pkg, settings, platform|
 
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'runtime'
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
   end
 
   if platform.is_windows?
     pkg.build_requires "runtime"
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
+    pkg.environment "CYGWIN", settings[:cygwin]
   end
 
   pkg.configure do

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -2,6 +2,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.version '7.51.0'
   pkg.md5sum '490e19a8ccd1f4a244b50338a0eb9456'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"
   pkg.build_requires "puppet-ca-bundle"

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -8,15 +8,15 @@ component 'curl' do |pkg, settings, platform|
 
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'runtime'
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
     pkg.environment "PKG_CONFIG_PATH", "/opt/puppetlabs/puppet/lib/pkgconfig"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   end
 
   if platform.is_windows?
     pkg.build_requires "runtime"
 
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
   end
 

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -2,6 +2,7 @@ component 'dmidecode' do |pkg, settings, platform|
   pkg.version '2.12'
   pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
   pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.173.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.175.patch"

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -12,8 +12,8 @@ component 'dmidecode' do |pkg, settings, platform|
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
   pkg.apply_patch "resources/patches/dmidecode/dmidecode-install-to-bin.patch"
 
-  pkg.environment "LDFLAGS" => settings[:ldflags]
-  pkg.environment "CFLAGS" => settings[:cflags]
+  pkg.environment "LDFLAGS", settings[:ldflags]
+  pkg.environment "CFLAGS", settings[:cflags]
 
   if platform.is_cross_compiled?
     # The Makefile doesn't honor environment overrides, so we need to

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -30,9 +30,9 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires "openssl"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
   end
 
   # OSX uses clang and system openssl.  cmake comes from brew.
@@ -99,7 +99,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   if java_home
-    pkg.environment "JAVA_HOME" => java_home
+    pkg.environment "JAVA_HOME", java_home
   end
 
   # Skip blkid unless we can ensure it exists at build time. Otherwise we depend
@@ -159,7 +159,7 @@ component "facter" do |pkg, settings, platform|
     special_flags += " -DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG' "
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -36,7 +36,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   # OSX uses clang and system openssl.  cmake comes from brew.
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
     pkg.build_requires "yaml-cpp"
@@ -139,7 +139,7 @@ component "facter" do |pkg, settings, platform|
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
-  if platform.is_osx?
+  if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
@@ -212,7 +212,7 @@ component "facter" do |pkg, settings, platform|
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     ldd = "otool -L"
   else
     ldd = "ldd"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -30,9 +30,9 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires "openssl"
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:$(PATH)"
   end
 
   # OSX uses clang and system openssl.  cmake comes from brew.

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -69,7 +69,7 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
@@ -88,7 +88,7 @@ component "leatherman" do |pkg, settings, platform|
 
   if platform.is_linux?
     # Ensure our gettext packages are found before system versions
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   end
 
   pkg.configure do

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -3,7 +3,7 @@ component "leatherman" do |pkg, settings, platform|
 
   make = platform[:make]
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
     pkg.build_requires "gettext"
@@ -49,7 +49,7 @@ component "leatherman" do |pkg, settings, platform|
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
-  if platform.is_osx?
+  if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -69,8 +69,8 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
@@ -88,7 +88,7 @@ component "leatherman" do |pkg, settings, platform|
 
   if platform.is_linux?
     # Ensure our gettext packages are found before system versions
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
   end
 
   pkg.configure do

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -3,18 +3,18 @@ component 'libedit' do |pkg, settings, platform|
   pkg.md5sum '43cdb5df3061d78b5e9d59109871b4f6'
   pkg.url "http://thrysoee.dk/editline/libedit-#{pkg.get_version}.tar.gz"
 
-  pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+  pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
 
   if platform.is_solaris?
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
   elsif platform.is_aix?
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/gawk-3.1.3-1.aix5.1.ppc.rpm"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "LDFLAGS", settings[:ldflags]
   end
 
   if platform.is_macos?
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   end
 
   pkg.configure do

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -2,6 +2,7 @@ component 'libedit' do |pkg, settings, platform|
   pkg.version '20150325-3.1'
   pkg.md5sum '43cdb5df3061d78b5e9d59109871b4f6'
   pkg.url "http://thrysoee.dk/editline/libedit-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libedit-#{pkg.get_version}.tar.gz"
 
   pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
 

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -13,7 +13,7 @@ component 'libedit' do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => settings[:ldflags]
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.environment "CFLAGS" => settings[:cflags]
   end
 

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -3,7 +3,7 @@ component 'libedit' do |pkg, settings, platform|
   pkg.md5sum '43cdb5df3061d78b5e9d59109871b4f6'
   pkg.url "http://thrysoee.dk/editline/libedit-#{pkg.get_version}.tar.gz"
 
-  pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+  pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
 
   if platform.is_solaris?
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -9,13 +9,13 @@ component "libxml2" do |pkg, settings, platform|
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_macos?

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -9,23 +9,23 @@ component "libxml2" do |pkg, settings, platform|
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_solaris?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
   elsif platform.is_macos?
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   end
 
   # The system pkg-config has been found to pass incorrect build flags on

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -18,7 +18,7 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS" => settings[:cflags]
     pkg.environment "LDFLAGS" => settings[:ldflags]
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   else

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -2,6 +2,7 @@ component "libxml2" do |pkg, settings, platform|
   pkg.version "2.9.4"
   pkg.md5sum "ae249165c173b1ff386ee8ad676815f5"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxml2-#{pkg.get_version}.tar.gz"
   # CVE-related patches needed until libxml 2.9.5 is released:
   pkg.apply_patch 'resources/patches/libxml2/fix_XPointer_paths_beginning_with_range-to_CVE-2016-5131.patch'
   pkg.apply_patch 'resources/patches/libxml2/fix_comparison_with_root_node_in_xmlXPathCmpNodes.patch'

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -10,9 +10,9 @@ component "libxslt" do |pkg, settings, platform|
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
 
@@ -21,7 +21,7 @@ component "libxslt" do |pkg, settings, platform|
     # don't depend on libgcrypto
     disable_crypto = "--without-crypto"
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -27,7 +27,7 @@ component "libxslt" do |pkg, settings, platform|
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
     pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   else

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -2,6 +2,7 @@ component "libxslt" do |pkg, settings, platform|
   pkg.version "1.1.29"
   pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxslt-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -10,31 +10,31 @@ component "libxslt" do |pkg, settings, platform|
 
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
 
     # libxslt is picky about manually specifying the build host
     build = "--build x86_64-linux-gnu"
     # don't depend on libgcrypto
     disable_crypto = "--without-crypto"
   elsif platform.is_solaris?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     # Configure on Solaris incorrectly passes flags to ld
     pkg.apply_patch 'resources/patches/libxslt/disable-version-script.patch'
     pkg.apply_patch 'resources/patches/libxslt/Update-missing-script-to-return-0.patch'
   elsif platform.is_macos?
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
-    pkg.environment "CFLAGS" => settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+    pkg.environment "CFLAGS", settings[:cflags]
   end
 
   if platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -2,6 +2,7 @@ component "nssm" do |pkg, settings, platform|
   pkg.version "2.24"
   pkg.md5sum "b2edd0e4a7a7be9d157c0da0ef65b1bc"
   pkg.url "https://nssm.cc/release/nssm-#{pkg.get_version}.zip"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/nssm-#{pkg.get_version}.zip"
 
   # Because we're unpacking a zip archive, we need to set the path to the executable.
   # We don't automatically have this set on windows, unfortunately. We need to set the

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -6,7 +6,7 @@ component "nssm" do |pkg, settings, platform|
   # Because we're unpacking a zip archive, we need to set the path to the executable.
   # We don't automatically have this set on windows, unfortunately. We need to set the
   # path to have access to 7za.
-  pkg.environment "PATH" => "/cygdrive/c/ProgramData/chocolatey/tools:$$PATH" if platform.is_windows?
+  pkg.environment "PATH", "/cygdrive/c/ProgramData/chocolatey/tools:$$PATH" if platform.is_windows?
 
   win_arch = platform.architecture == "x64" ? "win64" : "win32"
 

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -6,7 +6,7 @@ component "nssm" do |pkg, settings, platform|
   # Because we're unpacking a zip archive, we need to set the path to the executable.
   # We don't automatically have this set on windows, unfortunately. We need to set the
   # path to have access to 7za.
-  pkg.environment "PATH", "/cygdrive/c/ProgramData/chocolatey/tools:$$PATH" if platform.is_windows?
+  pkg.environment "PATH", "/cygdrive/c/ProgramData/chocolatey/tools:$(PATH)" if platform.is_windows?
 
   win_arch = platform.architecture == "x64" ? "win64" : "win32"
 

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -46,40 +46,40 @@ component "openssl" do |pkg, settings, platform|
   end
 
   if platform.is_macos?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
     target = 'darwin64-x86_64-cc'
     cflags = settings[:cflags]
     ldflags = ''
   elsif platform.is_huaweios?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc'
     ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.name =~ /ubuntu-16\.04-ppc64el/
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc64le'
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.architecture == "s390x"
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux64-s390x'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.architecture == "ppc64le"
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc64le'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.is_solaris?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     if platform.architecture =~ /86/
       target = 'solaris-x86-gcc'
     else
@@ -93,23 +93,23 @@ component "openssl" do |pkg, settings, platform|
     target = 'aix-gcc'
     ldflags = ''
     cflags = "$${CFLAGS} -static-libgcc"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
   elsif platform.is_windows?
     target = platform.architecture == "x64" ? "mingw64" : "mingw"
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
+    pkg.environment "CYGWIN", settings[:cygwin]
     cflags = settings[:cflags]
     ldflags = settings[:ldflags]
   elsif platform.name =~ /debian-8-arm/
     pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.build_requires "xutils-dev"
     target = 'linux-armv4'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   else
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
     if platform.architecture =~ /86$/
       target = 'linux-elf'
       sslflags = '386'

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -32,7 +32,7 @@ component "openssl" do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/openssl/add-shell-to-engines_makefile.patch'
     pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
     pkg.build_requires 'runtime'
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     pkg.build_requires 'makedepend'
   elsif platform.is_windows?
     pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
@@ -45,7 +45,7 @@ component "openssl" do |pkg, settings, platform|
     pkg.build_requires "runtime"
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
     target = 'darwin64-x86_64-cc'
     cflags = settings[:cflags]

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -46,39 +46,39 @@ component "openssl" do |pkg, settings, platform|
   end
 
   if platform.is_macos?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin"
     target = 'darwin64-x86_64-cc'
     cflags = settings[:cflags]
     ldflags = ''
   elsif platform.is_huaweios?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc'
     ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.name =~ /ubuntu-16\.04-ppc64el/
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc64le'
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.architecture == "s390x"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux64-s390x'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.architecture == "ppc64le"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
     target = 'linux-ppc64le'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.is_solaris?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin:/usr/ccs/bin:/usr/sfw/bin"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     if platform.architecture =~ /86/
       target = 'solaris-x86-gcc'
@@ -96,20 +96,20 @@ component "openssl" do |pkg, settings, platform|
     pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
   elsif platform.is_windows?
     target = platform.architecture == "x64" ? "mingw64" : "mingw"
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
     cflags = settings[:cflags]
     ldflags = settings[:ldflags]
   elsif platform.name =~ /debian-8-arm/
     pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.build_requires "xutils-dev"
     target = 'linux-armv4'
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
     cflags = "#{settings[:cflags]} -fPIC"
   else
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:/usr/local/bin"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin"
     if platform.architecture =~ /86$/
       target = 'linux-elf'
       sslflags = '386'

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -2,6 +2,7 @@ component "openssl" do |pkg, settings, platform|
   pkg.version "1.0.2k"
   pkg.md5sum "f965fc0bf01bf882b31314b61391ae65"
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-openssl'
 

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -10,7 +10,7 @@ component "puppet" do |pkg, settings, platform|
   end
   # Used to compile binary translation files
   # i18n is not supported on Solaris
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.build_requires "gettext"
   elsif platform.is_windows?
     pkg.build_requires "pl-gettext-#{platform.architecture}"
@@ -105,7 +105,7 @@ component "puppet" do |pkg, settings, platform|
   unless platform.is_solaris?
     if platform.is_windows?
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
-    elsif platform.is_osx?
+    elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
     else
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"
@@ -126,7 +126,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.requires 'tar' unless platform.is_aix?
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.add_source("file://resources/files/osx_paths.txt", sum: "077ceb5e2f71cf733190a61d2fd221fb")
     pkg.install_file("../osx_paths.txt", "/etc/paths.d/puppet-agent")
   end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -133,7 +133,7 @@ component "puppet" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.environment "FACTERDIR", settings[:facter_root]
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "RUBYLIB", "#{settings[:hiera_libdir]};#{settings[:facter_root]}/lib"
   end
 

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -132,9 +132,9 @@ component "puppet" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
-    pkg.environment "FACTERDIR" => settings[:facter_root]
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
-    pkg.environment "RUBYLIB" => "#{settings[:hiera_libdir]};#{settings[:facter_root]}/lib"
+    pkg.environment "FACTERDIR", settings[:facter_root]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "RUBYLIB", "#{settings[:hiera_libdir]};#{settings[:facter_root]}/lib"
   end
 
   if platform.is_windows?

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -5,9 +5,9 @@ component "pxp-agent" do |pkg, settings, platform|
   cmake = "/opt/pl-build-tools/bin/cmake"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH" => "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
   end
 
   pkg.build_requires "openssl"
@@ -41,7 +41,7 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "pl-boost-#{platform.architecture}"
 
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "CYGWIN" => settings[:cygwin]
+    pkg.environment "CYGWIN", settings[:cygwin]
 
     special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -5,9 +5,9 @@ component "pxp-agent" do |pkg, settings, platform|
   cmake = "/opt/pl-build-tools/bin/cmake"
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   else
-    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
   pkg.build_requires "openssl"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -22,7 +22,7 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -2,6 +2,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -140,7 +140,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.environment "optflags" => settings[:cflags]
   end
 

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -96,8 +96,8 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_proctitle.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.build_requires "libedit"
     pkg.build_requires "runtime"
 
@@ -135,13 +135,13 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
   if platform.is_macos?
-    pkg.environment "optflags" => settings[:cflags]
+    pkg.environment "optflags", settings[:cflags]
   end
 
   if platform.is_solaris?
@@ -157,9 +157,9 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH" => "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
   if platform.is_windows?
@@ -168,10 +168,10 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
-    pkg.environment "CYGWIN" => settings[:cygwin]
-    pkg.environment "optflags" => settings[:cflags] + " -O3"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "CYGWIN", settings[:cygwin]
+    pkg.environment "optflags", settings[:cflags] + " -O3"
+    pkg.environment "LDFLAGS", settings[:ldflags]
 
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
   end

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -135,7 +135,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -157,7 +157,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -168,7 +168,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:tools_root]}/bin):$(shell cygpath -u #{settings[:tools_root]}/include):$(shell cygpath -u #{settings[:bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:includedir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
     pkg.environment "optflags", settings[:cflags] + " -O3"
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -155,7 +155,7 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     pkg.environment "optflags" => "-O2"
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.environment "optflags" => settings[:cflags]
   end
 

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -98,8 +98,8 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.build_requires "libedit"
     pkg.build_requires "runtime"
 
@@ -135,12 +135,12 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
-  pkg.environment "optflags" => "-O2"
+  pkg.environment "optflags", "-O2"
 
   # The el-5-i386 and sles-10-i386 platforms have issues when using -O3 compiling
   # ruby. This is *possibly* a limitation of the versions of GCC we have running on those platforms.
@@ -149,14 +149,14 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   #         - Sean P. McDonald 07/21/16
   if platform.is_el?
     if platform.os_version == "5" && platform.architecture == "i386"
-      pkg.environment "optflags" => "-O2"
+      pkg.environment "optflags", "-O2"
     end
   elsif platform.is_sles? && platform.os_version == "10" && platform.architecture == "i386"
-    pkg.environment "optflags" => "-O2"
+    pkg.environment "optflags", "-O2"
   end
 
   if platform.is_macos?
-    pkg.environment "optflags" => settings[:cflags]
+    pkg.environment "optflags", settings[:cflags]
   end
 
   if platform.is_solaris?
@@ -175,9 +175,9 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH" => "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
   if platform.is_windows?
@@ -186,10 +186,10 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
-    pkg.environment "CYGWIN" => settings[:cygwin]
-    pkg.environment "optflags" => settings[:cflags] + " -O3"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "CYGWIN", settings[:cygwin]
+    pkg.environment "optflags", settings[:cflags] + " -O3"
+    pkg.environment "LDFLAGS", settings[:ldflags]
 
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
   end

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -135,7 +135,7 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -175,7 +175,7 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -186,7 +186,7 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:tools_root]}/bin):$(shell cygpath -u #{settings[:tools_root]}/include):$(shell cygpath -u #{settings[:bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:includedir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
     pkg.environment "optflags", settings[:cflags] + " -O3"
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -2,6 +2,7 @@ component "ruby-2.3.3" do |pkg, settings, platform|
   pkg.version "2.3.3"
   pkg.md5sum "e485f3a55649eb24a1e2e1a40bc120df"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -158,7 +158,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     pkg.environment "optflags" => "-O2"
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     pkg.environment "optflags" => settings[:cflags]
   end
 

--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -98,8 +98,8 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.apply_patch "#{base}/aix_ruby_2.1_libpath_with_opt_dir.patch"
     pkg.apply_patch "#{base}/aix_ruby_2.1_fix_make_test_failure.patch"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.build_requires "libedit"
     pkg.build_requires "runtime"
 
@@ -136,12 +136,12 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH" => "#{settings[:bindir]}:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
-  pkg.environment "optflags" => "-O2"
+  pkg.environment "optflags", "-O2"
 
   # The el-4-x86_64, el-5-i386 and sles-10-i386 platforms have issues when using -O3 compiling
   # ruby. This is *possibly* a limitatio of the versions of GCC we have running on those platforms.
@@ -150,16 +150,16 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   #         - Sean P. McDonald 07/21/16
   if platform.is_el?
     if platform.os_version == "5" && platform.architecture == "i386"
-      pkg.environment "optflags" => "-O2"
+      pkg.environment "optflags", "-O2"
     elsif platform.os_version == "4" && platform.architecture == "x86_64"
-      pkg.environment "optflags" => "-O2"
+      pkg.environment "optflags", "-O2"
     end
   elsif platform.is_sles? && platform.os_version == "10" && platform.architecture == "i386"
-    pkg.environment "optflags" => "-O2"
+    pkg.environment "optflags", "-O2"
   end
 
   if platform.is_macos?
-    pkg.environment "optflags" => settings[:cflags]
+    pkg.environment "optflags", settings[:cflags]
   end
 
   if platform.is_solaris?
@@ -178,9 +178,9 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH" => "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.environment "LDFLAGS" => "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+    pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
   if platform.is_windows?
@@ -189,10 +189,10 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
-    pkg.environment "CYGWIN" => settings[:cygwin]
-    pkg.environment "optflags" => settings[:cflags] + " -O3"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "CYGWIN", settings[:cygwin]
+    pkg.environment "optflags", settings[:cflags] + " -O3"
+    pkg.environment "LDFLAGS", settings[:ldflags]
 
     special_flags = " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g --prefix=#{settings[:ruby_dir]} --with-opt-dir=#{settings[:prefix]} "
   end

--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -2,6 +2,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   pkg.version "2.4.1"
   pkg.md5sum "782bca562e474dd25956dd0017d92677"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -136,7 +136,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
     special_flags += " --with-baseruby=#{settings[:host_ruby]} "
-    pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
+    pkg.environment "PATH", "#{settings[:bindir]}:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -178,7 +178,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     end
     pkg.build_requires 'libedit'
     pkg.build_requires 'runtime'
-    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$$PATH:/opt/csw/bin"
+    pkg.environment "PATH", "#{settings[:bindir]}:/usr/ccs/bin:/usr/sfw/bin:$(PATH):/opt/csw/bin"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
@@ -189,7 +189,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:tools_root]}/bin):$$(cygpath -u #{settings[:tools_root]}/include):$$(cygpath -u #{settings[:bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:includedir]}):$$PATH"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:tools_root]}/bin):$(shell cygpath -u #{settings[:tools_root]}/include):$(shell cygpath -u #{settings[:bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:includedir]}):$(PATH)"
     pkg.environment "CYGWIN", settings[:cygwin]
     pkg.environment "optflags", settings[:cflags] + " -O3"
     pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -2,6 +2,7 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
   pkg.url "http://download.augeas.net/ruby/ruby-augeas-#{pkg.get_version}.tgz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-augeas-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby-augeas'
 

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -8,7 +8,7 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "augeas"
 
-  pkg.environment "PATH", "$$PATH:/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
+  pkg.environment "PATH", "$(PATH):/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
   if platform.is_aix?
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
     pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -8,26 +8,26 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "augeas"
 
-  pkg.environment "PATH" => "$$PATH:/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
+  pkg.environment "PATH", "$$PATH:/opt/pl-build-tools/bin:/usr/local/bin:/opt/csw/bin:/usr/ccs/bin:/usr/sfw/bin"
   if platform.is_aix?
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/gcc"
-    pkg.environment "RUBY" => "/opt/puppetlabs/puppet/bin/ruby"
-    pkg.environment "LDFLAGS" => " -brtl #{settings[:ldflags]}"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/gcc"
+    pkg.environment "RUBY", "/opt/puppetlabs/puppet/bin/ruby"
+    pkg.environment "LDFLAGS", " -brtl #{settings[:ldflags]}"
   end
 
-  pkg.environment "CONFIGURE_ARGS" => '--vendor'
-  pkg.environment "PKG_CONFIG_PATH" => "#{File.join(settings[:libdir], 'pkgconfig')}:/usr/lib/pkgconfig"
+  pkg.environment "CONFIGURE_ARGS", '--vendor'
+  pkg.environment "PKG_CONFIG_PATH", "#{File.join(settings[:libdir], 'pkgconfig')}:/usr/lib/pkgconfig"
 
   if platform.is_solaris?
     if platform.architecture == 'sparc'
-      pkg.environment "RUBY" => settings[:host_ruby]
+      pkg.environment "RUBY", settings[:host_ruby]
     end
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "RUBY" => settings[:host_ruby]
+    pkg.environment "RUBY", settings[:host_ruby]
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
   else
     ruby = File.join(settings[:bindir], 'ruby')
   end

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -25,7 +25,7 @@ component "ruby-selinux" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     cc = "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     system_include = "-I/opt/pl-build-tools/#{settings[:platform_triple]}/sysroot/usr/include"
-    pkg.environment "RUBY" => settings[:host_ruby]
+    pkg.environment "RUBY", settings[:host_ruby]
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   end
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -5,10 +5,12 @@ component "ruby-selinux" do |pkg, settings, platform|
     pkg.md5sum "08762379de2242926854080dad649b67"
     pkg.apply_patch "resources/patches/ruby-selinux/libselinux-rhat.patch"
     pkg.url "http://pkgs.fedoraproject.org/repo/pkgs/libselinux/libselinux-1.33.4.tgz/08762379de2242926854080dad649b67/libselinux-1.33.4.tgz"
+    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
   else
     pkg.version "2.0.94"
     pkg.md5sum "544f75aab11c2af352facc51af12029f"
     pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
+    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tar.gz"
   end
 
   pkg.replaces 'pe-ruby-selinux'

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -3,6 +3,7 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
   # I am unable to find ruby-shadow-2.3.3 source anywhere other than our own website. Upstream appears to be dead.
   pkg.url "https://downloads.puppetlabs.com/enterprise/sources/3.8.3/solaris/11/source/ruby-shadow-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-shadow-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby-shadow'
 

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -7,7 +7,7 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.replaces 'pe-ruby-shadow'
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
-  pkg.environment "PATH", "$$PATH:/usr/ccs/bin:/usr/sfw/bin"
+  pkg.environment "PATH", "$(PATH):/usr/ccs/bin:/usr/sfw/bin"
   pkg.environment "CONFIGURE_ARGS", '--vendor'
 
   if platform.is_solaris?

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -7,16 +7,16 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.replaces 'pe-ruby-shadow'
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
-  pkg.environment "PATH" => "$$PATH:/usr/ccs/bin:/usr/sfw/bin"
-  pkg.environment "CONFIGURE_ARGS" => '--vendor'
+  pkg.environment "PATH", "$$PATH:/usr/ccs/bin:/usr/sfw/bin"
+  pkg.environment "CONFIGURE_ARGS", '--vendor'
 
   if platform.is_solaris?
     if platform.architecture == 'sparc'
-      pkg.environment "RUBY" => settings[:host_ruby]
+      pkg.environment "RUBY", settings[:host_ruby]
     end
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "RUBY" => settings[:host_ruby]
+    pkg.environment "RUBY", settings[:host_ruby]
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
   else
     ruby = File.join(settings[:bindir], 'ruby')

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -2,6 +2,7 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.3.3"
   pkg.md5sum "50a2c1b66982b426d67a83f56f4bc0e2"
   pkg.url "https://rubygems.org/downloads/stomp-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/stomp-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-ruby-stomp'
 

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -9,17 +9,17 @@ component "ruby-stomp" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   base = 'resources/patches/ruby-stomp'
   pkg.apply_patch "#{base}/verify_client_certs.patch", destination: "#{settings[:gem_home]}/gems/stomp-#{pkg.get_version}", after: "install"

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -12,14 +12,14 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   base = 'resources/patches/ruby-stomp'
   pkg.apply_patch "#{base}/verify_client_certs.patch", destination: "#{settings[:gem_home]}/gems/stomp-#{pkg.get_version}", after: "install"

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -8,18 +8,18 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} deep_merge-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -2,6 +2,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.version "1.0.1"
   pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
   pkg.url "https://rubygems.org/downloads/deep_merge-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/deep_merge-#{pkg.get_version}.gem"
 
   pkg.replaces "pe-rubygem-deep-merge"
 

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -8,7 +8,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
@@ -19,7 +19,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} deep_merge-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -13,7 +13,7 @@ component "rubygem-fast_gettext" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} fast_gettext-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -7,13 +7,13 @@ component "rubygem-fast_gettext" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} fast_gettext-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -2,6 +2,7 @@ component "rubygem-fast_gettext" do |pkg, settings, platform|
   pkg.version "1.1.0"
   pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
   pkg.url "https://rubygems.org/downloads/fast_gettext-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/fast_gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -14,15 +14,15 @@ component "rubygem-ffi" do |pkg, settings, platform|
 
     # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
     # Instead we use the host gem installation and override GEM_HOME. Yay?
-    pkg.environment "GEM_HOME" => settings[:gem_home]
+    pkg.environment "GEM_HOME", settings[:gem_home]
 
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
 
     # PA-25 in order to install gems in a cross-compiled environment we need to
     # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
     # hiera/version and puppet/version requires. Without this the gem install
     # will fail by blowing out the stack.
-    pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+    pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
     pkg.install do
       ["#{settings[:gem_install]} ffi-#{pkg.get_version}-#{platform.architecture}-mingw32.gem"]

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -5,9 +5,11 @@ component "rubygem-ffi" do |pkg, settings, platform|
     if platform.architecture == "x64"
       pkg.md5sum "664afc6a316dd648f497fbda3be87137"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
+      pkg.mirror "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x64-mingw32.gem"
     else
       pkg.md5sum "0b6fd994826952231d285f078cefce32"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
+      pkg.mirror "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x86-mingw32.gem"
     end
 
     pkg.build_requires "ruby-#{settings[:ruby_version]}"

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -16,13 +16,13 @@ component "rubygem-ffi" do |pkg, settings, platform|
     # Instead we use the host gem installation and override GEM_HOME. Yay?
     pkg.environment "GEM_HOME", settings[:gem_home]
 
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
 
     # PA-25 in order to install gems in a cross-compiled environment we need to
     # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
     # hiera/version and puppet/version requires. Without this the gem install
     # will fail by blowing out the stack.
-    pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+    pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
     pkg.install do
       ["#{settings[:gem_install]} ffi-#{pkg.get_version}-#{platform.architecture}-mingw32.gem"]

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -13,7 +13,7 @@ component "rubygem-gettext-setup" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} gettext-setup-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -2,6 +2,7 @@ component "rubygem-gettext-setup" do |pkg, settings, platform|
   pkg.version "0.24"
   pkg.md5sum "f766a5e12bbad9f85905638c500e08f6"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -7,13 +7,13 @@ component "rubygem-gettext-setup" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} gettext-setup-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -2,6 +2,7 @@ component "rubygem-gettext" do |pkg, settings, platform|
   pkg.version "3.2.2"
   pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
   pkg.url "https://rubygems.org/downloads/gettext-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -13,7 +13,7 @@ component "rubygem-gettext" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} gettext-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -7,13 +7,13 @@ component "rubygem-gettext" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} gettext-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -7,17 +7,17 @@ component "rubygem-hocon" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} hocon-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -2,6 +2,7 @@ component "rubygem-hocon" do |pkg, settings, platform|
   pkg.version "1.2.5"
   pkg.md5sum "e7821d3a731ab617320ccfa4f67f886b"
   pkg.url "https://rubygems.org/downloads/hocon-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/hocon-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -10,14 +10,14 @@ component "rubygem-hocon" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} hocon-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -7,13 +7,13 @@ component "rubygem-locale" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} locale-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -13,7 +13,7 @@ component "rubygem-locale" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} locale-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -2,6 +2,7 @@ component "rubygem-locale" do |pkg, settings, platform|
   pkg.version "2.1.2"
   pkg.md5sum "def1e89d1d3126a0c684d3b7b20d88d4"
   pkg.url "https://rubygems.org/downloads/locale-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/locale-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -2,6 +2,7 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.version "2.1.0"
   pkg.md5sum "d771975a58cef82daa6b0ee03522293f"
   pkg.url "https://rubygems.org/downloads/mini_portile2-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/mini_portile2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -10,14 +10,14 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} mini_portile2-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -7,17 +7,17 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} mini_portile2-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -7,17 +7,17 @@ component "rubygem-minitar" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} minitar-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -2,6 +2,7 @@ component "rubygem-minitar" do |pkg, settings, platform|
   pkg.version "0.6.1"
   pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
   pkg.url "https://rubygems.org/downloads/minitar-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/minitar-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -10,14 +10,14 @@ component "rubygem-minitar" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} minitar-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -13,14 +13,14 @@ component "rubygem-net-netconf" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} --force net-netconf-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -10,17 +10,17 @@ component "rubygem-net-netconf" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} --force net-netconf-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -1,7 +1,8 @@
 component "rubygem-net-netconf" do |pkg, settings, platform|
   pkg.version "0.4.3"
-  pkg.url "https://rubygems.org/downloads/net-netconf-#{get_version}.gem"
   pkg.md5sum "fa173b0965766a427d8692f6b31c85a4"
+  pkg.url "https://rubygems.org/downloads/net-netconf-#{get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-netconf-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "rubygem-net-scp"

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -8,17 +8,17 @@ component "rubygem-net-scp" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} net-scp-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -11,14 +11,14 @@ component "rubygem-net-scp" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} net-scp-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -2,6 +2,7 @@ component "rubygem-net-scp" do |pkg, settings, platform|
   pkg.version "1.2.1"
   pkg.md5sum "abeec1cab9696e02069e74bd3eac8a1b"
   pkg.url "https://rubygems.org/downloads/net-scp-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-scp-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "rubygem-net-ssh"

--- a/configs/components/rubygem-net-ssh-telnet2.rb
+++ b/configs/components/rubygem-net-ssh-telnet2.rb
@@ -14,7 +14,7 @@ component "rubygem-net-ssh-telnet2" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} net-ssh-telnet2-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-ssh-telnet2.rb
+++ b/configs/components/rubygem-net-ssh-telnet2.rb
@@ -2,6 +2,7 @@ component "rubygem-net-ssh-telnet2" do |pkg, settings, platform|
   pkg.version "0.1.1"
   pkg.md5sum "8fba7aada691a0c10caf5b74f57cfef2"
   pkg.url "https://rubygems.org/downloads/net-ssh-telnet2-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-ssh-telnet2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
   pkg.build_requires "rubygem-net-ssh"

--- a/configs/components/rubygem-net-ssh-telnet2.rb
+++ b/configs/components/rubygem-net-ssh-telnet2.rb
@@ -8,13 +8,13 @@ component "rubygem-net-ssh-telnet2" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} net-ssh-telnet2-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -2,6 +2,7 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version "4.1.0"
   pkg.md5sum "6af1ff8c42a07b11203058c9b74cbaef"
   pkg.url "https://rubygems.org/downloads/net-ssh-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-rubygem-net-ssh'
 

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -12,14 +12,14 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} net-ssh-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -9,17 +9,17 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} net-ssh-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -15,6 +15,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     end
   else
     pkg.url "https://rubygems.org/downloads/nokogiri-#{pkg.get_version}.gem"
+    pkg.mirror "http://buildsources.delivery.puppetlabs.net/nokogiri-#{pkg.get_version}.gem"
     pkg.md5sum "51402a536f389bfcef0ff1600b8acff5"
   end
 

--- a/configs/components/rubygem-pkg-config.rb
+++ b/configs/components/rubygem-pkg-config.rb
@@ -2,6 +2,7 @@ component "rubygem-pkg-config" do |pkg, settings, platform|
   pkg.version "1.1.7"
   pkg.md5sum "2767d4620b32f2a4ccddc18c353e5385"
   pkg.url "https://rubygems.org/downloads/pkg-config-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/pkg-config-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-pkg-config.rb
+++ b/configs/components/rubygem-pkg-config.rb
@@ -13,7 +13,7 @@ component "rubygem-pkg-config" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} pkg-config-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-pkg-config.rb
+++ b/configs/components/rubygem-pkg-config.rb
@@ -7,13 +7,13 @@ component "rubygem-pkg-config" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} pkg-config-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -2,6 +2,7 @@ component "rubygem-semantic_puppet" do |pkg, settings, platform|
   pkg.version "0.1.2"
   pkg.md5sum "192ae7729997cb5d5364f64b99b13121"
   pkg.url "https://rubygems.org/downloads/semantic_puppet-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/semantic_puppet-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -10,14 +10,14 @@ component "rubygem-semantic_puppet" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} semantic_puppet-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -7,17 +7,17 @@ component "rubygem-semantic_puppet" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} semantic_puppet-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -7,13 +7,13 @@ component "rubygem-text" do |pkg, settings, platform|
 
   # When cross-compiling, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} text-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -2,6 +2,7 @@ component "rubygem-text" do |pkg, settings, platform|
   pkg.version "1.3.1"
   pkg.md5sum "514c3d1db7a955fe793fc0cb149c164f"
   pkg.url "https://rubygems.org/downloads/text-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/text-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -13,7 +13,7 @@ component "rubygem-text" do |pkg, settings, platform|
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} text-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -2,6 +2,7 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
   pkg.version "0.4.9"
   pkg.md5sum "df14aa01bd6011f4b6332a05e15b7fb8"
   pkg.url "https://rubygems.org/downloads/win32-dir-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-dir-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -7,17 +7,17 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-dir-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -10,14 +10,14 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-dir-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -7,17 +7,17 @@ component "rubygem-win32-process" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-process-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -10,14 +10,14 @@ component "rubygem-win32-process" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-process-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -2,6 +2,7 @@ component "rubygem-win32-process" do |pkg, settings, platform|
   pkg.version "0.7.4"
   pkg.md5sum "3231cf152383fb2d792dcac8036b060f"
   pkg.url "https://rubygems.org/downloads/win32-process-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-process-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -2,6 +2,7 @@ component "rubygem-win32-security" do |pkg, settings, platform|
   pkg.version "0.2.5"
   pkg.md5sum "97c4b971ea19ca48cea7dec1d21d506a"
   pkg.url "https://rubygems.org/downloads/win32-security-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-security-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -10,14 +10,14 @@ component "rubygem-win32-security" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-security-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -7,17 +7,17 @@ component "rubygem-win32-security" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-security-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -2,6 +2,7 @@ component "rubygem-win32-service" do |pkg, settings, platform|
   pkg.version "0.8.8"
   pkg.md5sum "24cc05fed398eb931e14b8ee22196634"
   pkg.url "https://rubygems.org/downloads/win32-service-#{pkg.get_version}.gem"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-service-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -7,17 +7,17 @@ component "rubygem-win32-service" do |pkg, settings, platform|
 
   # Because we are cross-compiling on sparc, we can't use the rubygems we just built.
   # Instead we use the host gem installation and override GEM_HOME. Yay?
-  pkg.environment "GEM_HOME" => settings[:gem_home]
+  pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB" => "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-service-#{pkg.get_version}.gem"]

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -10,14 +10,14 @@ component "rubygem-win32-service" do |pkg, settings, platform|
   pkg.environment "GEM_HOME", settings[:gem_home]
 
   if platform.is_windows?
-    pkg.environment "PATH", "$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:ruby_bindir]}):$$(cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
   end
 
   # PA-25 in order to install gems in a cross-compiled environment we need to
   # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
   # hiera/version and puppet/version requires. Without this the gem install
   # will fail by blowing out the stack.
-  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$$RUBYLIB"
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.install do
     ["#{settings[:gem_install]} win32-service-#{pkg.get_version}.gem"]

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -27,7 +27,7 @@ component "runtime" do |pkg, settings, platform|
   end
 
   # The runtime script uses readlink, which is in an odd place on Solaris systems:
-  pkg.environment "PATH", "$$PATH:/opt/csw/gnu" if platform.is_solaris?
+  pkg.environment "PATH", "$(PATH):/opt/csw/gnu" if platform.is_solaris?
 
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -32,7 +32,7 @@ component "runtime" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
     pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -27,7 +27,7 @@ component "runtime" do |pkg, settings, platform|
   end
 
   # The runtime script uses readlink, which is in an odd place on Solaris systems:
-  pkg.environment "PATH" => "$$PATH:/opt/csw/gnu" if platform.is_solaris?
+  pkg.environment "PATH", "$$PATH:/opt/csw/gnu" if platform.is_solaris?
 
   if platform.is_aix?
     pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -28,9 +28,9 @@ component "virt-what" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     host_opt = "--host #{settings[:platform_triple]}"
 
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
-    pkg.environment "CFLAGS" => settings[:cflags]
-    pkg.environment "LDFLAGS" => settings[:ldflags]
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
   end
 
   pkg.configure do

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -2,6 +2,7 @@ component "virt-what" do |pkg, settings, platform|
   pkg.version "1.14"
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
   pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/virt-what-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-virt-what'
 

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -28,7 +28,7 @@ component "virt-what" do |pkg, settings, platform|
   if platform.is_cross_compiled_linux?
     host_opt = "--host #{settings[:platform_triple]}"
 
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):#{settings[:bindir]}"
     pkg.environment "CFLAGS", settings[:cflags]
     pkg.environment "LDFLAGS", settings[:ldflags]
   end

--- a/configs/components/wrapper-script.rb
+++ b/configs/components/wrapper-script.rb
@@ -9,7 +9,7 @@ component "wrapper-script" do |pkg, settings, platform|
 
   if platform.is_aix?
     pkg.install_file "aix-wrapper.sh", wrapper, mode: '0755'
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     pkg.install_file "osx-wrapper.sh", wrapper, mode: '0755'
   else
     pkg.install_file "sysv-wrapper.sh", wrapper, mode: '0755'

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -61,7 +61,7 @@ project "puppet-agent" do |proj|
     if platform.is_eos?
       proj.setting(:sysconfdir, "/persist/sys/etc/puppetlabs")
       proj.setting(:link_sysconfdir, "/etc/puppetlabs")
-    elsif platform.is_osx?
+    elsif platform.is_macos?
       proj.setting(:sysconfdir, "/private/etc/puppetlabs")
     else
       proj.setting(:sysconfdir, "/etc/puppetlabs")
@@ -157,7 +157,7 @@ project "puppet-agent" do |proj|
 
   if platform.is_solaris?
     proj.identifier "puppetlabs.com"
-  elsif platform.is_osx?
+  elsif platform.is_macos?
     proj.identifier "com.puppetlabs"
   end
 
@@ -187,7 +187,7 @@ project "puppet-agent" do |proj|
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
   end
 
-  if platform.is_osx?
+  if platform.is_macos?
     # For OS X, we should optimize for an older architecture than Apple
     # currently ships for; there's a lot of older xeon chips based on
     # that architecture still in use throughout the Mac ecosystem.
@@ -276,7 +276,7 @@ project "puppet-agent" do |proj|
   end
 
   # Components only applicable on OSX
-  if platform.is_osx?
+  if platform.is_macos?
     proj.component "cfpropertylist"
   end
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -293,10 +293,4 @@ project "puppet-agent" do |proj|
   proj.directory proj.piddir unless platform.is_windows?
 
   proj.timeout 7200 if platform.is_windows?
-
-  # Here we rewrite public http urls to use our internal source host instead.
-  # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
-  # rewritten as
-  # http://buildsources.delivery.puppetlabs.net/openssl-1.0.0r.tar.gz
-  proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
 end

--- a/test.rb
+++ b/test.rb
@@ -1,1 +1,0 @@
-pkg.environment "THING", "value"

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,1 @@
+pkg.environment "THING", "value"


### PR DESCRIPTION
We recently updated the vanagon version used from 0.8.2 to 0.12.1. In this gap, several pieces of functionality were changed, and deprecation warnings were added to the old usages. This PR contains three commits which clean up the bulk of the warnings:
1) `is_osx?` was renamed to `is_macos?`
2) environment variables should now be specified as two separate arguments (name and value) rather than as a hash
3) interpolation of environment variables in strings destined for the shell are now being handled differently by the intermediate steps, and a new syntax is preferred: `$$PATH` becomes `$(PATH)`

There is just one warning left, concerning the specification of a mirroring URL. However, the current alternative to `register_rewrite_rule` as used [here](https://github.com/puppetlabs/puppet-agent/blob/master/configs/projects/puppet-agent.rb#L301) is currently quite clunky, and comments in the Vanagon codebase indicate that the changes might still be under active development, so I'm leaving it for now.

On Windows there is also a warning about attempting to set file modes, which apparently still doesn't work. But that seems like a different sort of problem.