### PR TITLE
(maint) Set component versions for 5.4.0

### DIFF
--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/cpp-pcp-client.git","ref":"62c797a2b10d8ddf9f389cb63efebcd24fc96598"}
+{"url":"git://github.com/puppetlabs/cpp-pcp-client.git","ref":"refs/tags/1.5.5"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"fc6036de9b4159a5f979d6c0216d20d86437f930"}
+{"url":"git://github.com/puppetlabs/facter.git","ref":"ae9a9897dcb21e2fc15fc3764514bcf77be0a31a"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/hiera.git","ref":"ba12dfedaf9949ea4b1ef6ddd013e9ee2925bc72"}
+{"url":"git://github.com/puppetlabs/hiera.git","ref":"refs/tags/3.4.2"}

--- a/configs/components/marionette-collective.json
+++ b/configs/components/marionette-collective.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "c2d10c64af26bf6b24a5f0aee5b4caf31a61300f"}
+{"url": "git://github.com/puppetlabs/marionette-collective.git", "ref": "refs/tags/2.11.4"}

--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/nssm.git", "ref": "b0b01ded7c42178855bbf88b3943b1c5522768bc"}
+{"url": "git://github.com/puppetlabs/nssm.git", "ref": "refs/tags/2.24.2"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"af4bb4186c93a4254adf938aef7bb0686bbca12d"}
+{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"109650863ce2621637ad4b4bd477a190f54269b0"}


### PR DESCRIPTION
These generally match the versions used in the 5.3.4 release branch, with the exception of puppet, leatherman, and libwhereami, all of which use new source branches for the 5.4.x branch of puppet-agent.