### PR TITLE
(packaging) Pin hiera to 3.4.2 for agent 5.4.0 release

### DIFF
--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/hiera.git","ref":"7e0cbf18e6179f499517e6841847d401f69df067"}
+{"url":"git://github.com/puppetlabs/hiera.git","ref":"refs/tags/3.4.2"}


### PR DESCRIPTION
7e0cbf18e6179f499517e6841847d401f69df067 is [just an empty commit](https://github.com/puppetlabs/hiera/commit/7e0cbf18e6179f499517e6841847d401f69df067) erroneously generated by our CI - pinning to 3.4.2, since there are no other hiera changes.