### PR TITLE
(maint) Migrate vanagon projects to use buildsources in Artifactory

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -1,7 +1,7 @@
 component 'augeas' do |pkg, settings, platform|
   pkg.version '1.8.1'
   pkg.md5sum '623ff89d71a42fab9263365145efdbfa'
-  pkg.url "http://buildsources.delivery.puppetlabs.net/augeas-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:buildsources_url]}/augeas-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-augeas'
   if platform.is_sles? && platform.os_version == '10'

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -2,7 +2,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.version '7.56.1'
   pkg.md5sum '48ba7bd7b363b40cd446d1e7b4be9920'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/curl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 
   if platform.is_aix?
     # Patch to disable _ALL_SOURCE when including select.h from multi.c. See patch for details.

--- a/configs/components/libedit.rb
+++ b/configs/components/libedit.rb
@@ -2,7 +2,7 @@ component 'libedit' do |pkg, settings, platform|
   pkg.version '20150325-3.1'
   pkg.md5sum '43cdb5df3061d78b5e9d59109871b4f6'
   pkg.url "http://thrysoee.dk/editline/libedit-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libedit-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libedit-#{pkg.get_version}.tar.gz"
 
   pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
 

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -2,7 +2,7 @@ component "libxml2" do |pkg, settings, platform|
   pkg.version "2.9.4"
   pkg.md5sum "ae249165c173b1ff386ee8ad676815f5"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxml2-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxml2-#{pkg.get_version}.tar.gz"
   # CVE-related patches needed until libxml 2.9.5 is released:
   pkg.apply_patch 'resources/patches/libxml2/fix_XPointer_paths_beginning_with_range-to_CVE-2016-5131.patch'
   pkg.apply_patch 'resources/patches/libxml2/fix_comparison_with_root_node_in_xmlXPathCmpNodes.patch'

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -2,7 +2,7 @@ component "libxslt" do |pkg, settings, platform|
   pkg.version "1.1.29"
   pkg.md5sum "a129d3c44c022de3b9dcf6d6f288d72e"
   pkg.url "http://xmlsoft.org/sources/#{pkg.get_name}-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/libxslt-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/libxslt-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "libxml2"
 

--- a/configs/components/openssl.rb
+++ b/configs/components/openssl.rb
@@ -2,7 +2,7 @@ component "openssl" do |pkg, settings, platform|
   pkg.version "1.0.2k"
   pkg.md5sum "f965fc0bf01bf882b31314b61391ae65"
   pkg.url "https://openssl.org/source/openssl-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/openssl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/openssl-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-openssl'
   pkg.build_requires 'runtime'

--- a/configs/components/ruby-2.1.9.rb
+++ b/configs/components/ruby-2.1.9.rb
@@ -2,7 +2,7 @@ component "ruby-2.1.9" do |pkg, settings, platform|
   pkg.version "2.1.9"
   pkg.md5sum "d9d2109d3827789344cc3aceb8e1d697"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/ruby-2.3.5.rb
+++ b/configs/components/ruby-2.3.5.rb
@@ -2,7 +2,7 @@ component "ruby-2.3.5" do |pkg, settings, platform|
   pkg.version "2.3.5"
   pkg.md5sum "dda70c000632a83af5d15dfcf3e00a3e"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
     pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"

--- a/configs/components/ruby-2.4.2.rb
+++ b/configs/components/ruby-2.4.2.rb
@@ -2,10 +2,10 @@ component "ruby-2.4.2" do |pkg, settings, platform|
   pkg.version "2.4.2"
   pkg.md5sum "fe106eed9738c4e03813ab904f8d891c"
   pkg.url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 
   if platform.is_windows?
-    pkg.add_source "http://buildsources.delivery.puppetlabs.net/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
+    pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
     pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
     pkg.add_source "file://resources/files/ruby_242/windows_ruby_gem_wrapper.bat"
   end

--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -2,7 +2,7 @@ component "ruby-augeas" do |pkg, settings, platform|
   pkg.version "0.5.0"
   pkg.md5sum "a132eace43ce13ccd059e22c0b1188ac"
   pkg.url "http://download.augeas.net/ruby/ruby-augeas-#{pkg.get_version}.tgz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-augeas-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-augeas-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby-augeas'
 

