### PR TITLE
(maint) Update semantic_puppet gem to latest version

### DIFF
--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -1,6 +1,6 @@
 component "rubygem-semantic_puppet" do |pkg, settings, platform|
-  pkg.version "0.1.2"
-  pkg.md5sum "192ae7729997cb5d5364f64b99b13121"
+  pkg.version "1.0.1"
+  pkg.md5sum "8ce85a0206a640654e0019eadf615672"
   pkg.url "https://rubygems.org/downloads/semantic_puppet-#{pkg.get_version}.gem"
   pkg.mirror "http://buildsources.delivery.puppetlabs.net/semantic_puppet-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
The vendored version in Puppet is already at 1.0.1, so this commit brings the version in puppet-agent in line with that.