### PR TITLE
Merge up 5.5.x to master

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -16,11 +16,7 @@ component "leatherman" do |pkg, settings, platform|
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
-    if platform.name =~ /aix-7.1/
-      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-7.aix#{platform.os_version}.ppc.rpm"
-    else
-      pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-1.aix#{platform.os_version}.ppc.rpm"
-    end
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-7.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "cmake"

--- a/configs/components/libwhereami.json
+++ b/configs/components/libwhereami.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/libwhereami.git","ref":"refs/tags/0.2.0"}
+{"url":"git://github.com/puppetlabs/libwhereami.git","ref":"47fd91bc88e51beba5c7be2c45c0542abd55f25b"}

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -4,7 +4,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
   raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
   pkg.version runtime_tag
 
-  tarball_name = "agent-runtime-5.5.x-#{pkg.get_version}.#{platform.name}.tar.gz"
+  tarball_name = "agent-runtime-master-#{pkg.get_version}.#{platform.name}.tar.gz"
 
   pkg.sha1sum "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}.sha1"
   pkg.url "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}"

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"5846904f9f5c9ea65c87d51d5e0dd6d087b48bff"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"7435bf2a6504c01d0c9cf57c83bb62bf6f80b842"}

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -5,7 +5,7 @@ project "puppet-agent" do |proj|
   runtime_details = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', 'components/puppet-runtime.json')))
   runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
   raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  proj.inherit_settings 'agent-runtime-5.5.x', 'git://github.com/puppetlabs/puppet-runtime', runtime_tag
+  proj.inherit_settings 'agent-runtime-master', 'git://github.com/puppetlabs/puppet-runtime', runtime_tag
 
   platform = proj.get_platform
 


### PR DESCRIPTION
This mergeup applies the use of puppet-runtime to the master branch - the equivalent project files in puppet-runtime that replace the removed files are [here](https://github.com/puppetlabs/puppet-runtime/blob/master/configs/projects/agent-runtime-master.rb) and [here](https://github.com/puppetlabs/puppet-runtime/blob/master/configs/projects/base-agent-runtime.rb).