### PR TITLE
(CPR-391) Fedora packages have odd distro tag

### DIFF
--- a/configs/platforms/fedora-26-x86_64.rb
+++ b/configs/platforms/fedora-26-x86_64.rb
@@ -1,10 +1,11 @@
-platform "fedora-f27-x86_64" do |plat|
+platform "fedora-26-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-27.noarch.rpm"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
-  plat.vmpooler_template "fedora-27-x86_64"
+  plat.vmpooler_template "fedora-26-x86_64"
+  plat.dist "fc26"
 end

--- a/configs/platforms/fedora-27-x86_64.rb
+++ b/configs/platforms/fedora-27-x86_64.rb
@@ -1,10 +1,11 @@
-platform "fedora-f26-x86_64" do |plat|
+platform "fedora-27-x86_64" do |plat|
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
   plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc make rpmdevtools rpm-libs"
-  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-26.noarch.rpm"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-27.noarch.rpm"
   plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
-  plat.vmpooler_template "fedora-26-x86_64"
+  plat.vmpooler_template "fedora-27-x86_64"
+  plat.dist "fc27"
 end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,8 +17,8 @@ foss_platforms:
   - el-7-ppc64le
   - el-7-aarch64
   - eos-4-i386
-  - fedora-f26-x86_64
-  - fedora-f27-x86_64
+  - fedora-26-x86_64
+  - fedora-27-x86_64
   - osx-10.12-x86_64
   - osx-10.13-x86_64
   - sles-11-i386
@@ -87,9 +87,9 @@ platform_repos:
   - name: sles-12-ppc64le
     repo_location: repos/sles/12/**/ppc64le
   - name: fedora-26-x86_64
-    repo_location: repos/fedora/f26/**/x86_64
+    repo_location: repos/fedora/26/**/x86_64
   - name: fedora-27-x86_64
-    repo_location: repos/fedora/f27/**/x86_64
+    repo_location: repos/fedora/27/**/x86_64
   - name: debian-8-i386
     repo_location: repos/apt/jessie
   - name: debian-8-amd64


### PR DESCRIPTION
This commit updates the fedora platform configs to not use the 'f' prefix in
versions and, instead, use 'fc<version>' as the dist tag, which is standard for
fedora packages.