### PR TITLE
(PA-1462) rbconfig fixes for RHEL 7 Power8

### DIFF
--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -50,7 +50,7 @@ component "ruby-2.4.1" do |pkg, settings, platform|
       :target_double => "powerpc-linux",
     },
     'ppc64le-redhat-linux' => {
-      :sum => "1689251a1631767daa1009e767cb2d73",
+      :sum => "75f856df15c48c50514c803947f60bf9",
       :target_double => "powerpc64le-linux",
     },
     'powerpc64le-linux-gnu' => {

--- a/resources/files/ruby_241/rbconfig/rbconfig-ppc64le-redhat-linux.rb
+++ b/resources/files/ruby_241/rbconfig/rbconfig-ppc64le-redhat-linux.rb
@@ -1,12 +1,22 @@
+# encoding: ascii-8bit
+# frozen-string-literal: false
+#
+# The module storing Ruby interpreter configurations on building.
+#
 # This file was created from a native ruby build on a RHEL 7.3 ppc64le system.
-# Any changes made to this file will be lost the next time ruby is built.
+# It contains build information for ruby which is used e.g. by mkmf to build
+# compatible native extensions.  Any changes made to this file will be
+# lost the next time ruby is built.
 
 module RbConfig
-  RUBY_VERSION == "2.4.1" or
+  RUBY_VERSION.start_with?("2.4.") or
     raise "ruby lib version (2.4.1) doesn't match executable version (#{RUBY_VERSION})"
 
-  TOPDIR = File.dirname(__FILE__).chomp!("/lib64/ruby/")
+  # Ruby installed directory.
+  TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.4.0/powerpc64le-linux")
+  # DESTDIR on make install.
   DESTDIR = '' unless defined? DESTDIR
+  # The hash configurations stored.
   CONFIG = {}
   CONFIG["DESTDIR"] = DESTDIR
   CONFIG["MAJOR"] = "2"
@@ -16,33 +26,34 @@ module RbConfig
   CONFIG["INSTALL"] = '/usr/bin/install -c'
   CONFIG["EXEEXT"] = ""
   CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
-  CONFIG["ruby_install_name"] = "ruby"
-  CONFIG["RUBY_INSTALL_NAME"] = "ruby"
-  CONFIG["RUBY_SO_NAME"] = "ruby"
+  CONFIG["ruby_install_name"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_INSTALL_NAME"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_SO_NAME"] = "$(RUBY_BASE_NAME)"
   CONFIG["exec"] = "exec"
-  CONFIG["ruby_pc"] = "ruby.pc"
+  CONFIG["ruby_pc"] = "ruby-2.4.pc"
   CONFIG["PACKAGE"] = "ruby"
-  CONFIG["BUILTIN_TRANSSRCS"] = " newline.c"
+  CONFIG["BUILTIN_TRANSSRCS"] = " enc/trans/newline.c"
   CONFIG["USE_RUBYGEMS"] = "YES"
   CONFIG["MANTYPE"] = "doc"
   CONFIG["NROFF"] = "/usr/bin/nroff"
-  CONFIG["OPTIONAL_PRELUDES"] = "./abrt_prelude.rb"
-  CONFIG["vendorarchhdrdir"] = "$(vendorhdrdir)/$(arch)"
-  CONFIG["sitearchhdrdir"] = "$(sitehdrdir)/$(arch)"
-  CONFIG["rubyarchhdrdir"] = "$(DESTDIR)/usr/include"
+  CONFIG["vendorarchhdrdir"] = "$(vendorhdrdir)/$(sitearch)"
+  CONFIG["sitearchhdrdir"] = "$(sitehdrdir)/$(sitearch)"
+  CONFIG["rubyarchhdrdir"] = "$(rubyhdrdir)/$(arch)"
   CONFIG["vendorhdrdir"] = "$(rubyhdrdir)/vendor_ruby"
   CONFIG["sitehdrdir"] = "$(rubyhdrdir)/site_ruby"
-  CONFIG["rubyhdrdir"] = "$(DESTDIR)/usr/include"
+  CONFIG["rubyhdrdir"] = "$(includedir)/$(RUBY_VERSION_NAME)"
+  CONFIG["RUBY_SEARCH_PATH"] = ""
   CONFIG["UNIVERSAL_INTS"] = ""
   CONFIG["UNIVERSAL_ARCHNAMES"] = ""
   CONFIG["configure_args"] = " '--prefix=/opt/puppetlabs/puppet' '--with-opt-dir=/opt/puppetlabs/puppet' '--enable-shared' '--enable-bundled-libyaml' '--disable-install-doc' '--disable-install-rdoc'"
-  CONFIG["vendorarchdir"] = "$(DESTDIR)/usr/lib64/ruby/vendor_ruby"
+  CONFIG["CONFIGURE"] = "configure"
+  CONFIG["vendorarchdir"] = "$(vendorlibdir)/$(sitearch)"
   CONFIG["vendorlibdir"] = "$(vendordir)/$(ruby_version)"
-  CONFIG["vendordir"] = "$(DESTDIR)/usr/share/ruby/vendor_ruby"
-  CONFIG["sitearchdir"] = "$(DESTDIR)/usr/local/lib64/ruby/site_ruby"
+  CONFIG["vendordir"] = "$(rubylibprefix)/vendor_ruby"
+  CONFIG["sitearchdir"] = "$(sitelibdir)/$(sitearch)"
   CONFIG["sitelibdir"] = "$(sitedir)/$(ruby_version)"
-  CONFIG["sitedir"] = "$(DESTDIR)/usr/local/share/ruby/site_ruby"
-  CONFIG["rubyarchdir"] = "$(rubyarchprefix)/$(ruby_version)"
+  CONFIG["sitedir"] = "$(rubylibprefix)/site_ruby"
+  CONFIG["rubyarchdir"] = "$(rubylibdir)/$(arch)"
   CONFIG["rubylibdir"] = "$(rubylibprefix)/$(ruby_version)"
   CONFIG["ruby_version"] = "2.4.0"
   CONFIG["sitearch"] = "$(arch)"
@@ -51,12 +62,15 @@ module RbConfig
   CONFIG["archincludedir"] = "$(includedir)/$(arch)"
   CONFIG["sitearchlibdir"] = "$(libdir)/$(sitearch)"
   CONFIG["archlibdir"] = "$(libdir)/$(arch)"
+  CONFIG["libdirname"] = "libdir"
+  CONFIG["RUBY_EXEC_PREFIX"] = "/opt/puppetlabs/puppet"
+  CONFIG["RUBY_LIB_VERSION"] = ""
+  CONFIG["RUBY_LIB_VERSION_STYLE"] = "3\t/* full */"
   CONFIG["RI_BASE_NAME"] = "ri"
   CONFIG["ridir"] = "$(datarootdir)/$(RI_BASE_NAME)"
-  CONFIG["rubysitearchprefix"] = "$(sitearchlibdir)/$(RUBY_BASE_NAME)"
-  CONFIG["rubyarchprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"
-  CONFIG["rubylibprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"
-  CONFIG["MAKEFILES"] = "Makefile"
+  CONFIG["rubysitearchprefix"] = "$(rubylibprefix)/$(sitearch)"
+  CONFIG["rubyarchprefix"] = "$(rubylibprefix)/$(arch)"
+  CONFIG["MAKEFILES"] = "Makefile GNUmakefile"
   CONFIG["PLATFORM_DIR"] = ""
   CONFIG["THREAD_MODEL"] = "pthread"
   CONFIG["SYMBOL_PREFIX"] = ""
@@ -68,51 +82,43 @@ module RbConfig
   CONFIG["ENABLE_SHARED"] = "yes"
   CONFIG["DLDLIBS"] = " -lc"
   CONFIG["SOLIBS"] = "$(LIBS)"
-  CONFIG["LIBRUBYARG_SHARED"] = "-l$(RUBY_SO_NAME)"
-  CONFIG["LIBRUBYARG_STATIC"] = "-l$(RUBY_SO_NAME)-static"
+  CONFIG["LIBRUBYARG_SHARED"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)"
+  CONFIG["LIBRUBYARG_STATIC"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)-static"
   CONFIG["LIBRUBYARG"] = "$(LIBRUBYARG_SHARED)"
   CONFIG["LIBRUBY"] = "$(LIBRUBY_SO)"
   CONFIG["LIBRUBY_ALIASES"] = "lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR) lib$(RUBY_SO_NAME).so"
-  CONFIG["LIBRUBY_SO"] = "lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR).$(TEENY)"
+  CONFIG["LIBRUBY_SO"] = "lib$(RUBY_SO_NAME).so.$(RUBY_PROGRAM_VERSION)"
   CONFIG["LIBRUBY_A"] = "lib$(RUBY_SO_NAME)-static.a"
   CONFIG["RUBYW_INSTALL_NAME"] = ""
   CONFIG["rubyw_install_name"] = ""
-  CONFIG["LIBRUBY_DLDFLAGS"] = "-Wl,-soname,lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR) "
-  CONFIG["LIBRUBY_LDSHARED"] = "$(CC) -shared"
   CONFIG["EXTDLDFLAGS"] = ""
   CONFIG["EXTLDFLAGS"] = ""
-  CONFIG["strict_warnflags"] = "-ansi -std=iso9899:199409"
-  CONFIG["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wunused-variable -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration"
+  CONFIG["strict_warnflags"] = "-std=gnu99"
+  CONFIG["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format"
   CONFIG["debugflags"] = "-ggdb3"
   CONFIG["optflags"] = "-O3 -fno-fast-math"
-  CONFIG["cxxflags"] = " $(optflags) $(debugflags) $(warnflags)"
-  CONFIG["cflags"] = " $(optflags) $(debugflags) $(warnflags)"
-  CONFIG["cppflags"] = ""
   CONFIG["NULLCMD"] = ":"
   CONFIG["DLNOBJ"] = "dln.o"
-  CONFIG["INSTALLDOC"] = "all"
-  CONFIG["CAPITARGET"] = "nodoc"
-  CONFIG["RDOCTARGET"] = "rdoc"
-  CONFIG["DTRACE_GLOMMED_OBJ"] = "ruby-glommed.$(OBJEXT)"
-  CONFIG["DTRACE_OBJ"] = "probes.$(OBJEXT)"
-  CONFIG["DTRACE_EXT"] = "d"
+  CONFIG["INSTALL_STATIC_LIBRARY"] = "no"
   CONFIG["EXECUTABLE_EXTS"] = ""
   CONFIG["ARCHFILE"] = ""
   CONFIG["LIBRUBY_RELATIVE"] = "no"
   CONFIG["EXTOUT"] = ".ext"
-  CONFIG["RUNRUBY_COMMAND"] = "$(MINIRUBY) $(srcdir)/tool/runruby.rb --extout=$(EXTOUT) $(RUNRUBYOPT)"
   CONFIG["PREP"] = "miniruby$(EXEEXT)"
-  CONFIG["BTESTRUBY"] = "$(MINIRUBY)"
   CONFIG["CROSS_COMPILING"] = "no"
   CONFIG["TEST_RUNNABLE"] = "yes"
+  CONFIG["rubylibprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"
   CONFIG["setup"] = "Setup"
+  CONFIG["ENCSTATIC"] = ""
   CONFIG["EXTSTATIC"] = ""
   CONFIG["STRIP"] = "strip -S -x"
   CONFIG["TRY_LINK"] = ""
+  CONFIG["PRELOADENV"] = "LD_PRELOAD"
   CONFIG["LIBPATHENV"] = "LD_LIBRARY_PATH"
-  CONFIG["RPATHFLAG"] = ""
-  CONFIG["LIBPATHFLAG"] = " -L%s"
+  CONFIG["RPATHFLAG"] = " -Wl,-R%1$-s"
+  CONFIG["LIBPATHFLAG"] = " -L%1$-s"
   CONFIG["LINK_SO"] = ""
+  CONFIG["ASMEXT"] = "S"
   CONFIG["LIBEXT"] = "a"
   CONFIG["DLEXT2"] = ""
   CONFIG["DLEXT"] = "so"
@@ -120,8 +126,8 @@ module RbConfig
   CONFIG["LDSHARED"] = "$(CC) -shared"
   CONFIG["CCDLFLAGS"] = "-fPIC"
   CONFIG["STATIC"] = ""
-  CONFIG["ARCH_FLAG"] = "-m64"
-  CONFIG["DLDFLAGS"] = "-L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib "
+  CONFIG["ARCH_FLAG"] = ""
+  CONFIG["DLDFLAGS"] = "-L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
   CONFIG["ALLOCA"] = ""
   CONFIG["codesign"] = ""
   CONFIG["POSTLINK"] = ":"
@@ -136,7 +142,6 @@ module RbConfig
   CONFIG["PYTHON"] = ""
   CONFIG["DOXYGEN"] = ""
   CONFIG["DOT"] = ""
-  CONFIG["DTRACE"] = "dtrace"
   CONFIG["MAKEDIRS"] = "/usr/bin/mkdir -p"
   CONFIG["MKDIR_P"] = "/usr/bin/mkdir -p"
   CONFIG["INSTALL_DATA"] = "$(INSTALL) -m 644"
@@ -151,9 +156,13 @@ module RbConfig
   CONFIG["OBJDUMP"] = "objdump"
   CONFIG["ASFLAGS"] = ""
   CONFIG["AS"] = "as"
+  CONFIG["ARFLAGS"] = "rcD "
   CONFIG["AR"] = "ar"
   CONFIG["RANLIB"] = "ranlib"
   CONFIG["try_header"] = ""
+  CONFIG["CC_VERSION_MESSAGE"] = "gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16)\nCopyright (C) 2015 Free Software Foundation, Inc.\nThis is free software; see the source for copying conditions.  There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+  CONFIG["CC_VERSION"] = "$(CC) --version"
+  CONFIG["CSRCFLAG"] = ""
   CONFIG["COUTFLAG"] = "-o "
   CONFIG["OUTFLAG"] = "-o "
   CONFIG["CPPOUTFILE"] = "-o conftest.i"
@@ -163,59 +172,62 @@ module RbConfig
   CONFIG["EGREP"] = "/usr/bin/grep -E"
   CONFIG["GREP"] = "/usr/bin/grep"
   CONFIG["CPP"] = "$(CC) -E"
-  CONFIG["CXXFLAGS"] = "-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mcpu=power7 -mtune=power8"
-  CONFIG["CXX"] = "g++"
+  CONFIG["CXXFLAGS"] = "$(cxxflags)"
   CONFIG["OBJEXT"] = "o"
   CONFIG["CPPFLAGS"] = " -I/opt/puppetlabs/puppet/include $(DEFS) $(cppflags)"
-  CONFIG["LDFLAGS"] = "-L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib "
-  CONFIG["CFLAGS"] = "-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mcpu=power7 -mtune=power8 -fPIC"
+  CONFIG["LDFLAGS"] = "-L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
+  CONFIG["CFLAGS"] = "$(cflags)  -fPIC"
+  CONFIG["CXX"] = "g++"
   CONFIG["CC"] = "gcc"
+  CONFIG["NACL_LIB_PATH"] = ""
   CONFIG["NACL_SDK_VARIANT"] = ""
   CONFIG["NACL_SDK_ROOT"] = ""
   CONFIG["NACL_TOOLCHAIN"] = ""
   CONFIG["target_os"] = "linux"
-  CONFIG["target_vendor"] = "redhat"
+  CONFIG["target_vendor"] = "unknown"
   CONFIG["target_cpu"] = "powerpc64le"
   CONFIG["target"] = "powerpc64le-redhat-linux-gnu"
   CONFIG["host_os"] = "linux-gnu"
-  CONFIG["host_vendor"] = "redhat"
+  CONFIG["host_vendor"] = "unknown"
   CONFIG["host_cpu"] = "powerpc64le"
   CONFIG["host"] = "powerpc64le-redhat-linux-gnu"
   CONFIG["RUBY_VERSION_NAME"] = "$(RUBY_BASE_NAME)-$(ruby_version)"
   CONFIG["RUBYW_BASE_NAME"] = "rubyw"
   CONFIG["RUBY_BASE_NAME"] = "ruby"
   CONFIG["build_os"] = "linux-gnu"
-  CONFIG["build_vendor"] = "redhat"
+  CONFIG["build_vendor"] = "unknown"
   CONFIG["build_cpu"] = "powerpc64le"
   CONFIG["build"] = "powerpc64le-redhat-linux-gnu"
-  CONFIG["RUBY_RELEASE_DATE"] = "2015-12-16"
-  CONFIG["RUBY_PROGRAM_VERSION"] = "2.0.0"
+  CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.1"
+  CONFIG["cxxflags"] = "$(optflags) $(debugflags) $(warnflags)"
+  CONFIG["cppflags"] = ""
+  CONFIG["cflags"] = "$(optflags) $(debugflags) $(warnflags)"
   CONFIG["target_alias"] = ""
-  CONFIG["host_alias"] = "ppc64le-redhat-linux-gnu"
-  CONFIG["build_alias"] = "ppc64le-redhat-linux-gnu"
-  CONFIG["LIBS"] = "-lpthread -lrt -ldl -lcrypt -lm "
+  CONFIG["host_alias"] = ""
+  CONFIG["build_alias"] = ""
+  CONFIG["LIBS"] = "-lpthread -ldl -lcrypt -lm "
   CONFIG["ECHO_T"] = ""
   CONFIG["ECHO_N"] = "-n"
   CONFIG["ECHO_C"] = ""
   CONFIG["DEFS"] = ""
-  CONFIG["mandir"] = "$(DESTDIR)/usr/share/man"
+  CONFIG["mandir"] = "$(datarootdir)/man"
   CONFIG["localedir"] = "$(datarootdir)/locale"
   CONFIG["libdir"] = "$(exec_prefix)/lib"
   CONFIG["psdir"] = "$(docdir)"
   CONFIG["pdfdir"] = "$(docdir)"
   CONFIG["dvidir"] = "$(docdir)"
   CONFIG["htmldir"] = "$(docdir)"
-  CONFIG["infodir"] = "$(DESTDIR)/usr/share/info"
+  CONFIG["infodir"] = "$(datarootdir)/info"
   CONFIG["docdir"] = "$(datarootdir)/doc/$(PACKAGE)"
   CONFIG["oldincludedir"] = "/usr/include"
-  CONFIG["includedir"] = "$(DESTDIR)/usr/include"
-  CONFIG["localstatedir"] = "$(DESTDIR)/var"
-  CONFIG["sharedstatedir"] = "$(DESTDIR)/var/lib"
-  CONFIG["sysconfdir"] = "$(DESTDIR)/etc"
-  CONFIG["datadir"] = "$(DESTDIR)/usr/share"
+  CONFIG["includedir"] = "$(prefix)/include"
+  CONFIG["localstatedir"] = "$(prefix)/var"
+  CONFIG["sharedstatedir"] = "$(prefix)/com"
+  CONFIG["sysconfdir"] = "$(prefix)/etc"
+  CONFIG["datadir"] = "$(datarootdir)"
   CONFIG["datarootdir"] = "$(prefix)/share"
-  CONFIG["libexecdir"] = "$(DESTDIR)/usr/libexec"
-  CONFIG["sbindir"] = "$(DESTDIR)/usr/sbin"
+  CONFIG["libexecdir"] = "$(exec_prefix)/libexec"
+  CONFIG["sbindir"] = "$(exec_prefix)/sbin"
   CONFIG["bindir"] = "$(exec_prefix)/bin"
   CONFIG["exec_prefix"] = "$(prefix)"
   CONFIG["PACKAGE_URL"] = ""
@@ -226,10 +238,44 @@ module RbConfig
   CONFIG["PACKAGE_NAME"] = ""
   CONFIG["PATH_SEPARATOR"] = ":"
   CONFIG["SHELL"] = "/bin/sh"
+  CONFIG["UNICODE_VERSION"] = "9.0.0"
   CONFIG["archdir"] = "$(rubyarchdir)"
   CONFIG["topdir"] = File.dirname(__FILE__)
+  # Almost same with CONFIG. MAKEFILE_CONFIG has other variable
+  # reference like below.
+  #
+  #   MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
+  #
+  # The values of this constant is used for creating Makefile.
+  #
+  #   require 'rbconfig'
+  #
+  #   print <<-END_OF_MAKEFILE
+  #   prefix = #{Config::MAKEFILE_CONFIG['prefix']}
+  #   exec_prefix = #{Config::MAKEFILE_CONFIG['exec_prefix']}
+  #   bindir = #{Config::MAKEFILE_CONFIG['bindir']}
+  #   END_OF_MAKEFILE
+  #
+  #   => prefix = /usr/local
+  #      exec_prefix = $(prefix)
+  #      bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
+  #
+  # RbConfig.expand is used for resolving references like above in rbconfig.
+  #
+  #   require 'rbconfig'
+  #   p Config.expand(Config::MAKEFILE_CONFIG["bindir"])
+  #   # => "/usr/local/bin"
   MAKEFILE_CONFIG = {}
   CONFIG.each{|k,v| MAKEFILE_CONFIG[k] = v.dup}
+
+  # call-seq:
+  #
+  #   RbConfig.expand(val)         -> string
+  #   RbConfig.expand(val, config) -> string
+  #
+  # expands variable with given +val+ value.
+  #
+  #   RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
   def RbConfig::expand(val, config = CONFIG)
     newval = val.gsub(/\$\$|\$\(([^()]+)\)|\$\{([^{}]+)\}/) {
       var = $&
@@ -252,6 +298,10 @@ module RbConfig
     RbConfig::expand(val)
   end
 
+  # call-seq:
+  #
+  #   RbConfig.ruby -> path
+  #
   # returns the absolute pathname of the ruby command.
   def RbConfig.ruby
     File.join(
@@ -260,5 +310,4 @@ module RbConfig
     )
   end
 end
-autoload :Config, "rbconfig/obsolete.rb" # compatibility for ruby-1.8.4 and older.
 CROSS_COMPILING = nil unless defined? CROSS_COMPILING


### PR DESCRIPTION
This resolves problems with RHEL 7 Power8 agents being unable to
build native gem extensions.

I've tested this by building an agent package and smoke testing the agent, including its ruby environment and testing building a gem with native extensions (sqlite3).