### PR TITLE
Mergeup 1.10.x ->  5.3.x

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.55.1'
-  pkg.md5sum '3b832160a8c9c40075fd71191960307c'
+  pkg.version '7.56.0'
+  pkg.md5sum '65351b9df687ed539852ae7b9464006c'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
   pkg.mirror "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
 

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,17 +1,22 @@
 component 'dmidecode' do |pkg, settings, platform|
-  pkg.version '2.12'
-  pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
-  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
+  if platform.name == 'el-7-aarch64'
+    pkg.version '3.1'
+    pkg.md5sum '7798f68a02b82358c44af913da3b6b42'
+  else
+    pkg.version '2.12'
+    pkg.md5sum '02ee243e1ecac7fe0d04428aec85f63a'
 
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.173.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.175.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.176.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.177.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.181.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.182.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-1.195.patch"
-  pkg.apply_patch "resources/patches/dmidecode/dmidecode-install-to-bin.patch"
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.173.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.175.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.176.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.177.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.181.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.182.patch'
+    pkg.apply_patch 'resources/patches/dmidecode/dmidecode-1.195.patch'
+  end
+
+  pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
+  pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.environment "LDFLAGS", settings[:ldflags]
   pkg.environment "CFLAGS", settings[:cflags]


### PR DESCRIPTION
* upstream/1.10.x:
  bumping puppet to 3eff4193ed5620ae88feaf5850f1d94f625225c4
  (PA-1503) Update to latest curl
  (PA-1624) Update dmidecode to to 3.1 for el-7-aarch64