### PR TITLE
(PA-1635) Include Solaris 10 and Solaris 11 in ruby tests

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -1,17 +1,96 @@
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::CommandUtils
 
-def install_dependencies(agent)
+def package_installer(agent)
   # for some reason, beaker does not have a configured package installer
-  # for AIX, so need to manually do it
-  install_package_on_agent = agent['platform'] =~ /aix/ ?
-      lambda { |package| on(agent, "rpm -Uvh #{package}") }
-    : lambda { |package| agent.install_package(package) }
+  # for AIX, and for solaris-10 we install dependencies from opencsw. so we
+  # need to manually set up the package installer for these platforms.
+  case agent['platform']
+  when /aix/
+    lambda { |package| on(agent, "rpm -Uvh #{package}") }
+  when /solaris-10/
+    lambda { |package| on(agent, "opt/csw/bin/pkgutil -y -i #{package}") }
+  else
+    lambda { |package| agent.install_package(package) }
+  end
+end
 
+def setup_build_environment(agent)
+  gem_install_sqlite3 = gem_command(agent) + " install sqlite3"
+  install_package_on_agent = package_installer(agent)
+
+  case agent['platform'] 
+  when /aix/
+    # use pl-build-tools' gcc on AIX machines
+    gem_install_sqlite3 = "export PATH=\"/opt/pl-build-tools/bin:$PATH\" && #{gem_install_sqlite3}"
+  when /el-5/
+    # PA-1638
+    gem_install_sqlite3 += " -v 1.3.11" 
+  when /solaris-11-i386/
+    gem_install_sqlite3 = "export PATH=\"/usr/sfw/bin:$PATH\" && #{gem_install_sqlite3}"
+  when /solaris-11-sparc/
+    install_package_on_agent.call("developer/gcc-48")
+    gem_install_sqlite3 = "export PATH=\"/usr/gcc/4.8/bin:$PATH\" && #{gem_install_sqlite3}"
+  when /solaris-10/
+    # this code was obtained from https://github.com/puppetlabs/puppet-agent/blob/master/configs/platforms/solaris-10-i386.rb
+    # it's main purpose is to set up a base build environment that lets you compile stuff
+    # on the vm (e.g. by installing the system headers). otherwise, you would not be able to
+    # compile even a hello-world.c program.
+    vanagon_noask_contents = "mail=\n"\
+      "instance=overwrite\n"\
+      "partial=nocheck\n"\
+      "runlevel=nocheck\n"\
+      "idepend=nocheck\n"\
+      "rdepend=nocheck\n"\
+      "space=quit\n"\
+      "setuid=nocheck\n"\
+      "conflict=nocheck\n"\
+      "action=nocheck\n"\
+      "basedir=default"
+    vanagon_noask_path = "/var/tmp/vanagon-noask"
+    on(agent, "echo \"#{vanagon_noask_contents}\" > #{vanagon_noask_path}")
+
+    on(agent, "pkgadd -n -a #{vanagon_noask_path} -G -d http://get.opencsw.org/now all")
+    ["rsync", "gmake", "pkgconfig", "ggrep"].each { |pkg| install_package_on_agent.call(pkg) }
+    install_package_on_agent.call("coreutils") if agent['platform'] =~ /sparc/
+    on(agent, "ln -sf /opt/csw/bin/rsync /usr/bin/rsync")
+    ["glibc-devel", "ruby", "readline"].each do |pkg|
+      on(agent, "/opt/csw/bin/pkgutil -l #{pkg} | xargs -I{} pkgrm -n -a #{vanagon_noask_path} {}")
+    end
+
+    if agent['platform'] =~ /sparc/
+      gem_install_sqlite3 = "export PATH=\"/usr/sfw/bin:/usr/ccs/bin:$PATH\" && #{gem_install_sqlite3}"
+    else
+      # for some reason, sparc has everything else that it needs (system headers, gcc, etc.),
+      # but i386 does not. the code below ensures that all these dev tools are installed for i386.
+      # note that we probably don't need everything here, but it is too time consuming to check
+      # which one of these are necessary
+      base_url = "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/depends"
+      ['arc', 'gnu-idn', 'gpch', 'gtar', 'hea', 'libm', 'wgetu', 'xcu4'].each do |pkg|
+        tmpdir = on(agent, "mktemp -p /var/tmp -d").stdout.chomp
+        pkg_gz = "SUNW#{pkg}.pkg.gz"
+        in_temp_dir = lambda do |cmd|
+          "pushd #{tmpdir} && #{cmd} && popd"
+        end
+  
+        on(agent, in_temp_dir.call("curl -O #{base_url}/#{pkg_gz}"))
+        on(agent, in_temp_dir.call("gunzip -c #{pkg_gz} | pkgadd -d /dev/stdin -a #{vanagon_noask_path} all"))
+      end
+    end
+  end
+
+  gem_install_sqlite3
+end
+
+def install_dependencies(agent)
+  return if agent['platform'] =~ /osx|solaris-11|sparc/
+
+  install_package_on_agent = package_installer(agent) 
   dependencies = {
     'apt-get' => ['gcc', 'make', 'libsqlite3-dev'],
     'yum' => ['gcc', 'sqlite-devel'],
     'zypper' => ['gcc', 'sqlite3-devel'],
+    'opt/csw/bin/pkgutil' => ['sqlite3', 'libsqlite3_dev'],
     'rpm' => [
       'http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/pl-gcc-5.2.0-1.aix5.3.ppc.rpm',
       'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm',
@@ -24,9 +103,15 @@ def install_dependencies(agent)
   }
 
   provider = dependencies.keys.find do |_provider|
-    on(agent, "which #{_provider}", :accept_all_exit_codes => true).exit_code.zero? 
+    result = on(agent, "which #{_provider}", :accept_all_exit_codes => true)
+    # the `which` command on Solaris returns a 0 exit code even when the file
+    # does not exist
+    agent['platform'] =~ /solaris/ ?
+       result.stdout.chomp !~ /no #{_provider}/
+     : result.exit_code.zero? 
   end
-  assert(provider, "The agent does not have one of `apt-get`, `yum`, `zypper`, or `rpm` as its package provider")
+  providers = dependencies.keys.join(', ')
+  assert(provider, "The agent does not have one of #{providers} as its package provider")
 
   dependencies[provider].each do |dependency|
     install_package_on_agent.call(dependency)
@@ -59,18 +144,14 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
 
   step "'gem install' successfully installs a gem with native extensions" do
     # SLES POWER machines will be skipped until OPS-15487 is resolved
-    agents_to_skip = select_hosts({:platform => [/windows/, /solaris/, /cisco/, /eos/, /cumulus/, /sles.+ppc/]}, agents)
+    agents_to_skip = select_hosts({:platform => [/windows/, /cisco/, /eos/, /cumulus/, /sles.+ppc/]}, agents)
     agents_to_test = agents - agents_to_skip
     agents_to_test.each do |agent|
-      if agent['platform'] !~ /osx/
-        install_dependencies(agent)
-      end
+      gem_install_sqlite3 = setup_build_environment(agent)
+      install_dependencies(agent)
+      on(agent, gem_install_sqlite3)
 
       gem = gem_command(agent)
-      # use pl-build-tools' gcc on AIX machines
-      gem = "export PATH=\"/opt/pl-build-tools/bin:$PATH\" && #{gem}" if agent['platform'] =~ /aix/
-
-      on(agent, "#{gem} install sqlite3 #{"-v 1.3.11" if agent['platform'] =~ /el-5/}")
       listed_gems = on(agent, "#{gem} list").stdout.chomp
       assert_match(/sqlite3/, listed_gems, "'gem install' failed to build the sqlite3 gem")
     end


### PR DESCRIPTION
Previously, the test that built a native, sqlite3 gem skipped
Solaris platforms. This commit now includes Solaris 10 and 11.