### PR TITLE
(PA-2062) Remove hidden files from vendored modules

### DIFF
--- a/configs/components/_base-module.rb
+++ b/configs/components/_base-module.rb
@@ -39,8 +39,13 @@ else
   pkg.directory(settings[:module_vendordir], mode: '0755', owner: 'root', group: 'root')
 end
 
+target_directory = File.join(settings[:module_vendordir], module_name)
+
 pkg.install do
   [
-    "mv #{module_author}-#{module_name} #{File.join(settings[:module_vendordir], module_name)}"
+    # Rename appropriately for use with puppet
+    "mv #{module_author}-#{module_name} #{target_directory}",
+    # Remove git and CI-related files
+    "rm -r #{File.join(target_directory, '.[!.]*')} 2>/dev/null",
   ]
 end


### PR DESCRIPTION
Removes any hidden files from directories in the `module_vendordir`, including .git/, travis config, etc.

I compared the results of removing hidden files with the the contents of module directories produced by PMT installs, and they seem to be equivalent (from an admittedly small sample). That said, some modules do include nonessential non-hidden things like an `appveyor.yml` even in the PMT-installed versions, so I left those alone for now.