### PR TITLE
(maint) Update facter precompiled gem to include full gemdir path

### DIFF
--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -27,21 +27,27 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
     rm = 'rm'
     pkg.environment "PATH" => "/usr/local/bin:#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
+    gem_directory = settings[:gemdir]
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     rm = '/bin/rm'
     pkg.environment "PATH" => "/cygdrive/c/ProgramData/chocolatey/bin:$$(cygpath -u #{settings[:gcc_bindir]}):$$(cygpath -u #{settings[:build_tools_dir]}):$$(cygpath -u #{settings[:ruby_dir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment('FACTER_CMAKE_OPTS', '-G \"MinGW Makefiles\" -DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DCMAKE_TOOLCHAIN_FILE=C:\tools\pl-build-tools\pl-build-toolchain.cmake -DWITHOUT_JRUBY=ON')
+    # Once we are executing ruby code using the ruby binary,
+    # cygwin is no longer available, so we'll need to fully
+    # qualify the gem directory including the windows paths
+    gem_directory = 'C:/cygwin64' + settings[:gemdir]
   else
     make = 'make'
     rm = 'rm'
     pkg.environment "PATH" => "#{settings[:build_tools_dir]}:#{settings[:ruby_dir]}:$$PATH"
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
+    gem_directory = settings[:gemdir]
   end
 
   pkg.configure do
     [
-      "#{settings[:ruby_binary]} generate-gemspec.rb facter-precompiled.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-precompiled.gemspec.erb '#{gem_directory}' '#{settings[:project_version]}'"
     ]
   end
 

--- a/configs/components/facter-source-gem.rb
+++ b/configs/components/facter-source-gem.rb
@@ -11,9 +11,18 @@ component "facter-source-gem" do |pkg, settings, platform|
   pkg.install_file('extconf.rb', "#{settings[:gemdir]}/ext/facter")
   pkg.install_file('Makefile.erb', "#{settings[:gemdir]}/ext/facter")
 
+  if platform.is_windows?
+    # Once we are executing ruby code using the ruby binary,
+    # cygwin is no longer available, so we'll need to fully
+    # qualify the gem directory including the windows paths
+    gem_directory = 'C:/cygwin64' + settings[:gemdir]
+  else
+    gem_directory = settings[:gemdir]
+  end
+
   pkg.configure do
     [
-      "#{settings[:ruby_binary]} generate-gemspec.rb facter-source.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-source.gemspec.erb '#{gem_directory}' '#{settings[:project_version]}'"
     ]
   end
 


### PR DESCRIPTION
On windows we need to prepend the 'gemdir' setting with C:\cygwin64 since we
are operating in cygwin inside vanagon but when executing ruby code it's
native windows.