### PR TITLE
(PA-1847) Add puppet docs to MANPATH

### DIFF
--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -3,3 +3,7 @@
 if ! echo $PATH | grep -q /opt/puppetlabs/bin ; then
   export PATH=$PATH:/opt/puppetlabs/bin
 fi
+
+if ! echo $MANPATH | grep -q /opt/puppetlabs/puppet/share/man ; then
+  export MANPATH=$MANPATH:/opt/puppetlabs/puppet/share/man
+fi


### PR DESCRIPTION
When the user installs puppet-agent, by default, the man pages are not
included in the manpath. This updates the path through the
puppet-agent.sh script in profile.d.