### PR TITLE
(maint) Modules should be installed from gh repo

### DIFF
--- a/configs/components/_base-module.rb
+++ b/configs/components/_base-module.rb
@@ -26,10 +26,6 @@ unless match_data
 end
 module_author, module_name = match_data.captures
 
-unless pkg.get_version
-  raise "You must set a version for the #{module_author}-#{module_name} module."
-end
-
 # Modules must have puppet
 pkg.build_requires 'puppet'
 
@@ -43,14 +39,8 @@ else
   pkg.directory(settings[:module_vendordir], mode: '0755', owner: 'root', group: 'root')
 end
 
-# Determine the download URL
-module_slug = "#{module_author}-#{module_name}-#{pkg.get_version}"
-tarball_name = "#{module_slug}.tar.gz"
-pkg.url("#{settings[:forge_download_baseurl]}/#{tarball_name}")
-
 pkg.install do
   [
-    "gunzip -c #{tarball_name} | #{platform.tar} -C #{settings[:module_vendordir]} -xf -",
-    "mv #{File.join(settings[:module_vendordir], module_slug)} #{File.join(settings[:module_vendordir], module_name)}"
+    "mv #{module_author}-#{module_name} #{File.join(settings[:module_vendordir], module_name)}"
   ]
 end

--- a/configs/components/module-puppetlabs-mailalias_core.json
+++ b/configs/components/module-puppetlabs-mailalias_core.json
@@ -1,0 +1,1 @@
+{"url":"git://github.com/puppetlabs/puppetlabs-mailalias_core.git","ref":"refs/tags/1.0.2"}

--- a/configs/components/module-puppetlabs-mailalias_core.rb
+++ b/configs/components/module-puppetlabs-mailalias_core.rb
@@ -1,6 +1,5 @@
 component "module-puppetlabs-mailalias_core" do |pkg, settings, platform|
-  pkg.version "1.0.2"
-  pkg.md5sum "8221ef8868bbea49ba379fd9b398b46a"
+  pkg.load_from_json("configs/components/module-puppetlabs-mailalias_core.json")
 
   instance_eval File.read("configs/components/_base-module.rb")
 end

--- a/configs/components/module-puppetlabs-maillist_core.json
+++ b/configs/components/module-puppetlabs-maillist_core.json
@@ -1,0 +1,1 @@
+{"url":"git://github.com/puppetlabs/puppetlabs-maillist_core.git","ref":"refs/tags/1.0.1"}

--- a/configs/components/module-puppetlabs-maillist_core.rb
+++ b/configs/components/module-puppetlabs-maillist_core.rb
@@ -1,6 +1,5 @@
 component "module-puppetlabs-maillist_core" do |pkg, settings, platform|
-  pkg.version "1.0.1"
-  pkg.md5sum "575bb9d74154a48aae334bba478d19e3"
+  pkg.load_from_json("configs/components/module-puppetlabs-maillist_core.json")
 
   pkg.build_requires "module-puppetlabs-mailalias_core"
 


### PR DESCRIPTION
This commit alters how we're handling modules during the install
process. Prior, we had been installing them from the forge. This commit
changes the install so that we're installing from a github repo. This
allows us to include development versions of modules in the puppet-agent
package, as we do for all other component projects included here.

This commit also modifies mailalias and maillist to read data from
corresponding json files.