### PR TITLE
(PA-1893) Update virt-what from version 1.14 to version 1.18

### DIFF
--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -1,6 +1,7 @@
 component "virt-what" do |pkg, settings, platform|
-  pkg.version "1.14"
-  pkg.md5sum "4d9bb5afc81de31f66443d8674bb3672"
+  pkg.version "1.18"
+  pkg.md5sum "28661e619e36eadb17af70cb9bca9551"
+
   pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-virt-what'

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -3,6 +3,7 @@ component "virt-what" do |pkg, settings, platform|
   pkg.md5sum "28661e619e36eadb17af70cb9bca9551"
 
   pkg.url "https://people.redhat.com/~rjones/virt-what/files/virt-what-#{pkg.get_version}.tar.gz"
+  pkg.mirror "#{settings[:buildsources_url]}/virt-what-#{pkg.get_version}.tar.gz"
 
   pkg.replaces 'pe-virt-what'
 


### PR DESCRIPTION
Updates virt-what from version 1.14 to 1.18, and adds a mirror URL for the source.