### PR TITLE
(PA-1245) Add defs for cfacter-source-gem project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,10 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.4')
 gem 'packaging', :github => 'puppetlabs/packaging', :branch => '1.0.x'
 gem 'artifactory'
 gem 'rake'
 gem 'json'
+gem 'octokit'
 gem 'rubocop', "~> 0.34.2"

--- a/configs/components/cfacter-precompiled-gem.rb
+++ b/configs/components/cfacter-precompiled-gem.rb
@@ -1,0 +1,52 @@
+component "cfacter-precompiled-gem" do |pkg, settings, platform|
+  pkg.build_requires 'cfacter-source-gem'
+
+  pkg.add_source("file://resources/files/cfacter-gem/cfacter-precompiled.gemspec.erb", erb: 'true')
+  pkg.install_file('cfacter-precompiled.gemspec', "#{settings[:gemdir]}")
+
+  if platform.is_osx?
+    pkg.build_requires "cmake"
+    pkg.build_requires "boost"
+    pkg.build_requires "yaml-cpp"
+  elsif platform.is_windows?
+    pkg.build_requires "cmake"
+    pkg.build_requires "pl-toolchain-#{platform.architecture}"
+    pkg.build_requires "pl-boost-#{platform.architecture}"
+    pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+  else
+    pkg.build_requires "pl-gcc"
+    pkg.build_requires "pl-cmake"
+    pkg.build_requires "pl-boost"
+    pkg.build_requires "pl-yaml-cpp"
+  end
+
+  pkg.add_source("file://resources/files/cfacter-gem/make.bat")
+  pkg.install_file('make.bat', "#{settings[:build_tools_dir]}")
+
+  if platform.is_osx?
+    make = 'make'
+    pkg.environment "PATH" => "/usr/local/bin:#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
+    pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
+  elsif platform.is_windows?
+    make = "#{settings[:gcc_bindir]}/mingw32-make"
+    pkg.environment "PATH" => "/cygdrive/c/ProgramData/chocolatey/bin:$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:build_tools_dir]}):$$(cygpath -u #{settings[:ruby_dir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment('FACTER_CMAKE_OPTS', '-G \"MinGW Makefiles\" -DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DCMAKE_TOOLCHAIN_FILE=C:\tools\pl-build-tools\pl-build-toolchain.cmake -DWITHOUT_JRUBY=ON')
+  else
+    make = 'make'
+    pkg.environment "PATH" => "#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
+    pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
+  end
+
+
+  pkg.install do
+    [
+      "pushd #{settings[:gemdir]}",
+      "pushd ext/facter",
+      "#{settings[:ruby_binary]} extconf.rb",
+      "#{make} install",
+      "popd",
+      "#{settings[:gem_binary]} build cfacter-precompiled.gemspec",
+      "popd"
+    ]
+  end
+end

--- a/configs/components/cfacter-source-gem.rb
+++ b/configs/components/cfacter-source-gem.rb
@@ -1,0 +1,21 @@
+component "cfacter-source-gem" do |pkg, settings, platform|
+  pkg.build_requires 'facter-source'
+  pkg.build_requires 'leatherman-source'
+  pkg.build_requires 'cpp-hocon-source'
+  pkg.build_requires 'puppet-runtime'
+
+  pkg.add_source("file://resources/files/cfacter-gem/cfacter-source.gemspec.erb", erb: 'true')
+  pkg.add_source("file://resources/files/cfacter-gem/extconf.rb")
+  pkg.add_source("file://resources/files/cfacter-gem/Makefile.erb")
+  pkg.install_file('cfacter-source.gemspec', "#{settings[:gemdir]}")
+  pkg.install_file('extconf.rb', "#{settings[:gemdir]}/ext/facter")
+  pkg.install_file('Makefile.erb', "#{settings[:gemdir]}/ext/facter")
+
+  pkg.install do
+    [
+      "pushd #{settings[:gemdir]}",
+      "#{settings[:gem_binary]} build cfacter-source.gemspec",
+      "popd"
+    ]
+  end
+end

--- a/configs/components/cpp-hocon-source.rb
+++ b/configs/components/cpp-hocon-source.rb
@@ -1,0 +1,10 @@
+component "cpp-hocon-source" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/cpp-hocon.json')
+
+  pkg.build do
+    [
+      "mkdir -p #{settings[:gemdir]}/ext/facter/cpp-hocon",
+      "cp -r * #{settings[:gemdir]}/ext/facter/cpp-hocon"
+    ]
+  end
+end

