### PR TITLE
(maint) Use cygpath for facter gem build location on windows

### DIFF
--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -39,9 +39,15 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
     pkg.environment('FACTER_CMAKE_OPTS', "-DBOOST_STATIC=ON -DYAMLCPP_STATIC=ON -DLEATHERMAN_USE_CURL=FALSE -DWITHOUT_CURL=TRUE -DWITHOUT_OPENSSL=TRUE -DWITHOUT_BLKID=TRUE -DFACTER_SKIP_TESTS=TRUE -DWITHOUT_JRUBY=ON")
   end
 
+  if platform.is_windows?
+    gemdir = "$(shell cygpath -m #{settings[:gemdir]})"
+  else
+    gemdir = settings[:gemdir]
+  end
+
   pkg.configure do
     [
-      "#{settings[:ruby_binary]} generate-gemspec.rb facter-precompiled.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-precompiled.gemspec.erb \"#{gemdir}\" '#{settings[:project_version]}'"
     ]
   end
 

--- a/configs/components/facter-source-gem.rb
+++ b/configs/components/facter-source-gem.rb
@@ -11,9 +11,15 @@ component "facter-source-gem" do |pkg, settings, platform|
   pkg.install_file('extconf.rb', "#{settings[:gemdir]}/ext/facter")
   pkg.install_file('Makefile.erb', "#{settings[:gemdir]}/ext/facter")
 
+  if platform.is_windows?
+    gemdir = "$(shell cygpath -m #{settings[:gemdir]})"
+  else
+    gemdir = settings[:gemdir]
+  end
+
   pkg.configure do
     [
-      "#{settings[:ruby_binary]} generate-gemspec.rb facter-source.gemspec.erb '#{settings[:gemdir]}' '#{settings[:project_version]}'"
+      "#{settings[:ruby_binary]} generate-gemspec.rb facter-source.gemspec.erb \"#{gemdir}\" '#{settings[:project_version]}'"
     ]
   end
 


### PR DESCRIPTION
The ruby interpreter on Windows does not know how to load our
cygwin-generated temp directory. We need to convert it to a proper
Windows path to allow generating the gemspecs correctly.