### PR TITLE
(FACT-1547) Build working cfacter gem for windows

### DIFF
--- a/configs/components/cfacter-precompiled-gem.rb
+++ b/configs/components/cfacter-precompiled-gem.rb
@@ -25,14 +25,17 @@ component "cfacter-precompiled-gem" do |pkg, settings, platform|
 
   if platform.is_osx?
     make = 'make'
+    rm = 'rm'
     pkg.environment "PATH" => "/usr/local/bin:#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
+    rm = '/bin/rm'
     pkg.environment "PATH" => "/cygdrive/c/ProgramData/chocolatey/bin:$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:build_tools_dir]}):$$(cygpath -u #{settings[:ruby_dir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment('FACTER_CMAKE_OPTS', '-G \"MinGW Makefiles\" -DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DCMAKE_TOOLCHAIN_FILE=C:\tools\pl-build-tools\pl-build-toolchain.cmake -DWITHOUT_JRUBY=ON')
   else
     make = 'make'
+    rm = 'rm'
     pkg.environment "PATH" => "#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
   end
@@ -41,7 +44,7 @@ component "cfacter-precompiled-gem" do |pkg, settings, platform|
   pkg.install do
     [
       "pushd #{settings[:gemdir]}",
-      "rm cfacter*.gem",
+      "#{rm} cfacter*.gem",
       "pushd ext/facter",
       "#{settings[:ruby_binary]} extconf.rb",
       "#{make} install",

--- a/configs/projects/cfacter.rb
+++ b/configs/projects/cfacter.rb
@@ -29,17 +29,22 @@ project "cfacter" do |proj|
   proj.setting(:project_version, gem_version)
   proj.setting(:gemdir, '/var/tmp/facter_gem')
   if platform.is_windows?
-    proj.setting(:ruby_dir, '/cygdrive/c/Program\\ Files/Puppet\\ Labs/Puppet/sys/ruby')
-    proj.setting(:gem_binary, 'cmd /c "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\gem.bat"')
-    proj.setting(:ruby_binary, 'cmd /c "C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe"')
+    proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+    proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
+    proj.setting(:ruby_dir, '/cygdrive/c/ProgramFiles64Folder/PuppetLabs/Puppet/sys/ruby')
+    proj.setting(:ruby_bindir, File.join(proj.ruby_dir, 'bin'))
+    proj.setting(:gem_binary, 'cmd /c "C:\ProgramFiles64Folder\PuppetLabs\Puppet\sys\ruby\bin\gem.bat"')
+    proj.setting(:ruby_binary, 'cmd /c "C:\ProgramFiles64Folder\PuppetLabs\Puppet\sys\ruby\bin\ruby.exe"')
     proj.setting(:build_tools_dir, '/cygdrive/c/tools/pl-build-tools/bin')
     arch = platform.architecture == "x64" ? "64" : "32"
     proj.setting(:gcc_bindir, "C:/tools/mingw#{arch}/bin")
+    proj.setting(:precompiled_spec_glob, "Dir.glob(['lib/**/*', 'bin/**/*'])")
   else
     proj.setting(:ruby_dir, '/opt/puppetlabs/puppet/bin')
     proj.setting(:gem_binary, File.join(proj.ruby_dir, 'gem'))
     proj.setting(:ruby_binary, File.join(proj.ruby_dir, 'ruby'))
     proj.setting(:build_tools_dir, '/opt/pl-build-tools/bin')
+    proj.setting(:precompiled_spec_glob, "Dir.glob('lib/**/*')")
   end
 
   proj.component "facter-source"

--- a/resources/files/cfacter-gem/cfacter-precompiled.gemspec.erb
+++ b/resources/files/cfacter-gem/cfacter-precompiled.gemspec.erb
@@ -5,6 +5,6 @@ Gem::Specification.new 'cfacter', '<%= settings[:project_version] %>' do |s|
   s.license               = 'Apache-2.0'
   s.platform              = Gem::Platform::CURRENT
   s.required_ruby_version = '>= 0'
-  s.files                 = Dir.glob('lib/**/*')
+  s.files                 = <%= settings[:precompiled_spec_glob] %>
 end
 

--- a/resources/files/cfacter-gem/extconf.rb
+++ b/resources/files/cfacter-gem/extconf.rb
@@ -8,7 +8,7 @@ cmake_opts = ENV['FACTER_CMAKE_OPTS']
 if RbConfig::CONFIG['arch'].include?('mingw')
   windows_native_source = source_root.gsub('/', '\\')
   # xcopy will make the libdir for us, so there's no mkdir for windows
-  install_command = "xcopy \"prefix\\bin\\*facter*\" \"#{windows_native_source}\\..\\..\\lib\" /i"
+  install_command = "xcopy \"prefix\\bin\\*facter*\" \"#{windows_native_source}\\..\\..\\bin\" /i && xcopy \"prefix\\lib\\*facter*\" \"#{windows_native_source}\\..\\..\\lib\" /i"
   touch_command = 'type nul >'
   mkdir_command = 'mkdir'
 else


### PR DESCRIPTION
This commit makes a few necessary changes to facilitate the cfacter gem on
windows:

Paths have been updated and settings added to allow the puppet-runtime to
work.

The glob of files for the file list in the precompiled gem has been moved to
an erb template so the windows gem can include both lib/ and bin/ dirs

the windows gem now copies both the lib and bin dirs (since on windows
facter.rb expects to reside in lib/ and call out to bin/)