### PR TITLE
(maint) update commit check to include 'promoting'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task(:commits) do
 \n\tThis test for the commit summary is case-insensitive.\n\n\n
     HEREDOC
 
-    if /^\((maint|doc|docs|packaging)\)|revert|bumping|merge/i.match(commit_summary).nil?
+    if /^\((maint|doc|docs|packaging)\)|revert|bumping|merge|promoting/i.match(commit_summary).nil?
       ticket = commit_summary.match(/^\(([[:alpha:]]+-[[:digit:]]+)\).*/)
       if ticket.nil?
         raise error_message


### PR DESCRIPTION
Recently we updated the automation to say 'promoting' in component bump
tickets. We need the commit checker to pass for those commits