### PR TITLE
(PA-1466) Exclude dmidecode component for Power8 architectures

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -250,7 +250,7 @@ project "puppet-agent" do |proj|
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"
-    proj.component "dmidecode"
+    proj.component "dmidecode" unless platform.architecture =~ /ppc64(?:le|el)/
     proj.component "shellpath"
   end
 


### PR DESCRIPTION
Previously when running facter on a machine with a Power8
architecture, dmesg would show the following line of error:
Program dmidecode tried to access /dev/mem between f0000->100000

The fix is to exclude dmidecode for Power8 architectures.