### PR TITLE
(maint) Use the url in the puppet-runtime.json file

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -5,7 +5,7 @@ project "puppet-agent" do |proj|
   runtime_details = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', 'components/puppet-runtime.json')))
   runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
   raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  proj.inherit_settings 'agent-runtime-1.10.x', 'git://github.com/puppetlabs/puppet-runtime', runtime_tag
+  proj.inherit_settings 'agent-runtime-1.10.x', runtime_details['url'], runtime_tag
 
   platform = proj.get_platform
 


### PR DESCRIPTION
The puppet-agent project inherits its settings from puppet-runtime.
The code checks out from the ref in the puppet-runtime.json file,
but the source is hard-coded to puppetlabs/puppet-runtime. This commit
changes the source to be the url in the puppet-runtime.json file.