### PR TITLE
(maint) Do not try to execute mcollective state file

### DIFF
--- a/configs/components/marionette-collective.rb
+++ b/configs/components/marionette-collective.rb
@@ -65,7 +65,7 @@ component "marionette-collective" do |pkg, settings, platform|
     pkg.add_postinstall_action ["upgrade"],
       [<<-HERE.undent
         if [ -f #{service_statefile} ] ; then
-          #{puppet_bin} resource service mcollective ensure=$(#{service_statefile}) > /dev/null 2>&1 || :
+          #{puppet_bin} resource service mcollective ensure=$(cat #{service_statefile}) > /dev/null 2>&1 || :
           rm -rf #{rpm_statedir} || :
         fi
         HERE


### PR DESCRIPTION
The mcollective state file is not a scrip that returns data, it's a
file that needs to be dumped. Treat it as such.