### PR TITLE
(PA-1245) Split cfacter source/precompiled in to seperate projects

### DIFF
--- a/configs/components/cfacter-precompiled-gem.rb
+++ b/configs/components/cfacter-precompiled-gem.rb
@@ -41,6 +41,7 @@ component "cfacter-precompiled-gem" do |pkg, settings, platform|
   pkg.install do
     [
       "pushd #{settings[:gemdir]}",
+      "rm cfacter*.gem",
       "pushd ext/facter",
       "#{settings[:ruby_binary]} extconf.rb",
       "#{make} install",

--- a/configs/projects/cfacter-source.rb
+++ b/configs/projects/cfacter-source.rb
@@ -46,7 +46,6 @@ project "cfacter" do |proj|
   proj.component "leatherman-source"
   proj.component "cpp-hocon-source"
   proj.component "cfacter-source-gem"
-  proj.component "cfacter-precompiled-gem"
   proj.component "puppet-runtime"
   proj.fetch_artifact "#{settings[:gemdir]}/cfacter*.gem"
   proj.no_packaging true


### PR DESCRIPTION
We should be able to independently build the cfacter source and precompiled
so this commit adds the cfacter source project, and then updates the cfacter
project (which builds precompiled gems) to not ship the source gem as
well