### PR TITLE
(PCP-778) Fix \ escaping in nssm build

### DIFF
--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -7,7 +7,7 @@ component "nssm" do |pkg, settings, platform|
 
   pkg.install do
     [
-      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=.\\out\\ /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}",
+      "#{settings[:msbuild]} nssm.vcxproj /detailedsummary /p:Configuration=Release /p:OutDir=.\\\\out\\\\ /p:Platform=#{build_arch} /p:PlatformToolset=#{platform_toolset} /p:TargetPlatformVersion=#{target_platform_version}",
     ]
   end
 


### PR DESCRIPTION
we need to have the OutDir parameter in the msbuild line to be .\out\ when
msbuild gets it's hands on it. However between cygwin and ruby, we need to
escape a few times to get that exact string to msbuild and cmd.exe