### PR TITLE
(PA-1958) Rename redhat-fips platform to redhatfips

### DIFF
--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -1,4 +1,4 @@
-platform "redhat-fips-7-x86_64" do |plat|
+platform "redhatfips-7-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -43,7 +43,7 @@ pe_platforms:
   - aix-7.1-power
   - el-6-s390x
   - el-7-s390x
-  - redhat-fips-7-x86_64
+  - redhatfips-7-x86_64
   - sles-11-s390x
   - sles-12-s390x
   - solaris-10-i386
@@ -78,7 +78,7 @@ platform_repos:
   - name: el-7-aarch64
     repo_location: repos/el/7/**/aarch64
   - name: redhatfips-7-x86_64
-    repo_location: repos/redhat-fips/7/**/x86_64
+    repo_location: repos/redhatfips/7/**/x86_64
   - name: sles-11-s390x
     repo_location: repos/sles/11/**/s390x
   - name: sles-11-i386


### PR DESCRIPTION
Dashes in platform names cause trouble down the line when it comes time
to add the platform to pe_repo, so make this platform name 'redhatfips'.