### PR TITLE
(maint) Build libwhereami on Solaris and AIX

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -19,11 +19,7 @@ component "facter" do |pkg, settings, platform|
   pkg.build_requires 'leatherman'
   pkg.build_requires 'runtime'
   pkg.build_requires 'cpp-hocon'
-
-  unless platform.is_aix? or platform.is_solaris?
-    # libwhereami doesn't support AIX or Solaris yet
-    pkg.build_requires "libwhereami"
-  end
+  pkg.build_requires 'libwhereami'
 
   if platform.is_linux? && !platform.is_huaweios?
     # Running facter (as part of testing) expects virt-what is available
@@ -156,7 +152,7 @@ component "facter" do |pkg, settings, platform|
     cmake = "/opt/pl-build-tools/bin/cmake"
 
     if platform.is_cisco_wrlinux?
-      special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
+      special_flags += " -DLEATHERMAN_USE_LOCALES=OFF"
     end
   end
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -219,10 +219,7 @@ project "puppet-agent" do |proj|
   proj.component "marionette-collective"
   proj.component "cpp-pcp-client"
   proj.component "pxp-agent"
-
-  unless platform.is_solaris? or platform.is_aix?
-    proj.component "libwhereami"
-  end
+  proj.component "libwhereami"
 
   # Then the dependencies
   proj.component "augeas" unless platform.is_windows?


### PR DESCRIPTION
libwhereami#master now has hypervisor detectors for Solaris and AIX; this commit builds libwhereami on those platforms - I was able to build the agent successfully on both.