### PR TITLE
(PA-1982) Calculate facter gem version on build host

### DIFF
--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -1,8 +1,7 @@
 component "facter-precompiled-gem" do |pkg, settings, platform|
   pkg.build_requires 'facter-source-gem'
 
-  pkg.add_source("file://resources/files/facter-gem/facter-precompiled.gemspec.erb", erb: 'true')
-  pkg.install_file('facter-precompiled.gemspec', "#{settings[:gemdir]}")
+  pkg.add_source("file://resources/files/facter-gem/facter-precompiled.gemspec.erb")
 
   if platform.is_osx?
     pkg.build_requires "cmake"
@@ -40,6 +39,11 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
   end
 
+  pkg.configure do
+    [
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-precompiled.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+    ]
+  end
 
   pkg.install do
     [

--- a/configs/components/facter-source-gem.rb
+++ b/configs/components/facter-source-gem.rb
@@ -4,12 +4,18 @@ component "facter-source-gem" do |pkg, settings, platform|
   pkg.build_requires 'cpp-hocon-source'
   pkg.build_requires 'puppet-runtime'
 
-  pkg.add_source("file://resources/files/facter-gem/facter-source.gemspec.erb", erb: 'true')
+  pkg.add_source("file://resources/files/facter-gem/facter-source.gemspec.erb")
   pkg.add_source("file://resources/files/facter-gem/extconf.rb")
   pkg.add_source("file://resources/files/facter-gem/Makefile.erb")
-  pkg.install_file('facter-source.gemspec', "#{settings[:gemdir]}")
+  pkg.add_source("file://resources/files/facter-gem/generate-gemspec.rb")
   pkg.install_file('extconf.rb', "#{settings[:gemdir]}/ext/facter")
   pkg.install_file('Makefile.erb', "#{settings[:gemdir]}/ext/facter")
+
+  pkg.configure do
+    [
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-source.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+    ]
+  end
 
   pkg.install do
     [

--- a/configs/projects/facter-gem.rb
+++ b/configs/projects/facter-gem.rb
@@ -3,25 +3,14 @@ require 'octokit'
 
 project "facter-gem" do |proj|
   platform = proj.get_platform
-  # We don't generate the version for the facter gem in the same way we do
-  # for other vanagon projects. We read from the facter project to find facter's
-  # version, then use release_from_git to decide if we are on an agent tag.
-  # If we _are_ on an agent tag, the facter gem is versioned as:
-  #   'facterX'.'facterY'.'facterZ'.'date'
-  # if we _are not_ at a tag the version will be:
-  #   'facterX'.'facterY'.'facterZ'.rc.'date'
-  facter_data = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../components/facter.json')))
-  facter_version_file = Base64.decode64(Octokit::Client.new.contents('puppetlabs/facter', path: 'CMakeLists.txt', ref: facter_data['ref']).content)
-  facter_version = facter_version_file.match(/project\(FACTER VERSION [\d\.]*\)/).to_s.gsub(/[^\d\.]/, '')
-  gem_version = facter_version
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag
   # note that we ignore the actual value of release_from_git other than to check
   # if it was 0
   proj.release_from_git
   if proj._project.release.to_s == '0'
-    gem_version += '.cfacter.'
+    gem_version = '.cfacter.'
   else
-    gem_version += ".cfacter.rc."
+    gem_version = ".cfacter.rc."
   end
   gem_version += Time.now.strftime("%Y%m%d")
   proj.version gem_version
@@ -44,13 +33,11 @@ project "facter-gem" do |proj|
     proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
     proj.setting(:build_tools_dir, '/cygdrive/c/tools/pl-build-tools/bin')
     proj.setting(:ruby_bindir, File.join(proj.ruby_dir, 'bin'))
-    proj.setting(:precompiled_spec_glob, "Dir.glob(['lib/**/*', 'bin/**/*'])")
   else
     proj.setting(:ruby_dir, '/opt/puppetlabs/puppet/bin')
     proj.setting(:gem_binary, File.join(proj.ruby_dir, 'gem'))
     proj.setting(:ruby_binary, File.join(proj.ruby_dir, 'ruby'))
     proj.setting(:build_tools_dir, '/opt/pl-build-tools/bin')
-    proj.setting(:precompiled_spec_glob, "Dir.glob('lib/**/*')")
   end
 
   proj.component "facter-source"

--- a/configs/projects/facter-source-gem.rb
+++ b/configs/projects/facter-source-gem.rb
@@ -3,25 +3,14 @@ require 'octokit'
 
 project "facter-source-gem" do |proj|
   platform = proj.get_platform
-  # We don't generate the version for the facter gem in the same way we do
-  # for other vanagon projects. We read from the facter project to find facter's
-  # version, then use release_from_git to decide if we are on an agent tag.
-  # If we _are_ on an agent tag, the facter gem is versioned as:
-  #   'facterX'.'facterY'.'facterZ'.'date'
-  # if we _are not_ at a tag the version will be:
-  #   'facterX'.'facterY'.'facterZ'.rc.'date'
-  facter_data = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../components/facter.json')))
-  facter_version_file = Base64.decode64(Octokit::Client.new.contents('puppetlabs/facter', path: 'CMakeLists.txt', ref: facter_data['ref']).content)
-  facter_version = facter_version_file.match(/project\(FACTER VERSION [\d\.]*\)/).to_s.gsub(/[^\d\.]/, '')
-  gem_version = facter_version
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag
   # note that we ignore the actual value of release_from_git other than to check
   # if it was 0
   proj.release_from_git
   if proj._project.release.to_s == '0'
-    gem_version += '.cfacter.'
+    gem_version = '.cfacter.'
   else
-    gem_version += ".cfacter.rc."
+    gem_version = ".cfacter.rc."
   end
   gem_version += Time.now.strftime("%Y%m%d")
   proj.version gem_version

--- a/resources/files/facter-gem/facter-precompiled.gemspec.erb
+++ b/resources/files/facter-gem/facter-precompiled.gemspec.erb
@@ -1,10 +1,10 @@
-Gem::Specification.new 'facter', '<%= settings[:project_version] %>' do |s|
+Gem::Specification.new 'facter', '<%= facter_version %>' do |s|
   s.summary               = 'Facter gem wrapper'
   s.authors               = %w[Puppet Inc.]
   s.email                 = "info@puppet.com"
   s.license               = 'Apache-2.0'
   s.platform              = Gem::Platform::CURRENT
   s.required_ruby_version = '>= 0'
-  s.files                 = <%= settings[:precompiled_spec_glob] %>
+  s.files                 = Dir.glob(['lib/**/*', 'bin/**/*'])
 end
 

--- a/resources/files/facter-gem/facter-source.gemspec.erb
+++ b/resources/files/facter-gem/facter-source.gemspec.erb
@@ -1,4 +1,4 @@
-Gem::Specification.new 'facter', '<%= settings[:project_version] %>' do |s|
+Gem::Specification.new 'facter', '<%= facter_version %>' do |s|
   s.summary     = 'Facter gem wrapper'
   s.authors     = %w[Puppet Inc.]
   s.email       = "info@puppet.com"

--- a/resources/files/facter-gem/generate-gemspec.rb
+++ b/resources/files/facter-gem/generate-gemspec.rb
@@ -1,0 +1,17 @@
+require 'erb'
+
+template = ARGV[0]
+gemdir = ARGV[1]
+suffix = ARGV[2]
+
+facter_version = File.read("#{gemdir}/ext/facter/facter/CMakeLists.txt")
+                   .match(/project\(FACTER VERSION [\d\.]*\)/)
+                   .to_s
+                   .gsub(/[^\d\.]/, "")
+facter_version += suffix
+
+gemspec = ERB.new(File.read(template))
+outfile = template.gsub('.erb', '')
+File.open("#{gemdir}/#{outfile}", 'w') do |out|
+  out.write(gemspec.result(binding))
+end


### PR DESCRIPTION
Previously, the facter gem version was being computed in Vanagon. This
required fetching the facter version file from github, which was
leading to us hitting API rate limits.

This commit changes the build to calculate the version on the build
machine, using a small Ruby script. It avoids the need to hit github
and still creates artifacts with the proper version.