### PR TITLE
(PA-1896) Enable builds for Debian 9 on armhf

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -6,6 +6,14 @@ component 'augeas' do |pkg, settings, platform|
 
   pkg.replaces 'pe-augeas'
   pkg.build_requires "libxml2"
+
+  if platform.name =~ /debian-9-armhf/
+    pkg.build_requires "libreadline-dev:#{platform.architecture}"
+    pkg.build_requires "pkg-config"
+    pkg.environment "CFLAGS", settings[:cflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
+  end
+
   if platform.name =~ /^el-(5|6|7)-.*/ || platform.is_fedora?
     # Augeas needs a libselinux pkgconfig file on these platforms
     pkg.build_requires 'ruby-selinux'

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -12,8 +12,14 @@ component "cpp-hocon" do |pkg, settings, platform|
     cmake = "/usr/local/bin/cmake"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   elsif platform.is_cross_compiled_linux?
-    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
-    cmake = "/opt/pl-build-tools/bin/cmake"
+    # Debian 9 (armhf currently) is not using pl-build-tools
+    if platform.name =~ /debian-9-armhf/
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+      cmake = "/usr/bin/cmake"
+    else
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+      cmake = "/opt/pl-build-tools/bin/cmake"
+    end
   elsif platform.is_solaris?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
@@ -36,16 +42,25 @@ component "cpp-hocon" do |pkg, settings, platform|
     end
   end
 
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+  end
+
   # Until we build our own gettext packages, disable using locales.
   # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        #{boost_args} \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        -DBOOST_STATIC=#{boost_static} \
         ."]
   end
 

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -32,6 +32,10 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+    if platform.name =~ /debian-9-armhf/
+      cmake = "/usr/bin/cmake"
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+    end
   elsif platform.is_solaris?
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
@@ -45,10 +49,19 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end
 
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+  end
+
   pkg.configure do
     [
       "#{cmake} \
       #{toolchain} \
+      #{boost_args} \
       #{platform_flags} \
           -DLEATHERMAN_GETTEXT=ON \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -56,7 +69,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
-          -DBOOST_STATIC=ON \
+          -DBOOST_STATIC=#{boost_static} \
           ."
     ]
   end

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -18,7 +18,7 @@ component 'curl' do |pkg, settings, platform|
   pkg.build_requires "puppet-ca-bundle"
 
   if platform.is_cross_compiled_linux?
-    pkg.build_requires 'runtime'
+    pkg.build_requires 'runtime' unless platform.name =~ /debian-9-armhf/
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH:#{settings[:bindir]}"
     pkg.environment "PKG_CONFIG_PATH" => "/opt/puppetlabs/puppet/lib/pkgconfig"
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"

--- a/configs/components/dmidecode.rb
+++ b/configs/components/dmidecode.rb
@@ -1,5 +1,5 @@
 component 'dmidecode' do |pkg, settings, platform|
-  if platform.name == 'el-7-aarch64'
+  if platform.name == 'el-7-aarch64' || platform.name =~ /debian-9-armhf/
     pkg.version '3.1'
     pkg.md5sum '7798f68a02b82358c44af913da3b6b42'
   else
@@ -21,12 +21,13 @@ component 'dmidecode' do |pkg, settings, platform|
 
   pkg.environment "LDFLAGS", settings[:ldflags]
   pkg.environment "CFLAGS", settings[:cflags]
+  pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
 
   if platform.is_cross_compiled?
     # The Makefile doesn't honor environment overrides, so we need to
     # edit it directly for cross-compiling
     pkg.configure do
-      ["sed -i \"s|gcc|/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc|g\" Makefile"]
+      ["sed -i \"s|gcc|#{settings[:platform_triple]}-gcc|g\" Makefile"]
     end
   end
 

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -22,7 +22,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   pkg.build_requires 'leatherman'
-  pkg.build_requires 'runtime'
+  pkg.build_requires 'runtime' unless platform.name =~ /debian-9-armhf/
   pkg.build_requires 'cpp-hocon'
   pkg.build_requires 'libwhereami'
 
@@ -45,13 +45,26 @@ component "facter" do |pkg, settings, platform|
   elsif platform.name =~ /solaris-10/
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-yaml-cpp-0.5.1.#{platform.architecture}.pkg.gz"
   elsif platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
-    pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+    if platform.name =~ /debian-9-armhf/
+      pkg.build_requires "libyaml-cpp-dev:#{platform.architecture}"
+      pkg.requires "libyaml-cpp0.5v5"
+      pkg.requires "libboost-date-time1.62.0"
+      pkg.requires "libboost-thread1.62.0"
+      pkg.requires "libboost-chrono1.62.0"
+      pkg.requires "libboost-atomic1.62.0"
+      pkg.requires "libboost-log1.62.0"
+      pkg.requires "libboost-locale1.62.0"
+    else
+      pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+    end
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+  elsif platform.name =~ /debian-9-armhf/
+    pkg.build_requires "cmake"
   else
     pkg.build_requires "pl-yaml-cpp"
   end
@@ -132,6 +145,10 @@ component "facter" do |pkg, settings, platform|
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+    if platform.name =~ /debian-9-armhf/
+      cmake = "/usr/bin/cmake"
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+    end
   elsif platform.is_solaris?
     if platform.architecture == 'sparc'
       ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
@@ -169,17 +186,28 @@ component "facter" do |pkg, settings, platform|
                        -DRUBY_LIB_INSTALL=#{settings[:ruby_vendordir]}"
   end
 
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+    yamlcpp_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+    yamlcpp_static = "ON"
+  end
+
   # FACTER_RUBY Needs bindir
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        #{boost_args} \
         -DLEATHERMAN_GETTEXT=ON \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
-        -DYAMLCPP_STATIC=ON \
+        -DBOOST_STATIC=#{boost_static} \
+        -DYAMLCPP_STATIC=#{yamlcpp_static} \
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -7,6 +7,32 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "cmake"
     pkg.build_requires "boost"
     pkg.build_requires "gettext"
+  elsif platform.name =~ /debian-9-armhf/
+    pkg.build_requires "toolchain"
+    pkg.build_requires "libboost-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-regex-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-atomic-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-chrono-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-date-time-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-exception-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-filesystem-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-graph-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-graph-parallel-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-iostreams-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-locale-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-log-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-math-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-program-options-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-random-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-serialization-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-signals-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-test-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-system-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-thread-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-timer-dev:#{platform.architecture}"
+    pkg.build_requires "libboost-wave-dev:#{platform.architecture}"
+    pkg.build_requires "cmake"
+    pkg.build_requires "gettext"
   elsif platform.name =~ /solaris-10/
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-boost-1.58.0-7.#{platform.architecture}.pkg.gz"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-cmake-3.2.3-2.i386.pkg.gz"
@@ -34,7 +60,7 @@ component "leatherman" do |pkg, settings, platform|
   end
 
   pkg.build_requires "curl"
-  pkg.build_requires "runtime"
+  pkg.build_requires "runtime" unless platform.name =~ /debian-9-armhf/
   pkg.build_requires "ruby-#{settings[:ruby_version]}"
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
@@ -49,8 +75,13 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DLEATHERMAN_MOCK_CURL=FALSE"
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
-    toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
-    cmake = "/opt/pl-build-tools/bin/cmake"
+    if platform.name =~ /debian-9-armhf/
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+      cmake = "/usr/bin/cmake"
+    else
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+      cmake = "/opt/pl-build-tools/bin/cmake"
+    end
   elsif platform.is_solaris?
     if platform.architecture == 'sparc'
       ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig.rb"
@@ -85,18 +116,29 @@ component "leatherman" do |pkg, settings, platform|
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   end
 
+
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+  end
+
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        #{boost_args} \
         -DLEATHERMAN_GETTEXT=ON \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
+        -DLEATHERMAN_USE_ICU=TRUE \
         #{leatherman_locale_var} \
         -DLEATHERMAN_SHARED=TRUE \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        -DBOOST_STATIC=#{boost_static} \
         ."]
   end
 

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -14,6 +14,10 @@ component "libwhereami" do |pkg, settings, platform|
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+    if platform.name =~ /debian-9-armhf/
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+      cmake = "/usr/bin/cmake"
+    end
   elsif platform.is_solaris?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
@@ -36,16 +40,25 @@ component "libwhereami" do |pkg, settings, platform|
     end
   end
 
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+  end
+
   # Until we build our own gettext packages, disable using locales.
   # gettext 0.17 is required to compile .mo files with msgctxt.
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
+        #{boost_args} \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        -DBOOST_STATIC=#{boost_static} \
         ."]
   end
 

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -28,12 +28,12 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "CFLAGS" => settings[:cflags]
   end
 
-  pkg.build_requires 'runtime'
+  pkg.build_requires 'runtime' unless platform.name =~ /debian-9-armhf/
 
   # The system pkg-config has been found to pass incorrect build flags on
   # some (but not all) cross-compiled debian-based platforms:
   if platform.is_cross_compiled? && platform.is_deb?
-    pkg.build_requires "pl-pkg-config" unless platform.name =~ /ubuntu-16\.04-ppc64el/
+    pkg.build_requires "pl-pkg-config" unless platform.name =~ /ubuntu-16\.04-ppc64el/ || platform.name =~ /debian-9-armhf/
   end
 
   pkg.configure do

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -38,7 +38,7 @@ component "libxslt" do |pkg, settings, platform|
   end
 
   if platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
-    pkg.build_requires "pl-gcc-#{platform.architecture}"
+    pkg.build_requires "pl-gcc-#{platform.architecture}" unless platform.name =~ /debian-9-armhf/
   end
 
   pkg.configure do

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -17,7 +17,7 @@ component "puppet" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
   elsif !platform.is_solaris?
-    pkg.build_requires "pl-gettext"
+    pkg.build_requires "pl-gettext" unless platform.name =~ /debian-9-armhf/
   end
 
   pkg.replaces 'puppet', '4.0.0'
@@ -108,7 +108,11 @@ component "puppet" do |pkg, settings, platform|
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
     else
-      msgfmt = "/opt/pl-build-tools/bin/msgfmt"
+      if platform.name =~ /debian-9-armhf/
+        msgfmt = "msgfmt"
+      else
+        msgfmt = "/opt/pl-build-tools/bin/msgfmt"
+      end
     end
     pkg.configure do
       ["for dir in ./locales/*/ ; do [ -d \"$${dir}\" ] || continue ; [ -d \"$${dir}/LC_MESSAGES\" ] || /bin/mkdir \"$${dir}/LC_MESSAGES\" ; #{msgfmt} \"$${dir}/puppet.po\" -o \"$${dir}/LC_MESSAGES/puppet.mo\" ; done ;",]

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -34,6 +34,10 @@ component "pxp-agent" do |pkg, settings, platform|
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
+    if platform.name =~ /debian-9-armhf/
+      toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:datadir]}/doc/debian-#{platform.architecture}-toolchain"
+      cmake = "/usr/bin/cmake"
+    end
   elsif platform.is_solaris?
     cmake = "/opt/pl-build-tools/i386-pc-solaris2.#{platform.os_version}/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