--- a/configs/components/ruby-selinux.rb
+++ b/configs/components/ruby-selinux.rb
@@ -5,12 +5,12 @@ component "ruby-selinux" do |pkg, settings, platform|
     pkg.md5sum "08762379de2242926854080dad649b67"
     pkg.apply_patch "resources/patches/ruby-selinux/libselinux-rhat.patch"
     pkg.url "http://pkgs.fedoraproject.org/repo/pkgs/libselinux/libselinux-1.33.4.tgz/08762379de2242926854080dad649b67/libselinux-1.33.4.tgz"
-    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tgz"
+    pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tgz"
   else
     pkg.version "2.0.94"
     pkg.md5sum "544f75aab11c2af352facc51af12029f"
     pkg.url "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases/20100525/devel/libselinux-#{pkg.get_version}.tar.gz"
-    pkg.mirror "http://buildsources.delivery.puppetlabs.net/libselinux-#{pkg.get_version}.tar.gz"
+    pkg.mirror "#{settings[:buildsources_url]}/libselinux-#{pkg.get_version}.tar.gz"
   end
 
   pkg.replaces 'pe-ruby-selinux'

--- a/configs/components/ruby-shadow.rb
+++ b/configs/components/ruby-shadow.rb
@@ -3,7 +3,7 @@ component "ruby-shadow" do |pkg, settings, platform|
   pkg.md5sum "c9fec6b2a18d673322a6d3d83870e122"
   # I am unable to find ruby-shadow-2.3.3 source anywhere other than our own website. Upstream appears to be dead.
   pkg.url "https://downloads.puppetlabs.com/enterprise/sources/3.8.3/solaris/11/source/ruby-shadow-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/ruby-shadow-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/ruby-shadow-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-ruby-shadow'
 

--- a/configs/components/ruby-stomp.rb
+++ b/configs/components/ruby-stomp.rb
@@ -2,7 +2,7 @@ component "ruby-stomp" do |pkg, settings, platform|
   pkg.version "1.4.4"
   pkg.md5sum "1224b9efe7381cea25c506c9c6e28373"
   pkg.url "https://rubygems.org/downloads/stomp-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/stomp-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/stomp-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-ruby-stomp'
 

--- a/configs/components/rubygem-deep-merge.rb
+++ b/configs/components/rubygem-deep-merge.rb
@@ -2,7 +2,7 @@ component "rubygem-deep-merge" do |pkg, settings, platform|
   pkg.version "1.0.1"
   pkg.md5sum "6f30bc4727f1833410f6a508304ab3c1"
   pkg.url "https://rubygems.org/downloads/deep_merge-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/deep_merge-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/deep_merge-#{pkg.get_version}.gem"
 
   pkg.replaces "pe-rubygem-deep-merge"
 

--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -2,7 +2,7 @@ component "rubygem-fast_gettext" do |pkg, settings, platform|
   pkg.version "1.1.0"
   pkg.md5sum "fc0597bd4d84b749c579cc39c7ceda0f"
   pkg.url "https://rubygems.org/downloads/fast_gettext-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/fast_gettext-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/fast_gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -5,11 +5,11 @@ component "rubygem-ffi" do |pkg, settings, platform|
     if platform.architecture == "x64"
       pkg.md5sum "664afc6a316dd648f497fbda3be87137"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x64-mingw32.gem"
-      pkg.mirror "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x64-mingw32.gem"
+      pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x64-mingw32.gem"
     else
       pkg.md5sum "0b6fd994826952231d285f078cefce32"
       pkg.url "https://rubygems.org/downloads/ffi-#{pkg.get_version}-x86-mingw32.gem"
-      pkg.mirror "http://buildsources.delivery.puppetlabs.net/ffi-#{pkg.get_version}-x86-mingw32.gem"
+      pkg.mirror "#{settings[:buildsources_url]}/ffi-#{pkg.get_version}-x86-mingw32.gem"
     end
 
     pkg.build_requires "ruby-#{settings[:ruby_version]}"

