### PR TITLE
(PA-1406) Enable DEP support in Windows version of Puppet agent binaries

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -183,7 +183,7 @@ project "puppet-agent" do |proj|
     proj.setting(:tools_root, "C:/tools/pl-build-tools")
     proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
     proj.setting(:cflags, "#{proj.cppflags}")
-    proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir}")
+    proj.setting(:ldflags, "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat -Wl,--dynamicbase")
     proj.setting(:cygwin, "nodosfilewarning winsymlinks:native")
   end
 


### PR DESCRIPTION
Enable nxcompat and dynamicbase flags in Windows builds of all puppet and
3rd party exe's, dll's built using puppet-agent.
This is being done to meet some customer's security audit requirements.

**Note**: In addition to this change, git sha references in following component's project files (json files) need to be updated appropriately so as to enable DEP linker settings: cpp-pcp-client, facter, leatherman, pxp-agent. 
Refer to following PRs: 
https://github.com/puppetlabs/facter/pull/1624
https://github.com/puppetlabs/cpp-pcp-client/pull/228
https://github.com/puppetlabs/pxp-agent/pull/620
https://github.com/puppetlabs/leatherman/pull/247