@@ -51,10 +55,19 @@ component "pxp-agent" do |pkg, settings, platform|
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end
 
+  if platform.name =~ /debian-9-armhf/
+    boost_args = "-DBOOST_LIBRARYDIR=/usr/lib/#{settings[:platform_triple]}/lib"
+    boost_static = "OFF"
+  else
+    boost_args = ""
+    boost_static = "ON"
+  end
+
   pkg.configure do
     [
       "#{cmake}\
       #{toolchain} \
+      #{boost_args} \
           -DLEATHERMAN_GETTEXT=ON \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
@@ -62,7 +75,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           #{special_flags} \
-          -DBOOST_STATIC=ON \
+          -DBOOST_STATIC=#{boost_static} \
           ."
     ]
   end

--- a/configs/components/ruby-2.4.3.rb
+++ b/configs/components/ruby-2.4.3.rb
@@ -135,7 +135,7 @@ component "ruby-2.4.3" do |pkg, settings, platform|
   # Cross-compiles require a hand-built rbconfig from the target system as does Solaris, AIX and Windies
   if platform.is_cross_compiled_linux? || platform.is_solaris? || platform.is_aix? || platform.is_windows?
     pkg.add_source "file://resources/files/ruby_243/rbconfig/rbconfig-#{settings[:platform_triple]}.rb"
