### PR TITLE
(PA-1504) Change NSSM versioning scheme

### DIFF
--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/nssm.git", "ref": "refs/tags/2.24.1"}
+{"url": "git://github.com/Iristyle/nssm.git", "ref": "b1b3f83aa20b65035acb07d44d16ef152a3a49a4"}


### PR DESCRIPTION
 - Update NSSM code so that it now versions by

   Major.Minor.Patch.CommitsPastTag

   This is reproducible within our build system