### PR TITLE
(PA-1894) Add custom vendor dir for shared rubygems

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -16,7 +16,10 @@ def package_installer(agent)
 end
 
 def setup_build_environment(agent)
-  gem_install_sqlite3 = gem_command(agent) + " install sqlite3"
+  # We set the gem path for install here to our internal shared vendor
+  # path. This allows us to verify that our Ruby is able to read from
+  # this path when listing / loading gems in the test below.
+  gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3"
   install_package_on_agent = package_installer(agent)
 
   case agent['platform']

--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -23,6 +23,10 @@ component "ruby-2.4.3" do |pkg, settings, platform|
   pkg.apply_patch "#{base}/ostruct_remove_safe_nav_operator.patch"
   pkg.apply_patch "#{base}/thread_wakeup_ownership_check.patch"
 
+  # This patch creates our server/client shared Gem path, used for all
+  # gems that are dependencies of the shared Ruby code.
+  pkg.apply_patch "#{base}/rubygems_add_puppet_vendor_dir.patch"
+
   # These are a pretty smelly hack, and they run the risk of letting tests
   # based on the generated data (that should otherwise fail) pass
   # erroneously. We should probably fix the "not shipping our compiler"

--- a/resources/patches/ruby_243/rubygems_add_puppet_vendor_dir.patch
+++ b/resources/patches/ruby_243/rubygems_add_puppet_vendor_dir.patch
@@ -1,0 +1,45 @@
+diff --git a/lib/rubygems/defaults.rb b/lib/rubygems/defaults.rb
+index 43d57fc808..39eaafd6de 100644
+--- a/lib/rubygems/defaults.rb
++++ b/lib/rubygems/defaults.rb
+@@ -52,6 +52,32 @@ def self.default_dir
+     @default_dir ||= File.join(*path)
+   end
+ 
++  ##
++  # Additional default directory which does not include the ruby version
++  # Used for gems shared between puppet-server and puppet-agent
++
++  def self.puppet_vendor_dir
++    path = if defined? RUBY_FRAMEWORK_VERSION then
++             [
++               File.dirname(RbConfig::CONFIG['sitedir']),
++               'VendorGems'
++             ]
++           elsif RbConfig::CONFIG['rubylibprefix'] then
++             [
++              RbConfig::CONFIG['rubylibprefix'],
++              'vendor_gems',
++             ]
++           else
++             [
++               RbConfig::CONFIG['libdir'],
++               'ruby',
++               'vendor_gems',
++             ]
++           end
++
++    @puppet_vendor_dir ||= File.join(*path)
++  end
++
+   ##
+   # Returns binary extensions dir for specified RubyGems base dir or nil
+   # if such directory cannot be determined.
+@@ -93,6 +119,7 @@ def self.default_path
+     path = []
+     path << user_dir if user_home && File.exist?(user_home)
+     path << default_dir
++    path << puppet_vendor_dir
+     path << vendor_dir if vendor_dir and File.directory? vendor_dir
+     path
+   end


### PR DESCRIPTION
Puppet has a number of gem dependencies that are shared between using it in a server or client context. These dependencies are currently duplicated in both the agent and server packages, since both need to be able to load Puppet's ruby code.

The problem with this is that adding new dependencies to Puppet requires a dance with server releases, in order to ensure new versions of the puppet code can still run with older servers that do not include the gems, and in order to ensure that the latest server always ships the gems needed to enable all of Puppet's features.

Instead, we are introducing a new vendored gem directory which will contain gems intended to be used on both the agent and server. This will allow us to ship the required gems along with the shared Puppet code, ensuring the necessary gems for new features will always be present.

There are a couple of special requirements here that mean we don't want to use the normal vendor_ruby/gems dir:

1. This path needs to be ruby-version-independent, since it needs to be a stable API between agent and server packages even across major versions.
2. Because this path will be loaded by both MRI and JRuby, it needs to contain only pure-ruby gems. We want to keep the standard vendor_ruby/gems path available to ourselves for MRI-specific gems.