### PR TITLE
(PA-1733) Fix url for AIX pl-gcc package

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -100,7 +100,7 @@ def install_dependencies(agent)
     'zypper' => ['gcc', 'sqlite3-devel'],
     'opt/csw/bin/pkgutil' => ['sqlite3', 'libsqlite3_dev'],
     'rpm' => [
-      'http://pl-build-tools.delivery.puppetlabs.net/aix/5.3/ppc/pl-gcc-5.2.0-11.aix5.3.ppc.rpm',
+      'http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/pl-gcc-5.2.0-11.aix6.1.ppc.rpm',
       'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm',
       'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/info-4.6-1.aix5.1.ppc.rpm',
       'http://www.oss4aix.org/download/RPMS/readline/readline-7.0-3.aix5.1.ppc.rpm',


### PR DESCRIPTION
This was updated recently to point to a newer version of pl-gcc which
was never shipped for aix 5.3 since that platform has been EOL'ed. Point
it to the AIX 6.1 package instead.