### PR TITLE
(PA-1414) Clean up NSSM/msbuild commands

### DIFF
--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -2,11 +2,12 @@ component "nssm" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/nssm.json")
 
   build_arch = platform.architecture == "x64" ? "x64" : "Win32"
+  platform_toolset = 'v141'
+  target_platform_version = '8.1'
 
   pkg.install do
     [
-      "/cygdrive/c/Program\\ files\\ \\(x86\\)/Microsoft\\ Visual\\ Studio/2017/BuildTools/Common7/Tools/vsdevcmd.bat",
-      "/cygdrive/c/Program\\ Files\\ \\(x86\\)/Microsoft\\ Visual\\ Studio/2017/BuildTools/MSBuild/15.0/Bin/msbuild.exe nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=./out /p:Platform=#{build_arch} /p:PlatformToolset=v141 /p:TargetPlatformVersion=8.1",
+      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=./out /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}",
     ]
   end
 

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -2,19 +2,33 @@ platform "windows-2012r2-x64" do |plat|
   plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
+  visual_studio_version = '2017'
+  visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
   plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
 
+  # C:\tools is likely added by mingw, however because we also want to use that
+  # dir for vsdevcmd.bat we create it for safety
+  plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.2017-win8.1.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  # We use cache-location in the following install because msvc has several long paths
+  # if we do not update the cache location choco will fail because paths get too long
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
+  # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
+  # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
+  # through cygwin much easier.
+  #
+  # Note that the unruly \'s in the following string escape the following sequence to literal chars: "\" and then \""
+  plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
   plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
 

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -2,19 +2,33 @@ platform "windows-2012r2-x86" do |plat|
   plat.vmpooler_template "win-2012r2-x86_64"
 
   plat.servicetype "windows"
+  visual_studio_version = '2017'
+  visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
   plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
 
+  # C:\tools is likely added by mingw, however because we also want to use that
+  # dir for vsdevcmd.bat we create it for safety
+  plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.2017-win8.1.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  # We use cache-location in the following install because msvc has several long paths
+  # if we do not update the cache location choco will fail because paths get too long
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
+  # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
+  # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
+  # through cygwin much easier.
+  #
+  # Note that the unruly /'s in the following string escape the following sequence to literal chars: "\" and then \""
+  plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
   plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -179,6 +179,12 @@ project "puppet-agent" do |proj|
   if platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"
     proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
+    proj.setting(:vs_version, '2017')
+    # The msbuild command needs to be surrounded in quotes and shelled
+    # out to cmd.exe because otherwise cygwin will treat the && in bash and
+    # fail. Even though the invocation of msbuild is in quotes, parameters
+    # sent to it don't need extra quotes or escaping.
+    proj.setting(:msbuild, "cmd.exe /C \"C:/tools/vsdevcmd.bat && msbuild\"")
     proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
     proj.setting(:tools_root, "C:/tools/pl-build-tools")
     proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")


### PR DESCRIPTION
This commit does some cleanup of the nssm build and msbuild commands. It
cleans things up in the following ways:

* We add a batch file under C:\tools\vsdevcmd.bat that acts as a link to the
vsdevcmd.bat file in visual studio (but without any spaces in the path to
escape)
* We update the project to add a :msbuild setting, that shells out to cmd.exe
and executes vsdevcmd.bat && msbuild
* We use the new :msbuild project setting in the nssm build