-    pkg.build_requires 'runtime' if platform.is_cross_compiled_linux?
+    pkg.build_requires 'runtime' if platform.is_cross_compiled_linux? && !platform.name =~ /debian-9-armhf/
   end
 
   if settings[:vendor_openssl] == "no"
@@ -146,7 +146,11 @@ component "ruby-2.4.3" do |pkg, settings, platform|
 
 
   if platform.is_deb?
-    pkg.build_requires "zlib1g-dev"
+    if platform.is_cross_compiled? && platform.name == "debian-9-armhf"
+      pkg.build_requires "zlib1g-dev:#{platform.architecture}"
+    else
+      pkg.build_requires "zlib1g-dev"
+    end
   elsif platform.is_aix?
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-1.2.3-4.aix5.2.ppc.rpm"
     pkg.build_requires "http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/zlib-devel-1.2.3-4.aix5.2.ppc.rpm"
@@ -157,10 +161,15 @@ component "ruby-2.4.3" do |pkg, settings, platform|
   end
 
   if platform.is_cross_compiled_linux?
-    pkg.build_requires 'pl-ruby'
-    special_flags += " --with-baseruby=#{settings[:host_ruby]} "
+    if platform.name =~ /debian-9-armhf/
+      pkg.build_requires "ruby"
+      pkg.environment "CC", "#{settings[:platform_triple]}-gcc"
+    else
+      pkg.build_requires 'pl-ruby'
+      pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
+      special_flags += " --with-baseruby=#{settings[:host_ruby]} "
+    end
     pkg.environment "PATH", "#{settings[:bindir]}:$(PATH)"
