### PR TITLE
(PA-1580) Enable testing of system openssl linked puppet agent on rhel7 platforms

### DIFF
--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -120,6 +120,80 @@ agents.each do |agent|
   on agent, "#{ruby} --version"
 end
 
+
+step "Enable FIPS on agent hosts..." do
+
+ # There might be a better way to do some things below but till then...
+ # The TODO's need to be followed up
+
+  agents.each do |agent|
+    next if agent == master # Only on agents.
+
+    # Do this only on rhel7, rhel6, f24, f25
+    use_system_openssl = ENV['USE_SYSTEM_OPENSSL']
+    if use_system_openssl
+      # Other platforms to come...
+      next if !agent[:platform].match(/(?:el-7|redhat-7)/)
+
+      # Step 1: Disable prelinking
+      # TODO:: Handle cases where the /etc/sysconfig/prelink might exist
+      on(agent, 'echo "PRELINKING=no" > /etc/sysconfig/prelink')
+      # TODO: prelink is commented till we figure how to attempt executing
+      # it so any failures do not cause this thing to exit
+      # on(agent, "prelink -u -a")
+ 
+      # Step 2: Install dracut-fips, dracut-fips-aesni
+      on(agent, "yum -y install dracut-fips")
+      on(agent, "yum -y install dracut-fips-aesni")
+
+      # TODO:: Backup existing kernel image in case anything goes south..
+      # Step 3: Run dracut to update system for fips. 
+      on(agent, "dracut -v -f")
+
+
+      # TODO:: Steps 4 and 5 need to be adjusted for rhel6, f24, f25
+      # as the method of enabling FIPS are different on those platforms. 
+      # Below works on rhel7
+      
+      # Step 4: Find out the device details (BLOCK ID) of boot partition
+      # append enable fips and boot block id to kernel command line in grub file
+      
+      on(agent, 'boot_blkid=$(blkid `df /boot | grep "/dev" | awk \'BEGIN{ FS=" "}; {print $1}\'` | awk \'BEGIN{ FS=" "}; {print $2}\' | sed \'s/"//g\');\
+                 fips_bootblk="fips=1 boot="$boot_blkid;\
+                 grub_linux_cmdline=`grep -e "^GRUB_CMDLINE_LINUX" /etc/default/grub | sed "s/\"$/ $fips_bootblk\"/"`;\
+                 grep -v GRUB_CMDLINE_LINUX /etc/default/grub > /etc/default/grub.bak;\
+                 /bin/cp -rf /etc/default/grub.bak /etc/default/grub;\
+                 sed -i "/GRUB_DISABLE_RECOVERY/i $grub_linux_cmdline" /etc/default/grub')
+
+
+      # Step 5: Run grub2 mkconfig to make the changes take effect.
+      on(agent, 'grub2-mkconfig -o /boot/grub2/grub.cfg')
+
+      # Reboot is needed for the system to start in FIPS mode
+      agent.reboot
+      timeout = 30
+      begin
+        Timeout.timeout(timeout) do
+          until agent.up?
+            sleep 1
+          end
+        end
+      rescue Timeout::Error => e
+        raise "Agent did not come back up within #{timeout} seconds."
+      end
+      
+      # TODO:
+      # Ensure that agent is actually in fips mode by examining the contents of
+      # /proc/sys/crypto/fips_enabled and that it is 1
+
+      # Switch to using sha256 to work in fips mode.
+      on agent, puppet('config set digest_algorithm sha256')
+      
+    end
+  end
+end
+
+
 # Get a rough estimate of clock skew among hosts
 times = []
 hosts.each do |host|

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -11,7 +11,12 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "leatherman"
 
   if platform.is_aix?

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -9,7 +9,12 @@ component 'curl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/curl/curl-7.55.1-aix-poll.patch'
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "puppet-ca-bundle"
 
   if platform.is_cross_compiled_linux?

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/facter.git", "ref": "6a7d5dc9304da87fe21d14ab2e2c8e0bbca69e77"}
+{"url": "git://github.com/jsane/facter.git", "ref": "35f76c1c5c5ebfa9f51b8c8a98f10da9869b075f"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/facter.git", "ref": "be23681a71da0ac0c2d98a73e715ec5ca90362e0"}
+{"url": "git://github.com/jsane/facter.git", "ref": "6a7d5dc9304da87fe21d14ab2e2c8e0bbca69e77"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "32358935d38380b6b8e1a6e2ff29c29e37ead2f9"}
+{"url": "git://github.com/jsane/facter.git", "ref": "be23681a71da0ac0c2d98a73e715ec5ca90362e0"}

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -15,7 +15,12 @@ component "facter" do |pkg, settings, platform|
   pkg.replaces 'pe-facter'
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
-  pkg.build_requires 'openssl'
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires 'leatherman'
   pkg.build_requires 'runtime'
   pkg.build_requires 'cpp-hocon'
@@ -32,7 +37,6 @@ component "facter" do |pkg, settings, platform|
 
   # Running facter (as part of testing) expects augtool are available
   pkg.build_requires 'augeas' unless platform.is_windows?
-  pkg.build_requires "openssl"
 
   if platform.is_windows?
     pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/hiera.git", "ref": "5bc7b354b2c8784707d7c103a42f4ac180c9ae30"}
+{"url": "git://github.com/jsane/hiera.git", "ref": "8641d44c4e93ce84127b0aae18a139725b8c18fe"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/hiera.git", "ref": "8641d44c4e93ce84127b0aae18a139725b8c18fe"}
+{"url": "git://github.com/jsane/hiera.git", "ref": "4bf9f6def0e3f3114163e1657bca0b3222fd67de"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/hiera.git", "ref": "4bf9f6def0e3f3114163e1657bca0b3222fd67de"}
+{"url": "git://github.com/jsane/hiera.git", "ref": "1c79f96841e7035acd2c18241f69e33cc1d311ff"}

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -1,7 +1,12 @@
 component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet-ca-bundle.json")
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   java_available = true
   case platform.name
@@ -19,7 +24,12 @@ component "puppet-ca-bundle" do |pkg, settings, platform|
     java_available = false
   end
 
-  openssl_cmd = "#{settings[:bindir]}/openssl"
+  if settings[:vendor_openssl] == "no"
+    openssl_cmd = "/usr/bin/openssl"
+  else
+    openssl_cmd = "#{settings[:bindir]}/openssl"
+  end
+
   if platform.is_cross_compiled_linux?
     # Use the build host's openssl command, not our cross-compiled one
     openssl_cmd = "/usr/bin/openssl"

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "58d7091effd57485786d205db1491fc71d2937a7"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "1ebbee631b8ebc4d3cbab8691813e9ea96c37599"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "98d794c16aefeb09ec4e80d58d9437d54c1c28de"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "58d7091effd57485786d205db1491fc71d2937a7"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "d193bb3231cae63b734ae82d46c6e05ddba55bbc"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "3299b4a2c465f1a148fa98d3e465505abdea342d"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "5b26a542ffd6db336dcc7421c181747863d99a13"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "6504e90600aed57d82261c2e37230a9ed97299f4"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "19c1e2e8b746052b47cf8f8f1dbfe2b9038f8fcd"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "8c61df5cce5227196535ade9fcd8913a486b1a2c"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "6504e90600aed57d82261c2e37230a9ed97299f4"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "d193bb3231cae63b734ae82d46c6e05ddba55bbc"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "4211fab1d0c2547f199f3b53cfda167b26e362cc"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "48f1b18c9bc36b0c83c2f08f5471b5fa5d9d3a59"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "c3f7287aabe8f5e2ac79eea612cd47255aa069c4"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "2eab96863541ad997e686add3e1a084e6f1197e5"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "0ff9cf7ff3a96b14c677ccaec73d48465a18c9c9"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "19c1e2e8b746052b47cf8f8f1dbfe2b9038f8fcd"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "48f1b18c9bc36b0c83c2f08f5471b5fa5d9d3a59"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "c3f7287aabe8f5e2ac79eea612cd47255aa069c4"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "2eab96863541ad997e686add3e1a084e6f1197e5"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "98d794c16aefeb09ec4e80d58d9437d54c1c28de"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "1ebbee631b8ebc4d3cbab8691813e9ea96c37599"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "5b26a542ffd6db336dcc7421c181747863d99a13"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/puppet.git", "ref": "8c61df5cce5227196535ade9fcd8913a486b1a2c"}
+{"url": "git://github.com/jsane/puppet.git", "ref": "4211fab1d0c2547f199f3b53cfda167b26e362cc"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/jsane/pxp-agent.git", "ref": "abe5bd0738c15951b30a68394e0069b17d774d57"}
+{"url": "git://github.com/jsane/pxp-agent.git", "ref": "b09fae7c9491cf7ad37b5b4b57b8fc59125437a9"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "8979cb1efdbaf89fa3e8b0369e82103a025a59fa"}
+{"url": "git://github.com/jsane/pxp-agent.git", "ref": "abe5bd0738c15951b30a68394e0069b17d774d57"}

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -10,7 +10,12 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.environment "PATH", "#{settings[:bindir]}:/opt/pl-build-tools/bin:$(PATH)"
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
   pkg.build_requires "leatherman"
   pkg.build_requires "cpp-pcp-client"
   pkg.build_requires "cpp-hocon"

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -125,7 +125,12 @@ component "ruby-2.1.9" do |pkg, settings, platform|
     pkg.build_requires 'runtime' if platform.is_cross_compiled_linux?
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"

--- a/configs/components/ruby-2.3.3.rb
+++ b/configs/components/ruby-2.3.3.rb
@@ -121,7 +121,12 @@ component "ruby-2.3.3" do |pkg, settings, platform|
     pkg.build_requires 'runtime' if platform.is_cross_compiled_linux?
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"

--- a/configs/components/ruby-2.4.1.rb
+++ b/configs/components/ruby-2.4.1.rb
@@ -126,7 +126,12 @@ component "ruby-2.4.1" do |pkg, settings, platform|
     pkg.build_requires 'runtime' if platform.is_cross_compiled_linux?
   end
 
-  pkg.build_requires "openssl"
+  if settings[:vendor_openssl] == "no"
+    pkg.build_requires 'openssl-devel'
+  else
+    pkg.build_requires 'openssl'
+  end
+
 
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,5 +1,9 @@
 
 def use_system_openssl?
+  # Presently .i.e as of Oct 22 there is no way to specify an environment variable
+  # in PA CI so we are going to hard code it till there is support for FIPS platforms
+  return true
+
   # Debugging: Ensure that required parameter in CI show up as environment variables.
   sys_ssl = ENV["USE_SYSTEM_OPENSSL"]
   warn "Use system openssl: " + "#{sys_ssl}"
@@ -266,7 +270,7 @@ project "puppet-agent" do |proj|
   proj.component "ruby-augeas" unless platform.is_windows?
 
   if use_system_openssl?
-    if platform.name =~ /^el-(6|7)-.*/ || platform.name =~ /^fedora-f(24|25).*/
+    if platform.name =~ /^el-(6|7)-.*/ || platform.name =~ /^fedora-f(24|25|26).*/
       # Currently we plan to support linking against system openssl only on these platforms.
       proj.setting(:vendor_openssl, "no")
     else

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,3 +1,15 @@
+
+def use_system_openssl?
+  # Debugging: Ensure that required parameter in CI show up as environment variables.
+  sys_ssl = ENV["USE_SYSTEM_OPENSSL"]
+  warn "Use system openssl: " + "#{sys_ssl}"
+
+  # explicitly catch the expected "don't use this" values
+  return false if ENV["USE_SYSTEM_OPENSSL"] =~ /false|f|0/i
+  # explicitly cast the environment variable to a true Boolean otherwise
+  !!ENV["USE_SYSTEM_OPENSSL"]
+end
+
 project "puppet-agent" do |proj|
   platform = proj.get_platform
 
@@ -252,7 +264,24 @@ project "puppet-agent" do |proj|
   end
   proj.component "ruby-shadow" unless platform.is_aix? || platform.is_windows?
   proj.component "ruby-augeas" unless platform.is_windows?
-  proj.component "openssl"
+
+  if use_system_openssl?
+    if platform.name =~ /^el-(6|7)-.*/ || platform.name =~ /^fedora-f(24|25).*/
+      # Currently we plan to support linking against system openssl only on these platforms.
+      proj.setting(:vendor_openssl, "no")
+    else
+      # We cannot fail for Ubuntu on Jenkins so temporarily just warning and proceeding
+      warn "Currently linking against system openssl is supported only on Enterprise Linux 6,7
+            or Fedora 24, 25 platforms"
+      warn "Using packaged openssl instead"
+      proj.setting(:vendor_openssl, "yes")
+      proj.component "openssl"
+    end
+  else
+    proj.setting(:vendor_openssl, "yes")
+    proj.component "openssl"
+  end
+
   proj.component "puppet-ca-bundle"
   proj.component "libxml2" unless platform.is_windows?
   proj.component "libxslt" unless platform.is_windows?


### PR DESCRIPTION

The install script in all relevant components including puppet-agent repo
needs to be updated so it upgrades the version of openssl package on rhel7 platforms.
RHEL7 images used by CI/VMpooler uses an old openssl version, compared to that on
Centos7 which is where PA is built on,  which causes agent setup and tests to fail.
This has been preventing PA built against openssl to be tested in CI pipelines
which require one test target to be at least RHEL7.

Following components have been updated with above changes that puppet-agent now
refers to:
  - puppet-agent
  - puppet
  - hiera
  - facter
  - pxp-agent

Has been tested in PA CI - logs would be attached to PR for PA-1264 (enables linking PA against system openssl) which is required to do this testing. This does not impact regular agent build using vendor-ed openssl which disregard system openssl. 
