### PR TITLE
(maint) Actually remove nonfinal_link_target from build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -149,6 +149,5 @@ yum_repo_name: 'PC1'
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 repo_link_target: 'puppet'
-nonfinal_repo_link_target: ''
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
Simply setting the string to empty will not work, so actually completely
remove it