### PR TITLE
Use pxp-agent 1.8.2 tag for PA 5.4.0

### DIFF
--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"109650863ce2621637ad4b4bd477a190f54269b0"}
+{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"refs/tags/1.8.2"}


### PR DESCRIPTION
Sets the pxp-agent ref to 1.8.2, which was tagged in the 5.3.5-release branch today. Other components will be tagged for 5.4.0 later.