### PR TITLE
(PA-1411,PA-1457,PA-1536) Remove EOL platforms from build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -18,12 +18,9 @@ foss_platforms:
   - el-7-x86_64
   - el-7-ppc64le
   - eos-4-i386
-  - fedora-f24-i386
-  - fedora-f24-x86_64
   - fedora-f25-i386
   - fedora-f25-x86_64
   - fedora-f26-x86_64
-  - huaweios-6-powerpc
   - osx-10.10-x86_64
   - osx-10.11-x86_64
   - osx-10.12-x86_64
@@ -38,7 +35,6 @@ foss_platforms:
   - windows-2012-x86
   - windows-2012-x64
 pe_platforms:
-  - aix-5.3-power
   - aix-6.1-power
   - aix-7.1-power
   - el-6-s390x
@@ -50,8 +46,6 @@ pe_platforms:
   - solaris-11-i386
   - solaris-11-sparc
 platform_repos:
-  - name: aix-5.3-power
-    repo_location: repos/aix/5.3/**/ppc
   - name: aix-6.1-power
     repo_location: repos/aix/6.1/**/ppc
   - name: aix-7.1-power
@@ -86,10 +80,6 @@ platform_repos:
     repo_location: repos/sles/12/**/s390x
   - name: sles-12-x86_64
     repo_location: repos/sles/12/**/x86_64
-  - name: fedora-24-i386
-    repo_location: repos/fedora/f24/**/i386
-  - name: fedora-24-x86_64
-    repo_location: repos/fedora/f24/**/x86_64
   - name: fedora-25-i386
     repo_location: repos/fedora/f25/**/i386
   - name: fedora-25-x86_64


### PR DESCRIPTION
This commit removes the following EOL platforms from build_defaults:

AIX 5.3
Fedora 24
HuaweiOS