### PR TITLE
(maint) disable the 5.5.x branch from changing puppet-nightly link

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -149,6 +149,6 @@ yum_repo_name: 'PC1'
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 repo_link_target: 'puppet'
-nonfinal_repo_link_target: 'puppet-nightly'
+nonfinal_repo_link_target: ''
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
The 5.5.x series should continue to ship to the puppet5 nightly repo even
though there will be a puppet6 repo, however, the puppet-nightly link should
no longer be changed to link to puppet5-nightly (since that's no longer the
latest changes, puppet6-nightly is)

This is a cherry-pick of https://github.com/puppetlabs/puppet-agent/pull/1361