-    pkg.environment "CC", "/opt/pl-build-tools/bin/#{settings[:platform_triple]}-gcc"
     pkg.environment "LDFLAGS", "-Wl,-rpath=/opt/puppetlabs/puppet/lib"
   end
 
@@ -299,13 +308,25 @@ component "ruby-2.4.3" do |pkg, settings, platform|
     sed = "sed"
     sed = "gsed" if platform.is_solaris?
     sed = "/opt/freeware/bin/sed" if platform.is_aix?
-    pkg.install do
-      [
-        "#{sed} -i 's|raise|warn|g' #{target_dir}/rbconfig.rb",
-        "mkdir -p #{settings[:datadir]}/doc",
-        "cp #{target_dir}/rbconfig.rb #{settings[:datadir]}/doc",
-        "cp ../rbconfig-#{settings[:platform_triple]}.rb #{target_dir}/rbconfig.rb",
-      ]
+    if platform.name =~ /debian-9-armhf/
+      # Here we don't overwrite the rbconfig, because the one we create while
+      # building contains exactly what we want (e.g. system compiler, etc)
+      pkg.install do
+        [
+          "#{sed} -i 's|raise|warn|g' #{target_dir}/rbconfig.rb",
+          "mkdir -p #{settings[:datadir]}/doc",
+          "cp #{target_dir}/rbconfig.rb #{settings[:datadir]}/doc",
+        ]
+      end
+    else
+      pkg.install do
+        [
+          "#{sed} -i 's|raise|warn|g' #{target_dir}/rbconfig.rb",
+          "mkdir -p #{settings[:datadir]}/doc",
+          "cp #{target_dir}/rbconfig.rb #{settings[:datadir]}/doc",
+          "cp ../rbconfig-#{settings[:platform_triple]}.rb #{target_dir}/rbconfig.rb",
+        ]
+      end
     end
   end
 end

--- a/configs/components/toolchain.rb
+++ b/configs/components/toolchain.rb
@@ -1,0 +1,9 @@
+# This component simply installs a cmake toolchain file for use when building
+# using OS native build toolchains. This is needed before the configure step on
+# leatherman, which is why you can't use a `pkg.install_file` in the leatherman
+# component to make this work.
+#
+component "toolchain" do |pkg, settings, platform|
+  pkg.add_source "file://resources/files/toolchain/debian-#{platform.architecture}-toolchain"
+  pkg.install_file "debian-#{platform.architecture}-toolchain", "#{settings[:datadir]}/doc"
+end

--- a/configs/platforms/debian-9-armhf.rb
+++ b/configs/platforms/debian-9-armhf.rb
@@ -1,0 +1,30 @@
+platform "debian-9-armhf" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "stretch"
+
+
+  plat.provision_with %(
+    export DEBIAN_FRONTEND=noninteractive; apt-get update
+    apt-get install -qq -y --no-install-recommends build-essential devscripts make quilt \
+    pkg-config debhelper rsync fakeroot gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf \
+    cpp-arm-linux-gnueabihf g++-arm-linux-gnueabihf curl)
+
+  # You can't use plat.add_build_repository for this because the format is not
+  # exactly what is expected. This is to enable this specific architecture on
+  # amd64 hosts. (As is the next line)
+  #
+  # This can be removed if Puppet is no longer using OSmirror but using a real debian mirror with all arches.
+  plat.provision_with %(
+    echo  "deb [arch=#{plat.get_architecture}] http://deb.debian.org/debian #{plat.get_codename} main" >> /etc/apt/sources.list.d/#{plat.get_architecture}.list
+    echo  "deb [arch=#{plat.get_architecture}] http://deb.debian.org/debian #{plat.get_codename}-updates main" >> /etc/apt/sources.list.d/#{plat.get_architecture}.list
+    echo  "deb [arch=#{plat.get_architecture}] http://security.debian.org/debian-security/ #{plat.get_codename}/updates main" >> /etc/apt/sources.list.d/#{plat.get_architecture}.list
+  apt-get -qq update; dpkg --add-architecture #{plat.get_architecture}
+  )
+
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qq -qy --no-install-recommends "
+  plat.vmpooler_template "debian-9-x86_64"
+  plat.cross_compiled "true"
+  plat.output_dir File.join("deb", plat.get_codename, "PC1")
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -103,16 +103,22 @@ project "puppet-agent" do |proj|
   platform_triple = "powerpc64le-suse-linux" if platform.architecture == "ppc64le" && platform.name =~ /^sles-/
   platform_triple = "powerpc64le-linux-gnu" if platform.architecture == "ppc64el"
   platform_triple = "s390x-linux-gnu" if platform.architecture == "s390x"
