### PR TITLE
(PA-1522) Set REINSTALLMODE=amus

### DIFF
--- a/resources/windows/wix/properties.wxs.erb
+++ b/resources/windows/wix/properties.wxs.erb
@@ -12,6 +12,12 @@
       Id="ARPHELPLINK"
       Value="<%= settings[:links][:HelpLink] %>" />
 
+    <!-- Reinstallmode default to always replace files -->
+    <!-- https://msdn.microsoft.com/en-us/library/aa371182%28v=vs.85%29.aspx -->
+    <Property
+      Id="REINSTALLMODE"
+      Value="amus"/>
+
     <!-- This property is used in the localization strings for the GUI -->
     <Property
       Id="VersionUIString"


### PR DESCRIPTION
Cherrypick from  0ae5d5a88762e2566d0db1d674226250c9268938

This defaults to always replacing files regardless of their version or
checksum. This really only works for future upgrades, so the
REINSTALLMODE needs to be specified manually when downgrading to a
version of Puppet Agent without REINSTALLMODE set.