### PR TITLE
(maint) Use alternate mirror for Solaris 10 builds

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -9,7 +9,7 @@ def package_installer(agent)
   when /aix/
     lambda { |package| on(agent, "rpm -Uvh #{package}") }
   when /solaris-10/
-    lambda { |package| on(agent, "opt/csw/bin/pkgutil -y -i #{package}") }
+    lambda { |package| on(agent, "opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf  -y -i #{package}") }
   else
     lambda { |package| agent.install_package(package) }
   end
@@ -55,7 +55,10 @@ def setup_build_environment(agent)
     vanagon_noask_path = "/var/tmp/vanagon-noask"
     on(agent, "echo \"#{vanagon_noask_contents}\" > #{vanagon_noask_path}")
 
-    on(agent, "pkgadd -n -a #{vanagon_noask_path} -G -d http://get.opencsw.org/now all")
+    vanagon_pkgutil_contents = "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing"
+    vanagon_pkgutil_path = "/var/tmp/vanagon-pkgutil.conf"
+    on(agent, "echo \"#{vanagon_pkgutil_contents}\" > #{vanagon_pkgutil_path}")
+
     ["rsync", "gmake", "pkgconfig", "ggrep", "gcc4core"].each { |pkg| install_package_on_agent.call(pkg) }
     install_package_on_agent.call("coreutils") if agent['platform'] =~ /sparc/
     on(agent, "ln -sf /opt/csw/bin/rsync /usr/bin/rsync")

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -34,11 +34,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
   # Even though puppet's ruby comes from puppet-runtime, we still need a ruby
   # to build with on these platforms:
   if platform.architecture == "sparc"
-    if platform.os_version == "10"
-      # ruby1.8 is not new enough to successfully cross-compile ruby 2.1.x (it
-      # doesn't understand the --disable-gems flag)
-      pkg.build_requires 'ruby20'
-    elsif platform.os_version == "11"
+    if platform.os_version == "11"
       pkg.build_requires 'pl-ruby'
     end
   elsif platform.is_cross_compiled_linux?

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -35,8 +35,8 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
+  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -39,14 +39,14 @@ conflict=nocheck
 action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
-  pkgadd -n -a /var/tmp/vanagon-noask -G -d http://get.opencsw.org/now all;
-  /opt/csw/bin/pkgutil -y -i rsync gmake pkgconfig ggrep;
+  echo "mirror=http://www.gtlib.gatech.edu/pub/OpenCSW/testing" > /var/tmp/vanagon-pkgutil.conf;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
   ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-5250 - Solaris 10 templates are awful
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil -l ruby | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
 
   # Install base build dependencies


### PR DESCRIPTION
While opencsw.org's mirror service is unavailable, use specific mirror
for Solaris 10 dependency packages.