### PR TITLE
(PA-1731) Update curl to v7.57.0

### DIFF
--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -1,23 +1,25 @@
 component 'curl' do |pkg, settings, platform|
-  pkg.version '7.56.1'
-  pkg.md5sum '48ba7bd7b363b40cd446d1e7b4be9920'
+  pkg.version '7.57.0'
+  pkg.md5sum 'c7aab73aaf5e883ca1d7518f93649dc2'
   pkg.url "https://curl.haxx.se/download/curl-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/curl-#{pkg.get_version}.tar.gz"
 
   pkg.build_requires "openssl"
   pkg.build_requires "puppet-ca-bundle"
 
   if platform.is_cross_compiled_linux?
     pkg.build_requires 'runtime'
+
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
     pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
-  end
-
-  if platform.is_windows?
+  elsif platform.is_windows?
     pkg.build_requires "runtime"
 
     pkg.environment "PATH" => "$$(cygpath -u #{settings[:gcc_bindir]}):$$PATH"
     pkg.environment "CYGWIN" => settings[:cygwin]
+  else
+    pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
   end
 
   pkg.configure do


### PR DESCRIPTION
Updates curl from 7.56.1 to 7.57.0.

+ The additional `environment` else case here is backported from 5.3.x and master, which had this path setting in their curl components.