### PR TITLE
(PA-1453) Add ruby 2.4.1 rbconfig for SLES 12 Power8

### DIFF
--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -53,6 +53,10 @@ component "ruby-2.4.1" do |pkg, settings, platform|
       :sum => "1689251a1631767daa1009e767cb2d73",
       :target_double => "powerpc64le-linux",
     },
+    'powerpc64le-suse-linux' => {
+      :sum => "00247ac1d0a9e59b1fcfb72025e7d628",
+      :target_double => "powerpc64le-linux",
+    },
     'powerpc64le-linux-gnu' => {
       :sum => "55e9426a06726f2baa82cc561f073fbf",
       :target_double => "powerpc64le-linux",

--- a/resources/files/ruby_241/rbconfig/rbconfig-powerpc64le-suse-linux.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-powerpc64le-suse-linux.rb
@@ -1,0 +1,313 @@
+# encoding: ascii-8bit
+# frozen-string-literal: false
+#
+# The module storing Ruby interpreter configurations on building.
+#
+# This file was created from a native ruby build on a SLES 12 SP2 ppc64le system.
+# It contains build information for ruby which is used e.g. by mkmf to build
+# compatible native extensions.  Any changes made to this file will be
+# lost the next time ruby is built.
+
+module RbConfig
+  RUBY_VERSION.start_with?("2.4.") or
+    raise "ruby lib version (2.4.1) doesn't match executable version (#{RUBY_VERSION})"
+
+  # Ruby installed directory.
+  TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.4.0/powerpc64le-linux")
+  # DESTDIR on make install.
+  DESTDIR = '' unless defined? DESTDIR
+  # The hash configurations stored.
+  CONFIG = {}
+  CONFIG["DESTDIR"] = DESTDIR
+  CONFIG["MAJOR"] = "2"
+  CONFIG["MINOR"] = "4"
+  CONFIG["TEENY"] = "1"
+  CONFIG["PATCHLEVEL"] = "111"
+  CONFIG["INSTALL"] = '/usr/bin/install -c'
+  CONFIG["EXEEXT"] = ""
+  CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
+  CONFIG["ruby_install_name"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_INSTALL_NAME"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_SO_NAME"] = "$(RUBY_BASE_NAME)"
+  CONFIG["exec"] = "exec"
+  CONFIG["ruby_pc"] = "ruby-2.4.pc"
+  CONFIG["PACKAGE"] = "ruby"
+  CONFIG["BUILTIN_TRANSSRCS"] = " enc/trans/newline.c"
+  CONFIG["USE_RUBYGEMS"] = "YES"
+  CONFIG["MANTYPE"] = "doc"
+  CONFIG["NROFF"] = "/usr/bin/nroff"
+  CONFIG["vendorarchhdrdir"] = "$(vendorhdrdir)/$(sitearch)"
+  CONFIG["sitearchhdrdir"] = "$(sitehdrdir)/$(sitearch)"
+  CONFIG["rubyarchhdrdir"] = "$(rubyhdrdir)/$(arch)"
+  CONFIG["vendorhdrdir"] = "$(rubyhdrdir)/vendor_ruby"
+  CONFIG["sitehdrdir"] = "$(rubyhdrdir)/site_ruby"
+  CONFIG["rubyhdrdir"] = "$(includedir)/$(RUBY_VERSION_NAME)"
+  CONFIG["RUBY_SEARCH_PATH"] = ""
+  CONFIG["UNIVERSAL_INTS"] = ""
+  CONFIG["UNIVERSAL_ARCHNAMES"] = ""
+  CONFIG["configure_args"] = " '--prefix=/opt/puppetlabs/puppet' '--with-opt-dir=/opt/puppetlabs/puppet' '--enable-shared' '--enable-bundled-libyaml' '--disable-install-doc' '--disable-install-rdoc'"
+  CONFIG["CONFIGURE"] = "configure"
+  CONFIG["vendorarchdir"] = "$(vendorlibdir)/$(sitearch)"
+  CONFIG["vendorlibdir"] = "$(vendordir)/$(ruby_version)"
+  CONFIG["vendordir"] = "$(rubylibprefix)/vendor_ruby"
+  CONFIG["sitearchdir"] = "$(sitelibdir)/$(sitearch)"
+  CONFIG["sitelibdir"] = "$(sitedir)/$(ruby_version)"
+  CONFIG["sitedir"] = "$(rubylibprefix)/site_ruby"
+  CONFIG["rubyarchdir"] = "$(rubylibdir)/$(arch)"
+  CONFIG["rubylibdir"] = "$(rubylibprefix)/$(ruby_version)"
+  CONFIG["ruby_version"] = "2.4.0"
+  CONFIG["sitearch"] = "$(arch)"
+  CONFIG["arch"] = "powerpc64le-linux"
+  CONFIG["sitearchincludedir"] = "$(includedir)/$(sitearch)"
+  CONFIG["archincludedir"] = "$(includedir)/$(arch)"
+  CONFIG["sitearchlibdir"] = "$(libdir)/$(sitearch)"
+  CONFIG["archlibdir"] = "$(libdir)/$(arch)"
+  CONFIG["libdirname"] = "libdir"
+  CONFIG["RUBY_EXEC_PREFIX"] = "/opt/puppetlabs/puppet"
+  CONFIG["RUBY_LIB_VERSION"] = ""
+  CONFIG["RUBY_LIB_VERSION_STYLE"] = "3\t/* full */"
+  CONFIG["RI_BASE_NAME"] = "ri"
+  CONFIG["ridir"] = "$(datarootdir)/$(RI_BASE_NAME)"
+  CONFIG["rubysitearchprefix"] = "$(rubylibprefix)/$(sitearch)"
+  CONFIG["rubyarchprefix"] = "$(rubylibprefix)/$(arch)"
+  CONFIG["MAKEFILES"] = "Makefile GNUmakefile"
+  CONFIG["PLATFORM_DIR"] = ""
+  CONFIG["THREAD_MODEL"] = "pthread"
+  CONFIG["SYMBOL_PREFIX"] = ""
+  CONFIG["EXPORT_PREFIX"] = ""
+  CONFIG["COMMON_HEADERS"] = ""
+  CONFIG["COMMON_MACROS"] = ""
+  CONFIG["COMMON_LIBS"] = ""
+  CONFIG["MAINLIBS"] = ""
+  CONFIG["ENABLE_SHARED"] = "yes"
+  CONFIG["DLDLIBS"] = " -lc"
+  CONFIG["SOLIBS"] = "$(LIBS)"
+  CONFIG["LIBRUBYARG_SHARED"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)"
+  CONFIG["LIBRUBYARG_STATIC"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)-static"
+  CONFIG["LIBRUBYARG"] = "$(LIBRUBYARG_SHARED)"
+  CONFIG["LIBRUBY"] = "$(LIBRUBY_SO)"
+  CONFIG["LIBRUBY_ALIASES"] = "lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR) lib$(RUBY_SO_NAME).so"
+  CONFIG["LIBRUBY_SO"] = "lib$(RUBY_SO_NAME).so.$(RUBY_PROGRAM_VERSION)"
+  CONFIG["LIBRUBY_A"] = "lib$(RUBY_SO_NAME)-static.a"
+  CONFIG["RUBYW_INSTALL_NAME"] = ""
+  CONFIG["rubyw_install_name"] = ""
+  CONFIG["EXTDLDFLAGS"] = ""
+  CONFIG["EXTLDFLAGS"] = ""
+  CONFIG["strict_warnflags"] = "-std=gnu99"
+  CONFIG["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format"
+  CONFIG["debugflags"] = "-ggdb3"
+  CONFIG["optflags"] = "-O3 -fno-fast-math"
+  CONFIG["NULLCMD"] = ":"
+  CONFIG["DLNOBJ"] = "dln.o"
+  CONFIG["INSTALL_STATIC_LIBRARY"] = "no"
+  CONFIG["EXECUTABLE_EXTS"] = ""
+  CONFIG["ARCHFILE"] = ""
+  CONFIG["LIBRUBY_RELATIVE"] = "no"
+  CONFIG["EXTOUT"] = ".ext"
+  CONFIG["PREP"] = "miniruby$(EXEEXT)"
+  CONFIG["CROSS_COMPILING"] = "no"
+  CONFIG["TEST_RUNNABLE"] = "yes"
+  CONFIG["rubylibprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"
+  CONFIG["setup"] = "Setup"
+  CONFIG["ENCSTATIC"] = ""
+  CONFIG["EXTSTATIC"] = ""
+  CONFIG["STRIP"] = "strip -S -x"
+  CONFIG["TRY_LINK"] = ""
+  CONFIG["PRELOADENV"] = "LD_PRELOAD"
+  CONFIG["LIBPATHENV"] = "LD_LIBRARY_PATH"
+  CONFIG["RPATHFLAG"] = " -Wl,-R%1$-s"
+  CONFIG["LIBPATHFLAG"] = " -L%1$-s"
+  CONFIG["LINK_SO"] = ""
+  CONFIG["ASMEXT"] = "S"
+  CONFIG["LIBEXT"] = "a"
+  CONFIG["DLEXT2"] = ""
+  CONFIG["DLEXT"] = "so"
+  CONFIG["LDSHAREDXX"] = "$(CXX) -shared"
+  CONFIG["LDSHARED"] = "$(CC) -shared"
+  CONFIG["CCDLFLAGS"] = "-fPIC"
+  CONFIG["STATIC"] = ""
+  CONFIG["ARCH_FLAG"] = ""
+  CONFIG["DLDFLAGS"] = "-Wl,--compress-debug-sections=zlib -L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
+  CONFIG["ALLOCA"] = ""
+  CONFIG["codesign"] = ""
+  CONFIG["POSTLINK"] = ":"
+  CONFIG["WERRORFLAG"] = "-Werror"
+  CONFIG["CHDIR"] = "cd -P"
+  CONFIG["RMALL"] = "rm -fr"
+  CONFIG["RMDIRS"] = "rmdir --ignore-fail-on-non-empty -p"
+  CONFIG["RMDIR"] = "rmdir --ignore-fail-on-non-empty"
+  CONFIG["CP"] = "cp"
+  CONFIG["RM"] = "rm -f"
+  CONFIG["PKG_CONFIG"] = "pkg-config"
+  CONFIG["PYTHON"] = ""
+  CONFIG["DOXYGEN"] = ""
+  CONFIG["DOT"] = ""
+  CONFIG["MAKEDIRS"] = "/usr/bin/mkdir -p"
+  CONFIG["MKDIR_P"] = "/usr/bin/mkdir -p"
+  CONFIG["INSTALL_DATA"] = "$(INSTALL) -m 644"
+  CONFIG["INSTALL_SCRIPT"] = "$(INSTALL)"
+  CONFIG["INSTALL_PROGRAM"] = "$(INSTALL)"
+  CONFIG["SET_MAKE"] = ""
+  CONFIG["LN_S"] = "ln -s"
+  CONFIG["NM"] = "nm"
+  CONFIG["DLLWRAP"] = ""
+  CONFIG["WINDRES"] = ""
+  CONFIG["OBJCOPY"] = ":"
+  CONFIG["OBJDUMP"] = "objdump"
+  CONFIG["ASFLAGS"] = ""
+  CONFIG["AS"] = "as"
+  CONFIG["ARFLAGS"] = "rcD "
+  CONFIG["AR"] = "ar"
+  CONFIG["RANLIB"] = "ranlib"
+  CONFIG["try_header"] = ""
+  CONFIG["CC_VERSION_MESSAGE"] = "gcc (SUSE Linux) 4.8.5\nCopyright (C) 2015 Free Software Foundation, Inc.\nThis is free software; see the source for copying conditions.  There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+  CONFIG["CC_VERSION"] = "$(CC) --version"
+  CONFIG["CSRCFLAG"] = ""
+  CONFIG["COUTFLAG"] = "-o "
+  CONFIG["OUTFLAG"] = "-o "
+  CONFIG["CPPOUTFILE"] = "-o conftest.i"
+  CONFIG["GNU_LD"] = "yes"
+  CONFIG["LD"] = "ld"
+  CONFIG["GCC"] = "yes"
+  CONFIG["EGREP"] = "/usr/bin/grep -E"
+  CONFIG["GREP"] = "/usr/bin/grep"
+  CONFIG["CPP"] = "$(CC) -E"
+  CONFIG["CXXFLAGS"] = "$(cxxflags)"
+  CONFIG["OBJEXT"] = "o"
+  CONFIG["CPPFLAGS"] = " -I/opt/puppetlabs/puppet/include $(DEFS) $(cppflags)"
+  CONFIG["LDFLAGS"] = "-L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
+  CONFIG["CFLAGS"] = "$(cflags)  -fPIC"
+  CONFIG["CXX"] = "g++"
+  CONFIG["CC"] = "gcc"
+  CONFIG["NACL_LIB_PATH"] = ""
+  CONFIG["NACL_SDK_VARIANT"] = ""
+  CONFIG["NACL_SDK_ROOT"] = ""
+  CONFIG["NACL_TOOLCHAIN"] = ""
+  CONFIG["target_os"] = "linux"
+  CONFIG["target_vendor"] = "unknown"
+  CONFIG["target_cpu"] = "powerpc64le"
+  CONFIG["target"] = "powerpc64le-unknown-linux-gnu"
+  CONFIG["host_os"] = "linux-gnu"
+  CONFIG["host_vendor"] = "unknown"
+  CONFIG["host_cpu"] = "powerpc64le"
+  CONFIG["host"] = "powerpc64le-unknown-linux-gnu"
+  CONFIG["RUBY_VERSION_NAME"] = "$(RUBY_BASE_NAME)-$(ruby_version)"
+  CONFIG["RUBYW_BASE_NAME"] = "rubyw"
+  CONFIG["RUBY_BASE_NAME"] = "ruby"
+  CONFIG["build_os"] = "linux-gnu"
+  CONFIG["build_vendor"] = "unknown"
+  CONFIG["build_cpu"] = "powerpc64le"
+  CONFIG["build"] = "powerpc64le-unknown-linux-gnu"
+  CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.1"
+  CONFIG["cxxflags"] = "$(optflags) $(debugflags) $(warnflags)"
+  CONFIG["cppflags"] = ""
+  CONFIG["cflags"] = "$(optflags) $(debugflags) $(warnflags)"
+  CONFIG["target_alias"] = ""
+  CONFIG["host_alias"] = ""
+  CONFIG["build_alias"] = ""
+  CONFIG["LIBS"] = "-lpthread -ldl -lcrypt -lm "
+  CONFIG["ECHO_T"] = ""
+  CONFIG["ECHO_N"] = "-n"
+  CONFIG["ECHO_C"] = ""
+  CONFIG["DEFS"] = ""
+  CONFIG["mandir"] = "$(datarootdir)/man"
+  CONFIG["localedir"] = "$(datarootdir)/locale"
+  CONFIG["libdir"] = "$(exec_prefix)/lib"
+  CONFIG["psdir"] = "$(docdir)"
+  CONFIG["pdfdir"] = "$(docdir)"
+  CONFIG["dvidir"] = "$(docdir)"
+  CONFIG["htmldir"] = "$(docdir)"
+  CONFIG["infodir"] = "$(datarootdir)/info"
+  CONFIG["docdir"] = "$(datarootdir)/doc/$(PACKAGE)"
+  CONFIG["oldincludedir"] = "/usr/include"
+  CONFIG["includedir"] = "$(prefix)/include"
+  CONFIG["localstatedir"] = "$(prefix)/var"
+  CONFIG["sharedstatedir"] = "$(prefix)/com"
+  CONFIG["sysconfdir"] = "$(prefix)/etc"
+  CONFIG["datadir"] = "$(datarootdir)"
+  CONFIG["datarootdir"] = "$(prefix)/share"
+  CONFIG["libexecdir"] = "$(exec_prefix)/libexec"
+  CONFIG["sbindir"] = "$(exec_prefix)/sbin"
+  CONFIG["bindir"] = "$(exec_prefix)/bin"
+  CONFIG["exec_prefix"] = "$(prefix)"
+  CONFIG["PACKAGE_URL"] = ""
+  CONFIG["PACKAGE_BUGREPORT"] = ""
+  CONFIG["PACKAGE_STRING"] = ""
+  CONFIG["PACKAGE_VERSION"] = ""
+  CONFIG["PACKAGE_TARNAME"] = ""
+  CONFIG["PACKAGE_NAME"] = ""
+  CONFIG["PATH_SEPARATOR"] = ":"
+  CONFIG["SHELL"] = "/bin/sh"
+  CONFIG["UNICODE_VERSION"] = "9.0.0"
+  CONFIG["archdir"] = "$(rubyarchdir)"
+  CONFIG["topdir"] = File.dirname(__FILE__)
+  # Almost same with CONFIG. MAKEFILE_CONFIG has other variable
+  # reference like below.
+  #
+  #   MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
+  #
+  # The values of this constant is used for creating Makefile.
+  #
+  #   require 'rbconfig'
+  #
+  #   print <<-END_OF_MAKEFILE
+  #   prefix = #{Config::MAKEFILE_CONFIG['prefix']}
+  #   exec_prefix = #{Config::MAKEFILE_CONFIG['exec_prefix']}
+  #   bindir = #{Config::MAKEFILE_CONFIG['bindir']}
+  #   END_OF_MAKEFILE
+  #
+  #   => prefix = /usr/local
+  #      exec_prefix = $(prefix)
+  #      bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
+  #
+  # RbConfig.expand is used for resolving references like above in rbconfig.
+  #
+  #   require 'rbconfig'
+  #   p Config.expand(Config::MAKEFILE_CONFIG["bindir"])
+  #   # => "/usr/local/bin"
+  MAKEFILE_CONFIG = {}
+  CONFIG.each{|k,v| MAKEFILE_CONFIG[k] = v.dup}
+
+  # call-seq:
+  #
+  #   RbConfig.expand(val)         -> string
+  #   RbConfig.expand(val, config) -> string
+  #
+  # expands variable with given +val+ value.
+  #
+  #   RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
+  def RbConfig::expand(val, config = CONFIG)
+    newval = val.gsub(/\$\$|\$\(([^()]+)\)|\$\{([^{}]+)\}/) {
+      var = $&
+      if !(v = $1 || $2)
+	'$'
+      elsif key = config[v = v[/\A[^:]+(?=(?::(.*?)=(.*))?\z)/]]
+	pat, sub = $1, $2
+	config[v] = false
+	config[v] = RbConfig::expand(key, config)
+	key = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
+	key
+      else
+	var
+      end
+    }
+    val.replace(newval) unless newval == val
+    val
+  end
+  CONFIG.each_value do |val|
+    RbConfig::expand(val)
+  end
+
+  # call-seq:
+  #
+  #   RbConfig.ruby -> path
+  #
+  # returns the absolute pathname of the ruby command.
+  def RbConfig.ruby
+    File.join(
+      RbConfig::CONFIG["bindir"],
+      RbConfig::CONFIG["ruby_install_name"] + RbConfig::CONFIG["EXEEXT"]
+    )
+  end
+end
+CROSS_COMPILING = nil unless defined? CROSS_COMPILING


### PR DESCRIPTION
Since this platform was merged-up from the 1.10.x branch which uses
ruby 2.1.9, this commit is also needed to get this platform to build
from the 5.1.x branch.

I have smoke tested an agent built with this commit and verified its ruby environment is working properly with rubygems, including gem installs with native extensions.