### PR TITLE
(PA-1263) Do not install curl when building solaris 10 packages

### DIFF
--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -36,7 +36,7 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i curl rsync gmake pkgconfig ggrep;
+  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -40,7 +40,7 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i curl rsync gmake pkgconfig ggrep;
+  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;


### PR DESCRIPTION
Curl is an external dependency (opencsw), and is already installed
on the builders. Not trying to re-install it every time will help
us to avoid potential issues with the opencsw package repo (such
as the one in the ticket above)