### PR TITLE
(PA-1781) Bump fast_gettext for ruby 2.4 deprecation

### DIFF
--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -1,6 +1,6 @@
 component "rubygem-fast_gettext" do |pkg, settings, platform|
-  pkg.version "1.1.1"
-  pkg.md5sum "ceb03a1a979f288009d50d894beb0e22"
+  pkg.version "1.1.2"
+  pkg.md5sum "df5a2462d0e1d2e5d49bb233b841f4d6"
   pkg.url "https://rubygems.org/downloads/fast_gettext-#{pkg.get_version}.gem"
   pkg.mirror "#{settings[:buildsources_url]}/fast_gettext-#{pkg.get_version}.gem"
 


### PR DESCRIPTION
The fast_gettext emitted a deprecation warning on ruby 2.4 due to
IO#lines. Bump to 1.1.2.