### PR TITLE
(PA-1402) Avoid loading custom facts during upgrade

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -58,7 +58,7 @@ component "puppet" do |pkg, settings, platform|
       [<<-HERE.undent
         mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :
         if [ -x #{puppet_bin} ] ; then
-          #{puppet_bin} resource service puppet > #{service_statefile} || :
+          #{puppet_bin} resource service puppet | awk -F "'" '/ensure =>/ { print $2 }' > #{service_statefile} || :
         fi
         HERE
       ]
@@ -66,7 +66,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.add_postinstall_action ["upgrade"],
       [<<-HERE.undent
         if [ -f #{service_statefile} ] ; then
-          #{puppet_bin} apply #{service_statefile} > /dev/null 2>&1 || :
+          #{puppet_bin} resource service puppet ensure=$(cat #{service_statefile}) > /dev/null 2>&1 || :
           rm -rf #{rpm_statedir} || :
         fi
         HERE


### PR DESCRIPTION
Prior to this commit, we saved the output of
`puppet resource service puppet` and then applied it again after
upgrade with `puppet apply`.  This causes custom facts to be
loaded by `puppet apply` which is undesirable when your custom
fact wants to query the package manager.

After this commit, we blank out some puppet settings so that the
agent won't be able to find any custom facts that have been
pluginsynced or if its the agent on a master then custom facts
in the modulepath.