### PR TITLE
(PA-1408) Restrict permissions for pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -82,14 +82,14 @@ component "pxp-agent" do |pkg, settings, platform|
 
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent')
   if platform.is_windows?
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'etc', 'modules')
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'spool')
+    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'tasks-cache')
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'log')
     pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'run')
   else
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
-    pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool')
-    pkg.directory File.join(settings[:logdir], 'pxp-agent')
+    pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool'), mode: "0750"
+    pkg.directory File.join(settings[:install_root], 'pxp-agent', 'tasks-cache'), mode: "0750"
+    pkg.directory File.join(settings[:logdir], 'pxp-agent'), mode: "0750"
   end
 
   case platform.servicetype


### PR DESCRIPTION
pxp-agent log files and spool directory should not be readable by world.

Remove unused modules directory.

Add tasks-cache dir.