### PR TITLE
(maint) Add package mirror for dmidecode

### DIFF
--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -17,6 +17,7 @@ component 'dmidecode' do |pkg, settings, platform|
 
   pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
   pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
+  pkg.mirror "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.environment "LDFLAGS" => settings[:ldflags]
   pkg.environment "CFLAGS" => settings[:cflags]


### PR DESCRIPTION
Vanagon has been updated to the same version in 1.10.x as in 5.3.x, so this is possible now.