### PR TITLE
(PA-1995) Load puppet-runtime settings from yaml

### DIFF
--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-runtime.git","ref":"refs/tags/201805150"}
+{"location":"http://builds.puppetlabs.delivery.net/puppet-runtime/201805150/artifacts/","version":"201805150"}

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -1,13 +1,11 @@
 component 'puppet-runtime' do |pkg, settings, platform|
   runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  pkg.version runtime_tag
+  pkg.version runtime_details["version"]
 
   tarball_name = "agent-runtime-5.5.x-#{pkg.get_version}.#{platform.name}.tar.gz"
 
-  pkg.sha1sum "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}.sha1"
-  pkg.url "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}"
+  pkg.url File.join(runtime_details["location"], tarball_name)
+  pkg.sha1sum File.join(runtime_details["location"], "#{tarball_name}.sha1")
 
   # The contents of the runtime replace the following:
   pkg.replaces 'pe-augeas'

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,13 +1,14 @@
 project "puppet-agent" do |proj|
+  platform = proj.get_platform
+
   # puppet-agent inherits most build settings from puppetlabs/puppet-runtime:
   # - Modifications to global settings like flags and target directories should be made in puppet-runtime.
   # - Settings included in this file should apply only to local components in this repository.
-  runtime_details = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', 'components/puppet-runtime.json')))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  proj.inherit_settings 'agent-runtime-5.5.x', runtime_details['url'], runtime_tag
-
-  platform = proj.get_platform
+  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
+  settings_filename = "agent-runtime-5.5.x-#{runtime_details['version']}.#{platform.name}.settings.yaml"
+  settings_filepath = File.join(runtime_details['location'], settings_filename)
+  sha1_filepath = File.join(runtime_details['location'], "#{settings_filename}.sha1")
+  proj.inherit_yaml_settings(settings_filepath, sha1_filepath)
 
   # (PA-678) pe-r10k versions prior to 2.5.0.0 ship gettext gems.
   # Since we also ship those gems as part of puppet-agent


### PR DESCRIPTION
Updates the puppet-runtime.json file to a new format, which contains a
location (an http or file URL to some puppet-runtime output directory)
and a version for puppet-runtime. This information is used to determine
a download location for:

- an appropriate runtime tarball, and
- a yaml file containing inheritable project settings for the current platform

This removes the need to git-clone the runtime repository to inherit
settings on every build.

These changes are blocked on https://github.com/puppetlabs/vanagon/pull/566 and https://github.com/puppetlabs/puppet-runtime/pull/57, so I'll mark this `don't merge` for now.