### PR TITLE
(packaging) Pin cpp-pcp-client and pxp-agent to 5.0.1 release

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "ef0044ee2c6adb869d33a989042b001f3636f38d"}
+{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "refs/tags/1.5.3"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "5c94807f41f0edbc3a508190721ad6925b1629c1"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.6.1"}


### PR DESCRIPTION
We are not shipping these components as part of the 5.1.0 release