### PR TITLE
(maint) Migrate vanagon projects to use buildsources in Artifactory

### DIFF
--- a/bin/windows-toolset.ps1
+++ b/bin/windows-toolset.ps1
@@ -67,7 +67,7 @@ cd $toolsDir
 
 Verify-Tool '7za' ''
 
-$buildSourcesURL = "http://buildsources.delivery.puppetlabs.net/windows"
+$buildSourcesURL = "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows"
 $s3URL = "https://s3.amazonaws.com/kylo-pl-bucket"
 
 if ($buildSource) {

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -17,7 +17,7 @@ component 'dmidecode' do |pkg, settings, platform|
 
   pkg.apply_patch 'resources/patches/dmidecode/dmidecode-install-to-bin.patch'
   pkg.url "http://download.savannah.gnu.org/releases/dmidecode/dmidecode-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/dmidecode-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/dmidecode-#{pkg.get_version}.tar.gz"
 
   pkg.environment "LDFLAGS" => settings[:ldflags]
   pkg.environment "CFLAGS" => settings[:cflags]

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -4,7 +4,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
-    pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
+    pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
     pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
     pkg.add_source "file://resources/files/ruby_219/windows_ruby_gem_wrapper.bat"
   end

--- a/configs/components/ruby-2.3.1.rb
+++ b/configs/components/ruby-2.3.1.rb
@@ -4,7 +4,7 @@ component "ruby-2.3.1" do |pkg, settings, platform|
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
-    pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
+    pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
     pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
     pkg.add_source "file://resources/files/ruby_231/windows_ruby_gem_wrapper.bat"
   end

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -5,7 +5,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     # including its dependencies (mini_portile2), installing it on the target, and
     # installing the nokogiri gem using our gem command. The added files from
     # :gem_home were then tar'ed up and packed into this container tarball.
-    pkg.url "http://buildsources.delivery.puppetlabs.net/nokogiri-precompiled-huaweios-#{pkg.get_version}-patch1-for-ruby-#{settings[:ruby_version]}.tar.gz"
+    pkg.url "#{settings[:buildsources_url]}/nokogiri-precompiled-huaweios-#{pkg.get_version}-patch1-for-ruby-#{settings[:ruby_version]}.tar.gz"
     if settings[:ruby_version] == "2.1.9"
       pkg.md5sum "016db16f78d9e6d0c3ead89093e610a2"
     elsif settings[:ruby_version] == "2.3.1"

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -6,7 +6,7 @@ platform "windows-2012r2-x64" do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
 

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -6,7 +6,7 @@ platform "windows-2012r2-x86" do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository "http://buildsources.delivery.puppetlabs.net/windows/chocolatey/install-chocolatey.ps1"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
   plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -81,6 +81,9 @@ project "puppet-agent" do |proj|
   proj.setting(:datadir, File.join(proj.prefix, "share"))
   proj.setting(:mandir, File.join(proj.datadir, "man"))
 
+  proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+  proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+
   if platform.is_windows?
     proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby.exe"))
     proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem.bat"))
@@ -301,6 +304,6 @@ project "puppet-agent" do |proj|
   # Here we rewrite public http urls to use our internal source host instead.
   # Something like https://www.openssl.org/source/openssl-1.0.0r.tar.gz gets
   # rewritten as
-  # http://buildsources.delivery.puppetlabs.net/openssl-1.0.0r.tar.gz
-  proj.register_rewrite_rule 'http', 'http://buildsources.delivery.puppetlabs.net'
+  # https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/openssl-1.0.0r.tar.gz
+  proj.register_rewrite_rule 'http', proj.buildsources_url
 end


### PR DESCRIPTION
This commit adds `artifactory_url` and `buildsources_url` settings and replaces buildsources.delivery.puppetlabs.net with Artifactory.