### PR TITLE
Mergeup 1.10.x -> 5.3.x

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -132,17 +132,20 @@ module Puppet
       module_function :ruby_command
 
       def gem_command(host, type='aio')
-        if type == 'aio'
-          if host['platform'] =~ /windows/
-            "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
-          else
-            "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
-          end
-        else
-          on(host, 'which gem').stdout.chomp
-        end
+        command(host, 'gem', type)
       end
       module_function :gem_command
+
+      def irb_command(host, type='aio')
+        command(host, 'irb', type)
+      end
+      module_function :irb_command
+
+      def command(host, cmd, type)
+        return on(host, "which #{cmd}").stdout.chomp unless type == 'aio'
+        return "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c #{cmd}" if host['platform'] =~ /windows/
+        "env PATH=\"#{host['privatebindir']}:${PATH}\" #{cmd}"
+      end
     end
   end
 end

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -1,0 +1,79 @@
+require 'puppet/acceptance/temp_file_utils'
+extend Puppet::Acceptance::CommandUtils
+
+def install_dependencies(agent)
+  # for some reason, beaker does not have a configured package installer
+  # for AIX, so need to manually do it
+  install_package_on_agent = agent['platform'] =~ /aix/ ?
+      lambda { |package| on(agent, "rpm -Uvh #{package}") }
+    : lambda { |package| agent.install_package(package) }
+
+  dependencies = {
+    'apt-get' => ['gcc', 'make', 'libsqlite3-dev'],
+    'yum' => ['gcc', 'sqlite-devel'],
+    'zypper' => ['gcc', 'sqlite3-devel'],
+    'rpm' => [
+      'http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/pl-gcc-5.2.0-1.aix5.3.ppc.rpm',
+      'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm',
+      'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/info-4.6-1.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/readline/readline-7.0-3.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/readline/readline-devel-7.0-3.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/sqlite/sqlite-3.20.0-1.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/sqlite/sqlite-devel-3.20.0-1.aix5.1.ppc.rpm'
+    ]
+  }
+
+  provider = dependencies.keys.find do |_provider|
+    on(agent, "which #{_provider}", :accept_all_exit_codes => true).exit_code.zero? 
+  end
+  assert(provider, "The agent does not have one of `apt-get`, `yum`, `zypper`, or `rpm` as its package provider")
+
+  dependencies[provider].each do |dependency|
+    install_package_on_agent.call(dependency)
+  end
+end
+
+test_name 'PA-1319: Validate that the vendored ruby can load gems and is configured correctly' do
+
+  step "'gem list' displays a decent list of gems" do
+    minimum_number_of_gems = 3
+    # \d+\.\d+\.\d+ describes the gem version
+    gem_re = /[\w-]+ \(\d+\.\d+\.\d+(?:, \d+\.\d+\.\d+)*\)/
+
+    agents.each do |agent|
+      gem = gem_command(agent) 
+      listed_gems = on(agent, "#{gem} list").stdout.chomp.scan(gem_re)
+      assert(listed_gems.size >= minimum_number_of_gems, "'gem list' fails to list the available gems (i.e., the rubygems environment is not sane)")
+    end
+  end
+
+  step "'irb' successfully loads gems" do
+    agents.each do |agent|
+      irb = irb_command(agent)
+      ['hocon', 'deep_merge'].each do |gem|
+        stdout = on(agent, "echo \"require '#{gem}'\" | #{irb}").stdout.chomp
+        assert_match(/true/, stdout, "'irb' failed to require the #{gem} gem")
+      end
+    end
+  end
+
+  step "'gem install' successfully installs a gem with native extensions" do
+    # SLES POWER machines will be skipped until OPS-15487 is resolved
+    agents_to_skip = select_hosts({:platform => [/windows/, /solaris/, /cisco/, /eos/, /cumulus/, /sles.+ppc/]}, agents)
+    agents_to_test = agents - agents_to_skip
+    agents_to_test.each do |agent|
+      if agent['platform'] !~ /osx/
+        install_dependencies(agent)
+      end
+
+      gem = gem_command(agent)
+      # use pl-build-tools' gcc on AIX machines
+      gem = "export PATH=\"/opt/pl-build-tools/bin:$PATH\" && #{gem}" if agent['platform'] =~ /aix/
+
+      on(agent, "#{gem} install sqlite3 #{"-v 1.3.11" if agent['platform'] =~ /el-5/}")
+      listed_gems = on(agent, "#{gem} list").stdout.chomp
+      assert_match(/sqlite3/, listed_gems, "'gem install' failed to build the sqlite3 gem")
+    end
+  end
+end
+

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,6 +1,6 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.56.0'
-  pkg.md5sum '65351b9df687ed539852ae7b9464006c'
+  pkg.version '7.56.1'
+  pkg.md5sum '48ba7bd7b363b40cd446d1e7b4be9920'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
   pkg.mirror "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
 

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,6 +17,7 @@ foss_platforms:
   - el-6-x86_64
   - el-7-x86_64
   - el-7-ppc64le
+  - el-7-aarch64
   - eos-4-i386
   - fedora-f25-i386
   - fedora-f25-x86_64
@@ -71,6 +72,8 @@ platform_repos:
     repo_location: repos/el/7/**/s390x
   - name: el-7-ppc64le
     repo_location: repos/el/7/**/ppc64le
+  - name: el-7-aarch64
+    repo_location: repos/el/7/**/aarch64
   - name: sles-11-s390x
     repo_location: repos/sles/11/**/s390x
   - name: sles-11-i386


### PR DESCRIPTION
    Merge remote-tracking branch 'upstream/1.10.x' into 5.3.x

    * upstream/1.10.x:
      (PA-1503) Update curl to v7.56.1
      Revert "(PA-1569) Bump win32-process gem to 0.7.5"
      (PA-1638) Use sqlite3 version 1.3.11 for RHEL 5 platforms
      bumping pxp-agent to bc09cbeb9cac1d62a8416e2e7882c038427e139f
      (PA-1319) Add tests that validate the vendored ruby
      (PA-1625) Enable el-7-aarch64 in nightlies
      bumping puppet to b4038629e300ab73147b5a62ea9ed1f0b9c45107
      bumping facter to 244f034185897482535fb07f3f1fd911e71c410e
      bumping puppet to 74ff444293ac19d6150e5d694e8610b60d5c4343
      (PA-1569) Bump win32-process gem to 0.7.5