### PR TITLE
Openssl component config cleanup

### DIFF
--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -49,30 +49,11 @@ component "openssl" do |pkg, settings, platform|
     target = 'darwin64-x86_64-cc'
     cflags = settings[:cflags]
     ldflags = ''
-  elsif platform.is_huaweios?
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
   elsif platform.is_cross_compiled_linux?
-    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-
-    cflags = "#{settings[:cflags]} -fPIC"
-  elsif platform.name =~ /ubuntu-16\.04-ppc64el/
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$$PATH"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
 
-    target = 'linux-ppc64le'
     cflags = "#{settings[:cflags]} -fPIC"
-  elsif platform.architecture == "s390x"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-
-    target = 'linux64-s390x'
-    ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
-    cflags = "#{settings[:cflags]} -fPIC"
-  elsif platform.architecture == "ppc64le"
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
 
     if platform.is_huaweios?
@@ -109,14 +90,6 @@ component "openssl" do |pkg, settings, platform|
     pkg.environment "CYGWIN", settings[:cygwin]
     cflags = settings[:cflags]
     ldflags = settings[:ldflags]
-  elsif platform.name =~ /debian-8-arm/
-    pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
-    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
-    pkg.build_requires "xutils-dev"
-    target = 'linux-armv4'
-    ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
-    cflags = "#{settings[:cflags]} -fPIC"
   else
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH):/usr/local/bin"
     if platform.architecture =~ /86$/

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -49,6 +49,14 @@ component "openssl" do |pkg, settings, platform|
     target = 'darwin64-x86_64-cc'
     cflags = settings[:cflags]
     ldflags = ''
+  elsif platform.is_huaweios?
+    pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
+    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+  elsif platform.is_cross_compiled_linux?
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
+    pkg.environment "CC" => "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+
+    cflags = "#{settings[:cflags]} -fPIC"
   elsif platform.name =~ /ubuntu-16\.04-ppc64el/
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
@@ -66,8 +74,11 @@ component "openssl" do |pkg, settings, platform|
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
     pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     ldflags = "-Wl,-rpath=/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
-    cflags = "#{settings[:cflags]} -fPIC"
-    if platform.architecture == "aarch64"
+
+    if platform.is_huaweios?
+      ldflags = "-R/opt/pl-build-tools/#{settings[:platform_triple]}/lib -Wl,-rpath=#{settings[:libdir]} -L/opt/pl-build-tools/#{settings[:platform_triple]}/lib"
+      target = 'linux-ppc'
+    elsif platform.architecture == "aarch64"
       target = 'linux-aarch64'
     elsif platform.name =~ /debian-8-arm/
       target = 'linux-armv4'


### PR DESCRIPTION
This cleans up the openssl component config after the merge-up from 1.10.x -> 5.3.x created a control flow hairball that had to be unwound.