### PR TITLE
(packaging) Change vanagon target repo from 'PC1' to 'puppet5'

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -158,7 +158,7 @@ project "puppet-agent" do |proj|
   proj.license "See components"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppetlabs.com"
-  proj.target_repo "PC1"
+  proj.target_repo "puppet5"
 
   if platform.is_solaris?
     proj.identifier "puppetlabs.com"


### PR DESCRIPTION
This commit changes the vanagon target repo to 'puppet5' so that the nightly repo ship job knows where to find artifacts to ship to nightlies.pl.com.