### PR TITLE
(PA-1619) Update ruby 2.4.2 to include zlib for AIX

### DIFF
--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -17,7 +17,6 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
     # This should be moved to the toolchain file
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -49,7 +49,6 @@ component "facter" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -21,7 +21,6 @@ component "pxp-agent" do |pkg, settings, platform|
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""

--- a/configs/components/ruby-2.4.2.rb
+++ b/configs/components/ruby-2.4.2.rb
@@ -144,6 +144,7 @@ component "ruby-2.4.2" do |pkg, settings, platform|
   if platform.is_deb?
     pkg.build_requires "zlib1g-dev"
   elsif platform.is_aix?
+    pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm"
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-devel-1.2.3-4.aix5.2.ppc.rpm"
   elsif platform.is_rpm?
     pkg.build_requires "zlib-devel"

--- a/configs/platforms/aix-6.1-ppc.rb
+++ b/configs/platforms/aix-6.1-ppc.rb
@@ -9,6 +9,12 @@ platform "aix-6.1-ppc" do |plat|
   # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
-  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs "
+  # We use --force with rpm because the pl-gettext and pl-autoconf
+  # packages conflict with a charset.alias file.
+  #
+  # Until we get those packages to not conflict (or we remove the need
+  # for pl-autoconf) we'll need to force the installation
+  #                                         Sean P. McD.
+  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
   plat.vmpooler_template "aix-6.1-power"
 end

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -9,6 +9,12 @@ platform "aix-7.1-ppc" do |plat|
   # Basic vanagon operations require mktemp, rsync, coreutils, tar and sed so leave this in there
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
-  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs "
+  # We use --force with rpm because the pl-gettext and pl-autoconf
+  # packages conflict with a charset.alias file.
+  #
+  # Until we get those packages to not conflict (or we remove the need
+  # for pl-autoconf) we'll need to force the installation
+  #                                         Sean P. McD.
+  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
   plat.vmpooler_template "aix-7.1-power"
 end


### PR DESCRIPTION
The AIX builds need to include the zlib package to correctly install
zlib-devel.