### PR TITLE
(maint) Disable locales for libwhereami on cisco

### DIFF
--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -24,6 +24,10 @@ component "libwhereami" do |pkg, settings, platform|
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+
+    if platform.is_cisco_wrlinux?
+      special_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
+    end
   end
 
   # Until we build our own gettext packages, disable using locales.


### PR DESCRIPTION
Locales shouldn't be included on Cisco - this built cleanly for me on 5 and 7