### PR TITLE
(PA-611) Fix md5 for libselinux tarball and nssm zip archive

### DIFF
--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -1,6 +1,6 @@
 component "nssm" do |pkg, settings, platform|
   pkg.version "2.24"
-  pkg.md5sum "0fa251d152383ded6850097279291bb0"
+  pkg.md5sum "b2edd0e4a7a7be9d157c0da0ef65b1bc"
   pkg.url "https://nssm.cc/release/nssm-#{pkg.get_version}.zip"
 
   # Because we're unpacking a zip archive, we need to set the path to the executable.
@@ -10,5 +10,5 @@ component "nssm" do |pkg, settings, platform|
 
   win_arch = platform.architecture == "x64" ? "win64" : "win32"
 
-  pkg.install_file "#{win_arch}/nssm.exe", "#{settings[:service_dir]}/nssm.exe"
+  pkg.install_file "nssm-2.24/#{win_arch}/nssm.exe", "#{settings[:service_dir]}/nssm.exe"
 end

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -7,7 +7,7 @@ component "ruby-selinux" do |pkg, settings, platform|
     pkg.url "http://pkgs.fedoraproject.org/repo/pkgs/libselinux/libselinux-1.33.4.tgz/08762379de2242926854080dad649b67/libselinux-1.33.4.tgz"
   else
     pkg.version "2.0.94"
-    pkg.md5sum "f814c71fca5a85ebfeb81b57afed59db"
+    pkg.md5sum "544f75aab11c2af352facc51af12029f"
     pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
   end
 


### PR DESCRIPTION
This updates the md5 to reflect what the upstream tarball has. Once this is merged I'll overwrite the file on buildsources (after making a backup of it).