### PR TITLE
(PUP-7881) Update gettext to fix Japanese error output

### DIFF
--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -1,6 +1,6 @@
 component "rubygem-gettext-setup" do |pkg, settings, platform|
-  pkg.version "0.24"
-  pkg.md5sum "f766a5e12bbad9f85905638c500e08f6"
+  pkg.version "0.27"
+  pkg.md5sum "4c73638ed1371d7406e6adc58985b96e"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
   pkg.mirror "http://buildsources.delivery.puppetlabs.net/gettext-setup-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
This updates gettext-setup to a version where English is the initial
state for the locale, rather than a random locale based on the order in
which translation files were found.