### PR TITLE
(maint) Facilitate EC2 testing using always-be-scheduling

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -17,6 +17,7 @@ DEFAULT_TEST_TARGETS = "#{DEFAULT_MASTER_TEST_TARGET}-#{DEFAULT_AGENT_TEST_TARGE
 
 DEFAULT_INTERNAL_DOWNLOAD_URL = "http://builds.delivery.puppetlabs.net"
 DEFAULT_NIGHTLIES_DOWNLOAD_URL = "http://nightlies.puppet.com"
+SSH_KEYFILE = ENV['KEYFILE'] || "~/.ssh/id_rsa-acceptance"
 
 module HarnessOptions
 
@@ -28,7 +29,7 @@ module HarnessOptions
     :color => false,
     :root_keys => true,
     :ssh => {
-      :keys => ["~/.ssh/id_rsa-acceptance"],
+      :keys => [SSH_KEYFILE],
     },
     :xml => true,
     :timesync => false,


### PR DESCRIPTION
(maint) Always-be-scheduling needs to use a different keyfile for beaker specified by an environment variable in order to facilitate ec2 testing.