### PR TITLE
Merge 5.5.x -> master, enable puppet6 nightly repos

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -146,8 +146,9 @@ osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
-repo_name: 'puppet5'
-nonfinal_repo_name: 'puppet5-nightly'
+repo_name: 'puppet6'
+nonfinal_repo_name: 'puppet6-nightly'
 repo_link_target: 'puppet'
+nonfinal_repo_link_target: 'puppet-nightly'
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
This PR is both a mergeup and an additional commit to enable puppet6 nightly repo shipping.