### PR TITLE
(PCP-511) Add hocon dependency for pxp-agent

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -13,6 +13,7 @@ component "pxp-agent" do |pkg, settings, platform|
   pkg.build_requires "openssl"
   pkg.build_requires "leatherman"
   pkg.build_requires "cpp-pcp-client"
+  pkg.build_requires "cpp-hocon"
 
   make = platform[:make]
 


### PR DESCRIPTION
Ensures hocon will be built before pxp-agent when we add hocon support.