### PR TITLE
(maint) Bump puppet to revert PUP-2868 in advance of 5.4.0 release

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"db8636334d86ed5809e4a596a34fb6d11e99cd8e"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"b483798b01cf4f9846bf1173b4be391c2fda07c5"}


### PR DESCRIPTION
I just cut a puppet [5.4.0-release branch](https://github.com/puppetlabs/puppet/commits/5.4.0-release) to get the cherry-pick of the PUP-2868 revert from 5.4.x into 5.4.0 without including 5.4.x's version bump to 5.4.1. This commit points puppet at that branch's HEAD.