### PR TITLE
(maint) Bump to packaging 1.0.x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
 project: 'puppet-agent'
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 # foss_platforms will be shipped to the nightly repos
 foss_platforms:


### PR DESCRIPTION
This commit changes the branch of packaging to clone from. As RE is working towards fully automating the shipping process, there is certain functionality in packaging#1.0.x that is necessary, but not present in packaging#master.