### PR TITLE
(PE-22679) Add missing repo_location for redhatfips-7-x86_64

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -77,6 +77,8 @@ platform_repos:
     repo_location: repos/el/7/**/ppc64le
   - name: el-7-aarch64
     repo_location: repos/el/7/**/aarch64
+  - name: redhatfips-7-x86_64
+    repo_location: repos/redhat-fips/7/**/x86_64
   - name: sles-11-s390x
     repo_location: repos/sles/11/**/s390x
   - name: sles-11-i386


### PR DESCRIPTION
Note: I'm using 'redhatfips' as the name, as the PE installer expects the tarball to be named 'puppet-agent-redhatfips-7-x86_64.tar.gz' (see the ticket for additional details/context).