### PR TITLE
(maint) Use built ruby for gem build

### DIFF
--- a/configs/components/rubygem-puppet-resource_api.rb
+++ b/configs/components/rubygem-puppet-resource_api.rb
@@ -13,7 +13,7 @@ component "rubygem-puppet-resource_api" do |pkg, settings, platform|
   pkg.environment "RUBYLIB", "#{settings[:ruby_vendordir]}:$(RUBYLIB)"
 
   pkg.build do
-    ["gem build puppet-resource_api.gemspec"]
+    ["#{settings[:host_gem]} build puppet-resource_api.gemspec"]
   end
 
   pkg.install do


### PR DESCRIPTION
Previously `gem build` relied on the system Ruby, which is not present
on all platforms - particularly Solaris and Windows. Use puppet-runtime
ruby instead.