### PR TITLE
(PA-1555) Set component tags for 5.3.1 release

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "b8b496cbfabd77d97eedaa376282e0ef84efc399"}
+{"url": "git://github.com/puppetlabs/facter.git", "ref": "refs/tags/3.9.2"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "7db03e5a28e9c2499da6e34d6c38849cce399b12"}
+{"url": "git://github.com/puppetlabs/puppet.git", "ref": "refs/tags/5.3.1"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "ffbcdd6d3afcc35fd768f191a989f533e4599127"}
+{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "refs/tags/1.8.0"}


### PR DESCRIPTION
Sets tags for updated facter 3.9.2 and puppet 5.3.1.

Also pins pxp-agent back to 1.8.0. The diff between 1.8.0 and the version of 1.8.x that went through the pipelines today is [just an acceptance change](https://github.com/puppetlabs/pxp-agent/compare/1.8.0...1.8.x), and doesn't seem worth tagging a 1.8.1 for.