### PR TITLE
(PA-673) PA ENVIRONMENT should default to blank

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -102,11 +102,6 @@ End If
       Property="PUPPET_AGENT_ENVIRONMENT"
       Value="[CMDLINE_PUPPET_AGENT_ENVIRONMENT]"
       Execute="firstSequence" />
-    <CustomAction
-      Id="SetDefaultPuppetAgentEnvironment"
-      Property="PUPPET_AGENT_ENVIRONMENT"
-      Value="production"
-      Execute="firstSequence" />
 
     <!-- PUPPET_AGENT_CERTNAME -->
     <CustomAction

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -33,9 +33,6 @@
       <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='FileCost'>
         CMDLINE_PUPPET_AGENT_ENVIRONMENT
       </Custom>
-      <Custom Action='SetDefaultPuppetAgentEnvironment' Before='CostFinalize'>
-        PUPPET_AGENT_ENVIRONMENT=""
-      </Custom>
       <!-- PUPPET_AGENT_CERTNAME -->
       <Custom Action='SetFromIniPuppetAgentCertname' Before='FileCost'>
         INI_PUPPET_AGENT_CERTNAME
@@ -91,9 +88,6 @@
       <Custom Action='SaveCmdLinePuppetAgentEnvironment' Before='AppSearch' />
       <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='FileCost'>
         CMDLINE_PUPPET_AGENT_ENVIRONMENT
-      </Custom>
-      <Custom Action='SetDefaultPuppetAgentEnvironment' Before='CostFinalize'>
-        PUPPET_AGENT_ENVIRONMENT=""
       </Custom>
       <!-- PUPPET_AGENT_CERTNAME -->
       <Custom Action='SetFromIniPuppetAgentCertname' Before='FileCost'>


### PR DESCRIPTION
This was addressed originallin in PA-286 (in Puppet for the Win), but
this particular change didn't make it into the reworked Vanagon code.
So - ensure that if no ENVIRONMENT is set for the install then it should
not be set in puppet.conf, i.e. desired behaviour is:
- On a fresh install with PUPPET_AGENT_ENVIRONMENT not specified,
  puppet.conf does not have an environment key.
- On a fresh install with PUPPET_AGENT_ENVIRONMENT=foo specified,
  puppet.conf does have a key of environment=foo.
- On an upgrade where puppet.conf has an environment key, the value
  stays the same.
- On an upgrade where puppet.conf does not have an environment key,
  the key remains out of puppet.conf.