### PR TITLE
(PCP-778) Update nssm to use 2.x branch

### DIFF
--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/nssm.git", "ref": "b30ea2f69b1f4da23fb13c0748a5bca5b2bdcde9"}
+{"url": "git://github.com/puppetlabs/nssm.git", "ref": "2ad14eb370f16025fcc6db3123b523403d9e7886"}

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -7,7 +7,7 @@ component "nssm" do |pkg, settings, platform|
 
   pkg.install do
     [
-      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=./out /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}",
+      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=.\\out\\ /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}",
     ]
   end
 


### PR DESCRIPTION
This commit updates the nssm component to point to the 2.x branch of
puppetlabs/nssm

This commit also updates the OutDir parameter to msbuild to match msbuild
convention