### PR TITLE
(PA-1269) Enable EC2 master install

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -24,26 +24,62 @@ step "Install puppet-agent..." do
 end
 
 step "Install puppetserver..." do
-  if ENV['TESTING_RELEASED_PACKAGES']
-    # unlike the install_puppet_agent_* beaker methods,
-    # install_puppetlabs_release_repo_on does not use pc1 by default. Have to
-    # supply pc1 arg to install from pc1 rather than latest in pre-puppet
-    # collection repos which was version 1.2.0.
-    install_puppetlabs_release_repo_on(master, 'pc1')
+  if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
+    server_version = 'latest'
+    server_download_url = "http://nightlies.puppet.com"
   else
-    # the dev repos have only a single package, so we need one for both server
-    # and agent to satisfy server's dep on agent
-    if ENV['SERVER_VERSION'].nil? || ENV['SERVER_VERSION'] == 'latest'
-      server_version = 'latest'
-      server_download_url = "http://nightlies.puppet.com"
-    else
-      server_version = ENV['SERVER_VERSION']
-      server_download_url = "http://builds.delivery.puppetlabs.net"
-    end
-    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
-    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'], nil, :dev_builds_url => ENV['AGENT_DOWNLOAD_URL'])
+    server_version = ENV['SERVER_VERSION']
+    server_download_url = "http://builds.delivery.puppetlabs.net"
   end
-  master.install_package('puppetserver')
+  if master[:hypervisor] == 'ec2'
+    if master[:platform].match(/(?:el|centos|oracle|redhat|scientific)/)
+      # An EC2 master instance does not have access to puppetlabs.net for getting
+      # dev repos. We will install the nightly repo to satisfy the puppetserver
+      # requirement and then override it with the targeted SHA package later
+      # So, install the puppet-agent package directly
+      if server_version == 'latest'
+        logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+        install_repos_on(master, 'puppet-agent', 'nightly', 'repo-configs')
+        install_repos_on(master, 'puppetserver', 'nightly', 'repo-configs')
+      else
+        variant, version = master['platform'].to_array
+        if server_version.to_i < 5
+          logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+          on(master, "rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-#{version}.noarch.rpm")
+        else
+          logger.info "EC2 master found: Installing nightly build of puppet-agent repo to satisfy puppetserver dependency."
+          on(master, "rpm -Uvh https://yum.puppetlabs.com/puppet5-release-el-#{version}.noarch.rpm")
+        end
+      end
+
+      master.install_package('puppetserver')
+
+      logger.info "EC2 master found: Installing #{ENV['SHA']} build of puppet-agent."
+      # Override nightly puppet-agent with targeted SHA.
+      # Currently, only an `el` master is supported for this operation.
+      opts = {
+        :puppet_collection => 'PC1',
+        :puppet_agent_sha => ENV['SHA'],
+        :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA'] ,
+        :dev_builds_url => "http://builds.delivery.puppetlabs.net"
+      }
+
+      copy_dir_local = File.join('tmp', 'repo_configs', master['platform'])
+      release_path_end, release_file = master.puppet_agent_dev_package_info( opts[:puppet_collection], opts[:puppet_agent_version], opts)
+      release_path = "#{opts[:dev_builds_url]}/puppet-agent/#{opts[:puppet_agent_sha]}/repos/"
+      release_path << release_path_end
+      fetch_http_file(release_path, release_file, copy_dir_local)
+      scp_to master, File.join(copy_dir_local, release_file), master.external_copy_base
+      on master, "rpm -Uvh #{File.join(master.external_copy_base, release_file)} --oldpackage --force"
+    else
+      fail_test("EC2 master found, but it was not an `el` host: The specified `puppet-agent` build (#{ENV['SHA']}) cannot be installed.")
+    end
+  else
+    install_puppetlabs_dev_repo(master, 'puppetserver', server_version, nil, :dev_builds_url => server_download_url)
+    install_puppetlabs_dev_repo(master, 'puppet-agent', ENV['SHA'])
+    master.install_package('puppetserver')
+  end
+
 end
 
 # make sure install is sane, beaker has already added puppet and ruby


### PR DESCRIPTION
This commit updates the aio install pre-suite to allow installing
an ec2 master dynamically on a el based system without intervention.
Due to the expectations of the nightly puppetserver repo, the nightly
puppet-agent is installed first and then over-written with the
puppet-agent version under test. The specification of a SERVER_VERSION
is also supported.