### PR TITLE
(RE-9300) Update Gemfile to allow shipping to Artifactory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')
-gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
+gem 'packaging', :github => 'puppetlabs/packaging', :branch => '1.0.x'
+gem 'artifactory'
 gem 'rake'
 gem 'json'
 gem 'rubocop', "~> 0.34.2"


### PR DESCRIPTION
For discussion:

This updates the bundle's Packaging dep to the 1.0.x branch and adds a dependency on the Artifactory gem. This should enable builds to start shipping into our internal Artifactory .