### PR TITLE
(PA-1554) Add component tags for 5.3.0 release

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "7f50620f4e26fe23ea6da469204fbda01efeaa80"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.9.1"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "74116899c41ea66da9440715cd7ea7a1dcc56cb2"}
+{"url": "git://github.com/puppetlabs/hiera.git", "ref": "refs/tags/3.4.2"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "f005d55ef45fa354c05cf2566113e30e342bf69e"}
+{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "refs/tags/1.2.1"}

--- a/configs/components/libwhereami.json
+++ b/configs/components/libwhereami.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/libwhereami.git", "ref": "1a6d770cfb3d35fecccb81ab5f4ffe67150b8ceb"}
+{"url": "git://github.com/puppetlabs/libwhereami.git", "ref": "refs/tags/0.1.2"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "9f60ce0a57fb104b873901cb77cdff246de63a15"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.11.3"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "384311c359e43ac56cbb937fca9aba82068fd2d6"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/5.3.0"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "b40c9fd818bfd740fab2e44904fba82af85d916c"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.8.0"}


### PR DESCRIPTION
Sets tags for
- facter 3.9.1
- hiera 3.4.2
- leatherman 1.2.1 - the 1.2.x branch beyond 1.2.1 contains only a Travis change, so we didn't tag a v1.2.2
- libwhereami 0.1.2
- mcollective 2.11.3
- puppet 5.3.0
- pxp-agent 1.8.0
