### PR TITLE
(PA-1658) Set component tags for 5.3.3 release

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-pcp-client.git", "ref": "638a3eb7d6397b1abe6d992f21fc3dcb2ac7dcc0"}
+{"url":"git://github.com/puppetlabs/cpp-pcp-client.git","ref":"refs/tags/1.5.4"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/facter.git", "ref": "f4016b575c3072039f9607ebb0464b1ac172d347"}
+{"url":"git://github.com/puppetlabs/facter.git","ref":"refs/tags/3.9.3"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/leatherman.git", "ref": "f005d55ef45fa354c05cf2566113e30e342bf69e"}
+{"url":"git://github.com/puppetlabs/leatherman.git","ref":"refs/tags/1.2.1"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "5c871e39a27c5e1aa17cc951aab4fa29c63c0e1e"}
+{"url":"git://github.com/puppetlabs/marionette-collective.git","ref":"refs/tags/2.11.4"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/puppet.git", "ref": "04552076b0cc7d5d0af28765d26f6939a6b2061f"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"refs/tags/5.3.3"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/pxp-agent.git", "ref": "44a3c32e549982dd75738430fb9d382d6245f0b8"}
+{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"refs/tags/1.8.0"}


### PR DESCRIPTION
The components that are supposed to be pinned back were:

(1) Leatherman to 1.2.1 (LTH-147)
(2) PXP-agent to 1.8.0 (PCP-815)
(3) cpp-pcp-client to 1.5.4

The components tagged were:
(1) facter to 3.9.3 (FACT-1786)
(2) mcollective to 2.11.4 (MCO-823)
(3) puppet to 5.3.3 (PUP-8091)