### PR TITLE
(PA-1569) Bump win32-process gem to 0.7.5

### DIFF
--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -1,6 +1,6 @@
 component "rubygem-win32-process" do |pkg, settings, platform|
-  pkg.version "0.7.4"
-  pkg.md5sum "3231cf152383fb2d792dcac8036b060f"
+  pkg.version "0.7.5"
+  pkg.md5sum "d7ff67c7934b0d6ab93030d2cc2fc4f0"
   pkg.url "https://rubygems.org/downloads/win32-process-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"


### PR DESCRIPTION
 - Back on 6/27/2016, the win32-process gem was pinned to 0.7.5 in
   gem based workflows (and as a gem dependency for the Puppet gem).

   https://github.com/puppetlabs/puppet/commit/d4d6734e5f858b4e3f4db24c356ea7cb9db2d991

   However, the corresponding update was never made to the shipping
   puppet-agent MSI.

   Sync them up