### PR TITLE
(PA-1890) Copy the old hiera.yaml files instead of renaming them.

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -251,28 +251,44 @@ component "puppet" do |pkg, settings, platform|
     env_hiera = File.join(settings[:puppet_codedir], 'environments', 'production', 'hiera.yaml')
     rmv_hiera = File.join(configdir, 'remove_hiera5_files.rm')
 
-    # Pre-Install script to save copies of existing hiera configuration files.
-    # This also creates "marker files to indicate that the files pre-existed."
+    # Pre-Install script saves copies of existing hiera configuration files,
+    # and also creates "marker" files to indicate that the files pre-existed.
+    # We want to ensure that our copy preserves the metadata (e.g. permissions,
+    # timestamps, extended attributes) of the existing hiera config. files. The
+    # necessary flags that do this are platform dependent.
+    if platform.is_solaris?
+      # The @ option preserves extended attributes
+      cp_cmd = "cp -p@"
+    elsif platform.is_aix?
+      # The U option preserves extended attributes.
+      # On AIX 7.2, the S option preserves file
+      # sparseness.
+      cp_cmd = "cp -pU"
+      cp_cmd += "S" if platform.name =~ /7.2/
+    else
+      cp_cmd = "cp -a"
+    end
+
     preinstall = <<-PREINST
 # Backup the old hiera configs if present, so that we
 # can drop them back in place if the package manager
 # tries to remove it.
 if [ -e #{old_hiera} ]; then
-  mv #{old_hiera}{,.pkg-old}
+  #{cp_cmd} #{old_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi
 if [ -e #{cnf_hiera} ]; then
-  mv #{cnf_hiera}{,.pkg-old}
+  #{cp_cmd} #{cnf_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi
 if [ -e #{env_hiera} ]; then
-  mv #{env_hiera}{,.pkg-old}
+  #{cp_cmd} #{env_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi
 PREINST
 
-    # Post-install script to restore old hiera config files if the have been saved.
-    # and remove any extre hiera configuration files that we laid down
+    # Post-install script restores any old hiera config files that have been saved.
+    # It also remove any extra hiera configuration files that we laid down.
     postinstall = <<-POSTINST
 # Remove any extra hiera config files we laid down if prev config present
 if [ -e #{rmv_hiera} ]; then


### PR DESCRIPTION
RPM 4.14.0 contains the following commit: rpm-software-management/rpm@79ca74e. The commit introduces a new feature to RPM when upgrading packages. It is best described as follows. Assume that Package B is an upgraded version of Package A; both share a File C. Before RPM 4.14.0, RPM would create Package B's File C with a unique suffix, and then rename it to Package A's File C for all files (hence the upgrade). However with RPM 4.14.0 and that commit, RPM will instead, for some files, proceed to only update Package A's File C's metadata without doing anything else (from the commit diff and based on http://rpm.org/wiki/Releases/4.14.0) - these files are designated with an FA_TOUCH action. So essentially, RPM 4.14.0 gives you the opportunity to preserve the content of old config. files without having to explicitly do so in pre and post-installation scripts.

When we upgrade the agent, say from 5.3.x to 5.4.x, we preserve any hiera.yaml files on that agent via. the pre and post installation scripts outlined in https://github.com/ekinanp/puppet-agent/blob/5.3.x/configs/components/puppet.rb#L254-L295. Notice that in https://github.com/ekinanp/puppet-agent/blob/5.3.x/configs/components/puppet.rb#L254-L272, we rename the hiera.yaml files to have the additional pkg-old suffix via. the mv command. However RPM 4.14.0 associates the hiera.yaml files with the FA_TOUCH action, so that it will only overwrite the old agent's hiera.yaml files' metadata. But after the pre-installation script runs, those files do not exist – they were renamed. Hence, RPM would fail during the agent upgrade because it would try to update a non-existent file's metadata.

This failure was detected during the process of adding Fedora 27 x86_64 to the agent, but it will most definitely affect newer Linux OSes in the future.

By using `cp` instead of `mv`, we ensure that the hiera.yaml files continue to exist after the pre-installation script so that RPM successfully updates their metadata. We still need to save the old hiera.yaml files to maintain compatibility with other package managers and earlier versions of RPM that may not have an FA_TOUCH feature, and to also preserve their metadata.