### PR TITLE
(PA-1264) Add support to build PA against system openssl on FIPS platforms

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -11,7 +11,12 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "leatherman"
 
   if platform.is_aix?

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -9,7 +9,12 @@ component 'curl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/curl/curl-7.55.1-aix-poll.patch'
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "puppet-ca-bundle"
 
   if platform.is_cross_compiled_linux?

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -15,7 +15,12 @@ component "facter" do |pkg, settings, platform|
   pkg.replaces 'pe-facter'
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
-  pkg.build_requires 'openssl'
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires 'leatherman'
   pkg.build_requires 'runtime'
   pkg.build_requires 'cpp-hocon'
@@ -28,7 +33,6 @@ component "facter" do |pkg, settings, platform|
 
   # Running facter (as part of testing) expects augtool are available
   pkg.build_requires 'augeas' unless platform.is_windows?
-  pkg.build_requires "openssl"
 
   if platform.is_windows?
     pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -1,7 +1,12 @@
 component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet-ca-bundle.json")
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   java_available = true
   case platform.name
@@ -19,7 +24,12 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
     java_available = false
   end
 
-  openssl_cmd = "#{settings[:bindir]}/openssl"
+  if settings[:vendor_openssl] == "no"
+    openssl_cmd = "/usr/bin/openssl"
+  else
+    openssl_cmd = "#{settings[:bindir]}/openssl"
+  end
+
   if platform.is_cross_compiled_linux?
     # Use the build host's openssl command, not our cross-compiled one
     openssl_cmd = "/usr/bin/openssl"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -10,7 +10,12 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "leatherman"
   pkg.build_requires "cpp-pcp-client"
   pkg.build_requires "cpp-hocon"

--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -140,7 +140,12 @@ component "ruby-2.4.3" do |pkg, settings, platform|
     pkg.build_requires 'runtime' if platform.is_cross_compiled_linux?
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"

--- a/configs/platforms/redhat-fips-7-x86_64.rb
+++ b/configs/platforms/redhat-fips-7-x86_64.rb
@@ -1,0 +1,10 @@
+platform "redhat-fips-7-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "redhat-fips-7-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -253,7 +253,15 @@ project "puppet-agent" do |proj|
   end
   proj.component "ruby-shadow" unless platform.is_aix? || platform.is_windows?
   proj.component "ruby-augeas" unless platform.is_windows?
-  proj.component "openssl"
+
+  if platform.name =~ /^redhat-fips-7-.*/
+    # Link against system openssl and not package openssl
+    proj.setting(:vendor_openssl, "no")
+  else
+    proj.setting(:vendor_openssl, "yes")
+    proj.component "openssl"
+  end
+
   proj.component "puppet-ca-bundle"
   proj.component "libxml2" unless platform.is_windows?
   proj.component "libxslt" unless platform.is_windows?


### PR DESCRIPTION
This is being done to allow using puppet agent on FIPS enabled systems.
Vendored openssl is not allowed on FIPS systems as it is not FIPS certified.
System openssl linking is done when building on redhat_fips-7-x86_64 platform.
The rhel7 fips vmpooler image used for building will be FIPS enabled and have 
the appropriate version of openssl-devel package installed on it.
    
Also adding redhat-fips-7-x86_64 as a build platform. 
