### PR TITLE
(PA-1402) Ensure puppet apply is not called for mcollective service

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -52,7 +52,7 @@ component "marionette-collective" do |pkg, settings, platform|
   if (platform.servicetype == "sysv" && platform.is_rpm?) || platform.is_aix?
     puppet_bin = "/opt/puppetlabs/bin/puppet"
     rpm_statedir = "%{_localstatedir}/lib/rpm-state/#{pkg.get_name}"
-    service_statefile = "#{rpm_statedir}/service.pp"
+    service_statefile = "#{rpm_statedir}/service_state"
     pkg.add_preinstall_action ["upgrade"],
       [<<-HERE.undent
         mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :

--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -57,7 +57,7 @@ component "marionette-collective" do |pkg, settings, platform|
       [<<-HERE.undent
         mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :
         if [ -x #{puppet_bin} ] ; then
-          #{puppet_bin} resource service mcollective > #{service_statefile} || :
+          #{puppet_bin} resource service mcollective | awk -F "'" '/ensure =>/ { print $2 }' > #{service_statefile} || :
         fi
         HERE
       ]
@@ -65,7 +65,7 @@ component "marionette-collective" do |pkg, settings, platform|
     pkg.add_postinstall_action ["upgrade"],
       [<<-HERE.undent
         if [ -f #{service_statefile} ] ; then
-          #{puppet_bin} apply #{service_statefile} > /dev/null 2>&1 || :
+          #{puppet_bin} resource service mcollective ensure=$(#{service_statefile}) > /dev/null 2>&1 || :
           rm -rf #{rpm_statedir} || :
         fi
         HERE

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -53,7 +53,7 @@ component "puppet" do |pkg, settings, platform|
   if (platform.servicetype == "sysv" && platform.is_rpm?) || platform.is_aix?
     puppet_bin = "/opt/puppetlabs/bin/puppet"
     rpm_statedir = "%{_localstatedir}/lib/rpm-state/#{pkg.get_name}"
-    service_statefile = "#{rpm_statedir}/service.pp"
+    service_statefile = "#{rpm_statedir}/service_state"
     pkg.add_preinstall_action ["upgrade"],
       [<<-HERE.undent
         mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :


### PR DESCRIPTION
The first pass at this ticket only fixed the puppet service
management. The same approach is used for mcollective, which also
needs to be fixed up.