-  platform_triple = "arm-linux-gnueabihf" if platform.name == 'debian-8-armhf'
   platform_triple = "arm-linux-gnueabi" if platform.name == 'debian-8-armel'
+  platform_triple = "arm-linux-gnueabihf" if platform.name =~ /debian-[\d]-armhf/
   platform_triple = "aarch64-redhat-linux" if platform.name == 'el-7-aarch64'
 
   if platform.is_cross_compiled_linux?
     host = "--host #{platform_triple}"
 
-    # Use a standalone ruby for cross-compilation
-    proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
-    proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
+    if platform.name =~ /debian-9-armhf/
+      proj.setting(:host_ruby, "/usr/bin/ruby")
+      proj.setting(:host_gem, "/usr/bin/gem")
+    else
+      # Use a standalone ruby for cross-compilation
+      proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
+      proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
+    end
+
   end
 
   # For solaris, we build cross-compilers
@@ -175,9 +181,15 @@ project "puppet-agent" do |proj|
 
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
-  proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
-  proj.setting(:cflags, "#{proj.cppflags}")
-  proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+  if platform.name =~ /debian-9-armhf/
+    proj.setting(:cppflags, "-I#{proj.includedir}")
+    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:ldflags, "-L/opt/puppetlabs/puppet/lib -L/lib/#{settings[:platform_triple]} -L/usr/lib/#{settings[:platform_triple]} -Wl,-rpath=#{proj.libdir}")
+  else
+    proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+    proj.setting(:cflags, "#{proj.cppflags}")
+    proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+  end
 
   # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?
@@ -272,7 +284,11 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime"
+  if platform.name =~ /debian-9-armhf/
+    proj.component "toolchain"
+  else
+    proj.component "runtime"
+  end
 
   # Windows doesn't need these wrappers, only unix platforms
   unless platform.is_windows?

--- a/resources/files/toolchain/debian-armhf-toolchain
+++ b/resources/files/toolchain/debian-armhf-toolchain
@@ -1,0 +1,39 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+# these ones not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+SET(CMAKE_SYSTEM_PROCESSOR arm)
+
+# specify the cross compiler
+SET(PL_TOOLS_ROOT        /usr/)
+SET(PL_TOOLS_PREFIX      ${PL_TOOLS_ROOT}/arm-linux-gnueabihf)
+SET(CMAKE_C_COMPILER     ${PL_TOOLS_ROOT}/bin/arm-linux-gnueabihf-gcc)
+SET(CMAKE_CXX_COMPILER   ${PL_TOOLS_ROOT}/bin/arm-linux-gnueabihf-g++)
+SET(CMAKE_AR             ${PL_TOOLS_PREFIX}/bin/ar CACHE FILEPATH "Archiver")
+SET(CMAKE_LINKER         ${PL_TOOLS_ROOT}/bin/arm-linux-gnueabihf-gcc CACHE PATH "Linker Program")
+SET(CMAKE_NM             ${PL_TOOLS_PREFIX}/bin/nm)
+
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH ${PL_TOOLS_PREFIX})
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ALWAYS)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ALWAYS)
+
+SET(CMAKE_C_FLAGS "-fPIC -pthread ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+
+# update RPATH so our custom libraries can be found
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)


### PR DESCRIPTION
This commit enables builds for Debian 9 armhf, which is the target for
running raspian 9 (raspberry PI Debian). This build also has the
advantage of not requiring anything from pl-build-tools as this compiles
all natively using the xcc toolchain provided by Debian.

Since this uses system yaml-cpp and boost, it does add runtime
requirements on those libraries (as well as libicu).


## Points of note

* New run time dependencies for this agent (system boost, yaml-cpp, icu)
* New leatherman compile flag (USE_ICU)
* <s>This should be pretty easy to flip the rest of Debian/Ubuntu to use this setup. </s>
* Removes all usages of pl-build-tools. Also does not use the "runtime" component in PA. 

## Future Work

*<s> Look at all Deb builds this way.</s>
* Try a build not on the VPN (since all this stuff *should* be available)


Actual build available: 
 http://unsupported.s3.amazonaws.com/puppet-agent_5.4.0.412.g8f7446e2-1stretch_armhf.deb