### PR TITLE
(PA-1624) Update dmidecode to to 3.1 for el-7-aarch64

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,16 +1,22 @@
 component 'dmidecode' do |pkg, settings, platform|
-  pkg.version '2.12'
-  pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
-  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
+  if platform.name == 'el-7-aarch64'
+    pkg.version '3.1'
+    pkg.md5sum '7798f68a02b82358c44af913da3b6b42'
+  else
+    pkg.version '2.12'
+    pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
 
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.173.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.175.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.176.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.177.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.181.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.182.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-install-to-bin.patch"
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.173.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.175.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.176.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.177.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.181.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.182.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.195.patch'
+  end
+
+  pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
+  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.environment "LDFLAGS" => settings[:ldflags]
   pkg.environment "CFLAGS" => settings[:cflags]


### PR DESCRIPTION
el-7-aarch64 uses SMBIOS 3.0, which dmidecode 2.1 can't understand; I included dmidecode 3.1 here, since its git history contains all the recommended patches for 3.0. I did a test build of this today and it ran successfully (as did e.g. `facter dmi`) on an aarch64 centos 7 host. 