### PR TITLE
(maint) Bump libwhereami with fix for 32-bit platforms

### DIFF
--- a/configs/components/libwhereami.json
+++ b/configs/components/libwhereami.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/libwhereami.git", "ref": "0.1.0"}
+{"url": "git://github.com/puppetlabs/libwhereami.git", "ref": "ebbb62bbcbc2e9d1c063cef70b1ec5903ebd1889"}


### PR DESCRIPTION
Bumps to an untagged version of libwhereami to get a potential fix for
32-bit platform builds.