### PR TITLE
(maint) Update leatherman to 6773c8890c4e60b168f52daec0445166a3684902

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/leatherman.git","ref":"a899bcedfada07a0954df2b81d90252e47dcb0e1"}
+{"url":"git://github.com/puppetlabs/leatherman.git","ref":"6773c8890c4e60b168f52daec0445166a3684902"}


### PR DESCRIPTION
6773 contains the bump to 1.2.3, which we need in order for the tagging
job to correctly tag leatherman at 1.2.3