### PR TITLE
(PA-1362) Add fedora 26 definition to the agent

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -15,7 +15,9 @@ component "openssl" do |pkg, settings, platform|
     pkg.build_requires 'xorg-x11-util-devel' if platform.name =~ /^sles/
     pkg.build_requires 'xutils-dev' if platform.is_deb?
   elsif platform.is_linux?
-    pkg.build_requires 'pl-binutils'
+    unless platform.is_fedora? && platform.os_version.delete('f').to_i >= 26
+      pkg.build_requires 'pl-binutils'
+    end
     pkg.build_requires 'pl-gcc'
   elsif platform.is_solaris?
     if platform.os_version == "10"

--- a/configs/platforms/fedora-f26-x86_64.rb
+++ b/configs/platforms/fedora-f26-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-f26-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+  plat.vmpooler_template "fedora-26-x86_64"
+end


### PR DESCRIPTION
This commit adds support for fedora 26 to the agent. The only abnormal change
made to make things work was to specify that pl-binutils was _not_ a
requirement for openssl builds on fedora 26 in particular