### PR TITLE
(PA-1503) Update to latest curl

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.51.0'
-  pkg.md5sum '490e19a8ccd1f4a244b50338a0eb9456'
+  pkg.version '7.56.0'
+  pkg.md5sum '65351b9df687ed539852ae7b9464006c'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"


### PR DESCRIPTION
Curl 7.56.0 is the latest version of curl, and there are no vulnerabilities listed for it (yet) on curl's site. I built this for several platforms and architectures (including AIX, which requires a special patch) and all seemed to be in order.