--- a/configs/components/facter-source.rb
+++ b/configs/components/facter-source.rb
@@ -1,0 +1,10 @@
+component "facter-source" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/facter.json')
+
+  pkg.build do
+    [
+      "mkdir -p #{settings[:gemdir]}/ext/facter/facter",
+      "cp -r * #{settings[:gemdir]}/ext/facter/facter"
+    ]
+  end
+end

--- a/configs/components/leatherman-source.rb
+++ b/configs/components/leatherman-source.rb
@@ -1,0 +1,10 @@
+component "leatherman-source" do |pkg, settings, platform|
+  pkg.load_from_json('configs/components/leatherman.json')
+
+  pkg.build do
+    [
+      "mkdir -p #{settings[:gemdir]}/ext/facter/leatherman",
+      "cp -r * #{settings[:gemdir]}/ext/facter/leatherman"
+    ]
+  end
+end

--- a/configs/projects/cfacter.rb
+++ b/configs/projects/cfacter.rb
@@ -1,0 +1,53 @@
+require 'json'
+require 'octokit'
+
+project "cfacter" do |proj|
+  platform = proj.get_platform
+  # We don't generate the version for the facter gem in the same way we do
+  # for other vanagon projects. We read from the facter project to find facter's
+  # version, then use release_from_git to decide if we are on an agent tag.
+  # If we _are_ on an agent tag, the facter gem is versioned as:
+  #   'facterX'.'facterY'.'facterZ'.'date'
+  # if we _are not_ at a tag the version will be:
+  #   'facterX'.'facterY'.'facterZ'.rc.'date'
+  facter_data = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../components/facter.json')))
+  facter_version_file = Base64.decode64(Octokit::Client.new.contents('puppetlabs/facter', path: 'CMakeLists.txt', ref: facter_data['ref']).content)
+  facter_version = facter_version_file.match(/project\(FACTER VERSION [\d\.]*\)/).to_s.gsub(/[^\d\.]/, '')
+  gem_version = facter_version
+  # identify if we are at a tag. Git sets the release to '0' when we are on a tag
+  # note that we ignore the actual value of release_from_git other than to check
+  # if it was 0
+  proj.release_from_git
+  if proj._project.release.to_s == '0'
+    gem_version += '.'
+  else
+    gem_version += ".rc."
+  end
+  gem_version += Time.now.strftime("%Y%m%d")
+  proj.version gem_version
+
+  proj.setting(:project_version, gem_version)
+  proj.setting(:gemdir, '/var/tmp/facter_gem')
+  if platform.is_windows?
+    proj.setting(:ruby_dir, '/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/sys/ruby')
+    proj.setting(:gem_binary, 'cmd /c "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\gem.bat"')
+    proj.setting(:ruby_binary, 'cmd /c "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe"')
+    proj.setting(:build_tools_dir, '/cygdrive/c/tools/pl-build-tools/bin')
+    arch = platform.architecture == "x64" ? "64" : "32"
+    proj.setting(:gcc_bindir, "C:/tools/mingw#{arch}/bin")
+  else
+    proj.setting(:ruby_dir, '/opt/puppetlabs/puppet/bin')
+    proj.setting(:gem_binary, File.join(proj.ruby_dir, 'gem'))
+    proj.setting(:ruby_binary, File.join(proj.ruby_dir, 'ruby'))
+    proj.setting(:build_tools_dir, '/opt/pl-build-tools/bin')
+  end
+
+  proj.component "facter-source"
+  proj.component "leatherman-source"
+  proj.component "cpp-hocon-source"
+  proj.component "cfacter-source-gem"
+  proj.component "cfacter-precompiled-gem"
+  proj.component "puppet-runtime"
+  proj.fetch_artifact "#{settings[:gemdir]}/cfacter*.gem"
+  proj.no_packaging true
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -146,3 +146,4 @@ vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
 build_tar: FALSE
+build_gem: TRUE

