### PR TITLE
(PA-1949) Fix incorrect runtime tarball name

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -4,7 +4,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
   raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
   pkg.version runtime_tag
 
-  tarball_name = "agent-runtime-1.10.x-#{pkg.get_version}.#{platform.name}.tar.gz"
+  tarball_name = "agent-runtime-5.3.x-#{pkg.get_version}.#{platform.name}.tar.gz"
 
   pkg.sha1sum "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}.sha1"
   pkg.url "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}"


### PR DESCRIPTION
I neglected to fix this line in the [mergeup between 1.10.x and 5.3.x this week](https://github.com/puppetlabs/puppet-agent/commit/c3d2cc02de756c073961a52674b0a21f7469ab54) :man_facepalming: 