### PR TITLE
(PA-1512) Tag nssm/puppet at updated versions

### DIFF
--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/nssm.git", "ref": "b0b01ded7c42178855bbf88b3943b1c5522768bc"}
+{"url": "git://github.com/puppetlabs/nssm.git", "ref": "refs/tags/2.24.2"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "8261be3d78d9f1537b18251033d0b91f942587d5"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/4.10.8"}


### PR DESCRIPTION
This commit updates nssm and puppet components to their new versions for
puppet-agent 1.10.8