### PR TITLE
(PA-1990) migrate nuget from nexus to artifactory

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -7,8 +7,7 @@ platform "windows-2012r2-x64" do |plat|
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
   plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
-  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
-  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget"
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -7,8 +7,7 @@ platform "windows-2012r2-x86" do |plat|
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
   plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1"
-  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/"
-  plat.add_build_repository "http://nexus.delivery.puppetlabs.net/service/local/nuget/nuget-pl-build-tools/"
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget"
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety


### PR DESCRIPTION
We are migrating everything over from nexus to artifactory. This commit changes the url for the nuget build repository and uses the artifactory/nuget api