--- a/resources/files/cfacter-gem/Makefile.erb
+++ b/resources/files/cfacter-gem/Makefile.erb
@@ -1,0 +1,31 @@
+CMAKE=<%= cmake_binary %>
+ROOT=<%= source_root %>
+OPTS=-DCMAKE_INSTALL_PREFIX=../../prefix -DLEATHERMAN_GETTEXT=OFF <%= cmake_opts %>
+
+LEATHERMAN=-DLeatherman_DIR=`pwd`/../../prefix/lib/cmake/leatherman
+
+all: facter.built
+
+leatherman.built:
+	<%= mkdir_command %> "build/leatherman"
+	cd build/leatherman && \
+	${CMAKE} -DLEATHERMAN_SHARED=OFF ${OPTS} ${ROOT}/leatherman && \
+	make install
+	<%= touch_command %> leatherman.built
+
+hocon.built: leatherman.built
+	<%= mkdir_command %> "build/cpp-hocon"
+	cd build/cpp-hocon && \
+	${CMAKE} -DBUILD_SHARED_LIBS=OFF ${LEATHERMAN} ${OPTS} ${ROOT}/cpp-hocon && \
+	make install
+	<%= touch_command %> hocon.built
+
+facter.built: hocon.built
+	<%= mkdir_command %> "build/facter"
+	cd build/facter && \
+	${CMAKE} -DRUBY_LIB_INSTALL=${ROOT}/prefix/lib ${LEATHERMAN} ${OPTS} ${ROOT}/facter && \
+	make install
+	<%= touch_command %> facter.built
+
+install: facter.built
+	<%= install_command %>

--- a/resources/files/cfacter-gem/cfacter-precompiled.gemspec.erb
+++ b/resources/files/cfacter-gem/cfacter-precompiled.gemspec.erb
@@ -1,0 +1,10 @@
+Gem::Specification.new 'cfacter', '<%= settings[:project_version] %>' do |s|
+  s.summary               = 'Facter gem wrapper'
+  s.authors               = %w[Puppet Inc.]
+  s.email                 = "info@puppet.com"
+  s.license               = 'Apache-2.0'
+  s.platform              = Gem::Platform::CURRENT
+  s.required_ruby_version = '>= 0'
+  s.files                 = Dir.glob('lib/**/*')
+end
+

--- a/resources/files/cfacter-gem/cfacter-source.gemspec.erb
+++ b/resources/files/cfacter-gem/cfacter-source.gemspec.erb
@@ -1,0 +1,13 @@
+Gem::Specification.new 'cfacter', '<%= settings[:project_version] %>' do |s|
+  s.summary     = 'Facter gem wrapper'
+  s.authors     = %w[Puppet Inc.]
+  s.email       = "info@puppet.com"
+  s.license     = 'Apache-2.0'
+
+  # this tells RubyGems to build an extension upon install
+  s.extensions  = %w[ext/facter/extconf.rb]
+
+  # naturally you must include the extension source in the gem
+  s.files       = Dir.glob('ext/**/*')
+end
+

--- a/resources/files/cfacter-gem/extconf.rb
+++ b/resources/files/cfacter-gem/extconf.rb
@@ -1,0 +1,22 @@
+require 'mkmf'
+require 'erb'
+
+cmake_binary = find_executable('cmake')
+source_root = File.expand_path("#{__FILE__}/..")
+cmake_opts = ENV['FACTER_CMAKE_OPTS']
+
+if RbConfig::CONFIG['arch'].include?('mingw')
+  windows_native_source = source_root.gsub('/', '\\')
+  # xcopy will make the libdir for us, so there's no mkdir for windows
+  install_command = "xcopy \"prefix\\bin\\*facter*\" \"#{windows_native_source}\\..\\..\\lib\" /i"
+  touch_command = 'type nul >'
+  mkdir_command = 'mkdir'
+else
+  install_command = "mkdir -p #{source_root}/../../lib && cp prefix/lib/*facter* #{source_root}/../../lib"
+  touch_command = 'touch'
+  mkdir_command = 'mkdir -p'
+end
+
+make_template = File.open(source_root+"/Makefile.erb").read
+makefile = ERB.new(make_template).result(binding)
+File.write('Makefile', makefile)

--- a/resources/files/cfacter-gem/make.bat
+++ b/resources/files/cfacter-gem/make.bat
@@ -1,0 +1,1 @@
+mingw32-make.exe %*


### PR DESCRIPTION
This will be a new vanagon project included with the agent. It makes use of 5
components:

* cpp-hocon-source < just the entire cpp-hocon source copied in to place
* leatherman-source < just the entire leatherman project copied in to place
* facter-source < just the entire facter project copied in to place
* cfacter-source-gem < a component with build rules to construct the source gem
from sources and resource files.
* cfacter-precompiled-gem < a component with build rules to actually precompile a gem and package it up

This commit is entirely additive, and should not effect the agent in any way.

The cfacter source gem is a gem that can be installed on a system with new
enough gcc/boost/cmake to give the user access to facter.

the cfacter precompiled gem should be installable right away on a system matching the arch and OS type

This commit makes use of changes from
https://github.com/puppetlabs/vanagon/pull/543