--- a/configs/components/rubygem-gettext-setup.rb
+++ b/configs/components/rubygem-gettext-setup.rb
@@ -2,7 +2,7 @@ component "rubygem-gettext-setup" do |pkg, settings, platform|
   pkg.version "0.28"
   pkg.md5sum "65c8e2bb3fe8e07b91f8ea9f0b4c2196"
   pkg.url "https://rubygems.org/downloads/gettext-setup-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/gettext-setup-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/gettext-setup-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-gettext.rb
+++ b/configs/components/rubygem-gettext.rb
@@ -2,7 +2,7 @@ component "rubygem-gettext" do |pkg, settings, platform|
   pkg.version "3.2.2"
   pkg.md5sum "4cbb125f8d8206e9a8f3a90f6488e4da"
   pkg.url "https://rubygems.org/downloads/gettext-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/gettext-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/gettext-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-hocon.rb
+++ b/configs/components/rubygem-hocon.rb
@@ -2,7 +2,7 @@ component "rubygem-hocon" do |pkg, settings, platform|
   pkg.version "1.2.5"
   pkg.md5sum "e7821d3a731ab617320ccfa4f67f886b"
   pkg.url "https://rubygems.org/downloads/hocon-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/hocon-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/hocon-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-locale.rb
+++ b/configs/components/rubygem-locale.rb
@@ -2,7 +2,7 @@ component "rubygem-locale" do |pkg, settings, platform|
   pkg.version "2.1.2"
   pkg.md5sum "def1e89d1d3126a0c684d3b7b20d88d4"
   pkg.url "https://rubygems.org/downloads/locale-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/locale-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/locale-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-mini_portile2.rb
+++ b/configs/components/rubygem-mini_portile2.rb
@@ -2,7 +2,7 @@ component "rubygem-mini_portile2" do |pkg, settings, platform|
   pkg.version "2.1.0"
   pkg.md5sum "d771975a58cef82daa6b0ee03522293f"
   pkg.url "https://rubygems.org/downloads/mini_portile2-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/mini_portile2-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/mini_portile2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-minitar.rb
+++ b/configs/components/rubygem-minitar.rb
@@ -2,7 +2,7 @@ component "rubygem-minitar" do |pkg, settings, platform|
   pkg.version "0.6.1"
   pkg.md5sum "ce4ee63a94e80fb4e3e66b54b995beaa"
   pkg.url "https://rubygems.org/downloads/minitar-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/minitar-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/minitar-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-net-netconf.rb
+++ b/configs/components/rubygem-net-netconf.rb
@@ -2,7 +2,7 @@ component "rubygem-net-netconf" do |pkg, settings, platform|
   pkg.version "0.4.3"
   pkg.md5sum "fa173b0965766a427d8692f6b31c85a4"
   pkg.url "https://rubygems.org/downloads/net-netconf-#{get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-netconf-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/net-netconf-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "rubygem-net-scp"

--- a/configs/components/rubygem-net-scp.rb
+++ b/configs/components/rubygem-net-scp.rb
@@ -2,7 +2,7 @@ component "rubygem-net-scp" do |pkg, settings, platform|
   pkg.version "1.2.1"
   pkg.md5sum "abeec1cab9696e02069e74bd3eac8a1b"
   pkg.url "https://rubygems.org/downloads/net-scp-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-scp-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/net-scp-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
   pkg.build_requires "rubygem-net-ssh"

--- a/configs/components/rubygem-net-ssh-telnet2.rb
+++ b/configs/components/rubygem-net-ssh-telnet2.rb
@@ -2,7 +2,7 @@ component "rubygem-net-ssh-telnet2" do |pkg, settings, platform|
   pkg.version "0.1.1"
   pkg.md5sum "8fba7aada691a0c10caf5b74f57cfef2"
   pkg.url "https://rubygems.org/downloads/net-ssh-telnet2-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-ssh-telnet2-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/net-ssh-telnet2-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby"
   pkg.build_requires "rubygem-net-ssh"

