### PR TITLE
(PDK-526) Add puppet-resource_api gem

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -146,7 +146,7 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
   step "'irb' successfully loads gems" do
     agents.each do |agent|
       irb = irb_command(agent)
-      ['hocon', 'deep_merge'].each do |gem|
+      ['hocon', 'deep_merge', 'puppet/resource_api'].each do |gem|
         stdout = on(agent, "echo \"require '#{gem}'\" | #{irb}").stdout.chomp
         assert_match(/true/, stdout, "'irb' failed to require the #{gem} gem")
       end
@@ -168,4 +168,3 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
     end
   end
 end
-

--- a/configs/components/rubygem-puppet-resource_api.json
+++ b/configs/components/rubygem-puppet-resource_api.json
@@ -1,0 +1,4 @@
+{
+  "url": "git://github.com/puppetlabs/puppet-resource_api.git",
+  "ref": "9caab67cc2e347096bae3c93044d7d2da02e81ee"
+}

--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -1,0 +1,22 @@
+component "rubygem-puppet-resource_api" do |pkg, settings, platform|
+  pkg.load_from_json("configs/components/rubygem-puppet-resource_api.json")
+
+  pkg.build_requires "puppet-runtime"
+
+  # Install into the directory for gems shared by puppet and puppetserver
+  pkg.environment "GEM_HOME", settings[:puppet_gem_vendor_dir]
+
+  # PA-25 in order to install gems in a cross-compiled environment we need to
+  # set RUBYLIB to include puppet and hiera, so that their gemspecs can resolve
+  # hiera/version and puppet/version requires. Without this the gem install
+  # will fail by blowing out the stack.
+  pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
+
+  pkg.build do
+    ["gem build puppet-resource_api.gemspec"]
+  end
+
+  pkg.install do
+    ["#{settings[:gem_install]} puppet-resource_api-*.gem"]
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -98,6 +98,7 @@ project "puppet-agent" do |proj|
   # Provides augeas, curl, libedit, libxml2, libxslt, openssl, puppet-ca-bundle, ruby and rubygem-*
   proj.component "puppet-runtime"
   proj.component "nssm" if platform.is_windows?
+  proj.component "rubygem-puppet-resource_api"
 
   # These utilites don't really work on unix
   if platform.is_linux?


### PR DESCRIPTION
```
david@davids:~/git/puppet-agent$ sudo dpkg -i output/deb/stretch/PC1/puppet-agent_5.5.0.89.g0c885104-1stretch_amd64.deb
[sudo] password for david:
dpkg: warning: downgrading puppet-agent from 5.5.0.89.g9adc14d0-1stretch to 5.5.0.89.g0c885104-1stretch
(Reading database ... 295203 files and directories currently installed.)
Preparing to unpack .../puppet-agent_5.5.0.89.g0c885104-1stretch_amd64.deb ...
Unpacking puppet-agent (5.5.0.89.g0c885104-1stretch) over (5.5.0.89.g9adc14d0-1stretch) ...
Setting up puppet-agent (5.5.0.89.g0c885104-1stretch) ...
Processing triggers for libc-bin (2.27-2) ...
david@davids:~/git/puppet-agent$ /opt/puppetlabs/puppet/bin/gem list --local | grep resource
puppet-resource_api (1.0.1)
david@davids:~/git/puppet-agent$ cd ../puppet-resource_api/spec/fixtures/modules
david@davids:~/git/puppet-resource_api/spec/fixtures/modules$ /opt/puppetlabs/bin/puppet resource --modulepath . test_simple_get_filter
test_simple_get_filter { "bar":
  ensure => 'present',
  test_string => 'default',
}
test_simple_get_filter { "foo":
  ensure => 'present',
  test_string => 'default',
}
david@davids:~/git/puppet-resource_api/spec/fixtures/modules$
```