### PR TITLE
(maint) Update to use packaging as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def vanagon_location_for(place)
+def location_for(place)
   if place =~ /^(git[:@][^#]*)#(.*)/
     [{ :git => $1, :branch => $2, :require => false }]
   elsif place =~ /^file:\/\/(.*)/
@@ -10,9 +10,8 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')
-gem 'packaging', :github => 'puppetlabs/packaging', :branch => '1.0.x'
-gem 'artifactory'
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 gem 'rake'
 gem 'json'
 gem 'rubocop', "~> 0.34.2"

--- a/Rakefile
+++ b/Rakefile
@@ -1,39 +1,15 @@
-RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+require 'packaging'
 
-begin
-  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
-rescue LoadError
-end
+Pkg::Util::RakeUtils.load_packaging_tasks
 
-build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
-if File.exist?(build_defs_file)
-  begin
-    require 'yaml'
-    @build_defaults ||= YAML.load_file(build_defs_file)
-  rescue Exception => e
-    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
-    raise e
+namespace :package do
+  #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+  task :bootstrap do
+    puts 'This command is no longer needed, with packaging as a gem!'
   end
-  @packaging_url  = @build_defaults['packaging_url']
-  @packaging_repo = @build_defaults['packaging_repo']
-  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
-  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
-
-  namespace :package do
- #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
-    task :bootstrap do
-      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
-        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
-      else
-        cd File.join(RAKE_ROOT, 'ext') do
-          %x{git clone #{@packaging_url}}
-        end
-      end
-    end
- #   desc "Remove all cloned packaging automation"
-    task :implode do
-      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
-    end
+  #   desc "Remove all cloned packaging automation"
+  task :implode do
+    puts 'This command is no longer needed, with packaging as a gem!'
   end
 end
 


### PR DESCRIPTION
Rather than cloning packaging to ext/packaging, we should be using
packaging as a gem. This allows us to not directly depend on
artifactory, as that is only a dependency of packaging and also vastly
simplifies logic in the Rakefile. Support for the PACKAGING_VERSION
environment variable has also been added to support runtime switching of
which packaging we're building/shipping/etc with.