--- a/configs/components/rubygem-net-ssh.rb
+++ b/configs/components/rubygem-net-ssh.rb
@@ -2,7 +2,7 @@ component "rubygem-net-ssh" do |pkg, settings, platform|
   pkg.version "4.1.0"
   pkg.md5sum "6af1ff8c42a07b11203058c9b74cbaef"
   pkg.url "https://rubygems.org/downloads/net-ssh-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/net-ssh-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/net-ssh-#{pkg.get_version}.gem"
 
   pkg.replaces 'pe-rubygem-net-ssh'
 

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -15,7 +15,7 @@ component "rubygem-nokogiri" do |pkg, settings, platform|
     end
   else
     pkg.url "https://rubygems.org/downloads/nokogiri-#{pkg.get_version}.gem"
-    pkg.mirror "http://buildsources.delivery.puppetlabs.net/nokogiri-#{pkg.get_version}.gem"
+    pkg.mirror "#{settings[:buildsources_url]}/nokogiri-#{pkg.get_version}.gem"
     pkg.md5sum "51402a536f389bfcef0ff1600b8acff5"
   end
 

--- a/configs/components/rubygem-pkg-config.rb
+++ b/configs/components/rubygem-pkg-config.rb
@@ -2,7 +2,7 @@ component "rubygem-pkg-config" do |pkg, settings, platform|
   pkg.version "1.1.7"
   pkg.md5sum "2767d4620b32f2a4ccddc18c353e5385"
   pkg.url "https://rubygems.org/downloads/pkg-config-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/pkg-config-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/pkg-config-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-semantic_puppet.rb
+++ b/configs/components/rubygem-semantic_puppet.rb
@@ -2,7 +2,7 @@ component "rubygem-semantic_puppet" do |pkg, settings, platform|
   pkg.version "0.1.2"
   pkg.md5sum "192ae7729997cb5d5364f64b99b13121"
   pkg.url "https://rubygems.org/downloads/semantic_puppet-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/semantic_puppet-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/semantic_puppet-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-text.rb
+++ b/configs/components/rubygem-text.rb
@@ -2,7 +2,7 @@ component "rubygem-text" do |pkg, settings, platform|
   pkg.version "1.3.1"
   pkg.md5sum "514c3d1db7a955fe793fc0cb149c164f"
   pkg.url "https://rubygems.org/downloads/text-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/text-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/text-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-dir.rb
+++ b/configs/components/rubygem-win32-dir.rb
@@ -2,7 +2,7 @@ component "rubygem-win32-dir" do |pkg, settings, platform|
   pkg.version "0.4.9"
   pkg.md5sum "df14aa01bd6011f4b6332a05e15b7fb8"
   pkg.url "https://rubygems.org/downloads/win32-dir-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-dir-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/win32-dir-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-process.rb
+++ b/configs/components/rubygem-win32-process.rb
@@ -2,7 +2,7 @@ component "rubygem-win32-process" do |pkg, settings, platform|
   pkg.version "0.7.5"
   pkg.md5sum "d7ff67c7934b0d6ab93030d2cc2fc4f0"
   pkg.url "https://rubygems.org/downloads/win32-process-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-process-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/win32-process-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-security.rb
+++ b/configs/components/rubygem-win32-security.rb
@@ -2,7 +2,7 @@ component "rubygem-win32-security" do |pkg, settings, platform|
   pkg.version "0.2.5"
   pkg.md5sum "97c4b971ea19ca48cea7dec1d21d506a"
   pkg.url "https://rubygems.org/downloads/win32-security-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-security-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/win32-security-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/rubygem-win32-service.rb
+++ b/configs/components/rubygem-win32-service.rb
@@ -2,7 +2,7 @@ component "rubygem-win32-service" do |pkg, settings, platform|
   pkg.version "0.8.8"
   pkg.md5sum "24cc05fed398eb931e14b8ee22196634"
   pkg.url "https://rubygems.org/downloads/win32-service-#{pkg.get_version}.gem"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/win32-service-#{pkg.get_version}.gem"
+  pkg.mirror "#{settings[:buildsources_url]}/win32-service-#{pkg.get_version}.gem"
 
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -2,7 +2,7 @@ component "virt-what" do |pkg, settings, platform|
   pkg.version "1.14"
   pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
   pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
-  pkg.mirror "http://buildsources.delivery.puppetlabs.net/virt-what-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-virt-what'
 


### PR DESCRIPTION
This commit replaces buildsources.delivery.puppetlabs.net with Artifactory.
I started this process on a branch that had fewer components, so I missed a bunch in the merge-up.