### PR TITLE
Revert "(maint) Enable SLES 12 Power8 builds in nightlies"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -28,7 +28,6 @@ foss_platforms:
   - sles-11-i386
   - sles-11-x86_64
   - sles-12-x86_64
-  - sles-12-ppc64le
   - ubuntu-14.04-amd64
   - ubuntu-14.04-i386
   - ubuntu-16.04-amd64
@@ -78,8 +77,6 @@ platform_repos:
     repo_location: repos/sles/11/**/i386
   - name: sles-11-x86_64
     repo_location: repos/sles/11/**/x86_64
-  - name: sles-12-ppc64le
-    repo_location: repos/sles/12/**/ppc64le
   - name: sles-12-s390x
     repo_location: repos/sles/12/**/s390x
   - name: sles-12-x86_64


### PR DESCRIPTION
This reverts commit 86e2bbf72f64555154eb58668f074bcc826ac9de.