### PR TITLE
(PA-2188) migrate docker build scripts for puppet-agent

### DIFF
--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -1,0 +1,4 @@
+release-engineering/puppet-agent:
+  Build:
+    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
+    - '(cd docker && /bin/bash -x ./ci/build)'

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,0 +1,13 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+def location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.1.5')

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -10,4 +10,4 @@ def location_for(place)
   end
 end
 
-gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.1.5')
+gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.2')

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -17,7 +17,7 @@ function build_and_test_image() {
   : === build and test $container_name
   : ===
   bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --no-latest
-  bundle exec puppet-docker spec "$container_name"
+  bundle exec puppet-docker spec "$container_name" --image "puppet/$container_name:$version"
 }
 
 function push_image() {

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -eux
+
+BUNDLER_PATH=.bundle/gems
+
+function build_and_test_image() {
+  container_name=$1
+
+  # Haven't yet figured out how to run a container with a mounted file in pipelines
+  # will probably end up adding an image with hadolint preloaded and update the
+  # lint commands to optionally use a local installation if I don't hear back that
+  # this is possible.
+  #: ===
+  #: === run linter on the docker files
+  #: ===
+  # bundle exec puppet-docker lint $container_name
+
+  : ===
+  : === build and test $container_name
+  : ===
+  bundle exec puppet-docker rev-labels $container_name
+  bundle exec puppet-docker build $container_name --repository pcr-internal.puppet.net/release-engineering
+  bundle exec puppet-docker spec $container_name
+}
+
+function push_image() {
+  container_name=$1
+  : ===
+  : === push $container_name
+  : ===
+  bundle exec puppet-docker push $container_name --repository pcr-internal.puppet.net/release-engineering
+}
+
+: ===
+: === bundle install to get ready
+: ===
+bundle install --path $BUNDLER_PATH
+
+: ===
+: === pull updated base images
+: ===
+bundle exec puppet-docker update-base-images centos:7 alpine:3.4 debian:9 ubuntu:16.04
+
+container_list=(puppet-agent-centos puppet-agent-alpine puppet-agent-debian puppet-agent-ubuntu puppet-agent)
+
+: ===
+: === build and test all the images before we push anything
+: ===
+for container in ${container_list[@]}; do
+  build_and_test_image $container
+done
+
+: ===
+: === push all the images
+: ===
+for container in ${container_list[@]}; do
+  push_image $container
+done
+
+: ===
+: === SUCCESS
+: ===

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -2,40 +2,49 @@
 
 set -eux
 
+PATH="$PATH":/usr/local/bin
 BUNDLER_PATH=.bundle/gems
 
 function build_and_test_image() {
-  container_name=$1
+  container_name="$1"
 
-  # Haven't yet figured out how to run a container with a mounted file in pipelines
-  # will probably end up adding an image with hadolint preloaded and update the
-  # lint commands to optionally use a local installation if I don't hear back that
-  # this is possible.
-  #: ===
-  #: === run linter on the docker files
-  #: ===
-  # bundle exec puppet-docker lint $container_name
+  : ===
+  : === run linter on the docker files
+  : ===
+   bundle exec puppet-docker local-lint "$container_name"
 
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker rev-labels $container_name
-  bundle exec puppet-docker build $container_name --repository pcr-internal.puppet.net/release-engineering
-  bundle exec puppet-docker spec $container_name
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --no-latest
+  bundle exec puppet-docker spec "$container_name"
 }
 
 function push_image() {
-  container_name=$1
+  container_name="$1"
+  container_version="$2"
   : ===
   : === push $container_name
   : ===
-  bundle exec puppet-docker push $container_name --repository pcr-internal.puppet.net/release-engineering
+  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version" --no-latest
 }
 
 : ===
 : === bundle install to get ready
 : ===
-bundle install --path $BUNDLER_PATH
+bundle install --path "$BUNDLER_PATH"
+
+: ===
+: === If we do not git pull --unshallow we get really weird results with git describe
+: ===
+git pull --unshallow
+
+: ===
+: === make sure we fetch tags for versioning
+: ===
+git fetch origin 'refs/tags/*:refs/tags/*'
+git_describe=`git describe`
+version="${git_describe%%-*}"
 
 : ===
 : === pull updated base images
@@ -47,15 +56,15 @@ container_list=(puppet-agent-centos puppet-agent-alpine puppet-agent-debian pupp
 : ===
 : === build and test all the images before we push anything
 : ===
-for container in ${container_list[@]}; do
-  build_and_test_image $container
+for container in "${container_list[@]}"; do
+  build_and_test_image "$container"
 done
 
 : ===
 : === push all the images
 : ===
-for container in ${container_list[@]}; do
-  push_image $container
+for container in "${container_list[@]}"; do
+  push_image "$container"
 done
 
 : ===

--- a/docker/distelli-manifest.yml
+++ b/docker/distelli-manifest.yml
@@ -1,4 +1,4 @@
 release-engineering/puppet-agent:
   Build:
     - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
-    - '(cd docker && /bin/bash -x ./ci/build)'
+    - /bin/bash -x ./ci/build

--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.4
+
+ENV PUPPET_VERSION="5.5.1" FACTER_VERSION="2.5.1"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Agent (Alpine)" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:10:01Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apk add --no-cache \
+      ca-certificates \
+      pciutils \
+      ruby \
+      ruby-irb \
+      ruby-rdoc \
+      && \
+    echo http://dl-4.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories && \
+    apk add --no-cache shadow && \
+    gem install puppet:"$PUPPET_VERSION" facter:"$FACTER_VERSION" && \
+    /usr/bin/puppet module install puppetlabs-apk
+
+# Workaround for https://tickets.puppetlabs.com/browse/FACT-1351
+RUN rm /usr/lib/ruby/gems/2.3.0/gems/facter-"$FACTER_VERSION"/lib/facter/blockdevices.rb
+
+ENTRYPOINT ["/usr/bin/puppet"]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+
+COPY Dockerfile /

--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -1,16 +1,22 @@
 FROM alpine:3.4
 
-ENV PUPPET_VERSION="5.5.1" FACTER_VERSION="2.5.1"
+ARG version=5.5.1
+ARG vcs_ref
+ARG build_date
+
+ENV PUPPET_AGENT_VERSION="$version"
+ENV PUPPET_VERSION="~> 5.5.1"
+ENV FACTER_VERSION="2.5.1"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-agent" \
       org.label-schema.name="Puppet Agent (Alpine)" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version=$PUPPET_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:10:01Z" \
+      org.label-schema.version="$PUPPET_AGENT_VERSION" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-agent" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
@@ -30,6 +36,6 @@ RUN apk add --no-cache \
 RUN rm /usr/lib/ruby/gems/2.3.0/gems/facter-"$FACTER_VERSION"/lib/facter/blockdevices.rb
 
 ENTRYPOINT ["/usr/bin/puppet"]
-CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize"]
 
 COPY Dockerfile /

--- a/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
@@ -16,10 +16,6 @@ describe 'Dockerfile' do
   end
 
   describe 'Dockerfile#running' do
-    include_context 'with a docker container'
-
-    describe command('/usr/bin/puppet help') do
-      its(:exit_status) { should eq 0 }
-    end
+    it_should_behave_like 'a running container', 'help', 0
   end
 end

--- a/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'using alpine'
+  include_context 'with a docker image'
+
+  describe package('puppet') do
+    it { is_expected.to be_installed.by('gem') }
+  end
+
+  describe file('/usr/bin/puppet') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe command('/usr/bin/puppet help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
@@ -3,19 +3,22 @@ require 'puppet_docker_tools/spec_helper'
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 
 describe 'Dockerfile' do
-  include_context 'using alpine'
   include_context 'with a docker image'
-
-  describe package('puppet') do
-    it { is_expected.to be_installed.by('gem') }
+  include_context 'with a docker container' do
+    def docker_run_options
+      "--entrypoint /bin/sh"
+    end
   end
 
-  describe file('/usr/bin/puppet') do
-    it { should exist }
-    it { should be_executable }
+  describe 'has puppet installed' do
+    it_should_behave_like 'a running container', 'gem list --installed puppet', 0
+  end
+
+  describe 'has /usr/bin/puppet' do
+    it_should_behave_like 'a running container', 'stat -L /usr/bin/puppet', 0, 'Access: \(0755\/\-rwxr\-xr\-x\)'
   end
 
   describe 'Dockerfile#running' do
-    it_should_behave_like 'a running container', 'help', 0
+    it_should_behave_like 'a running container', 'puppet help', 0
   end
 end

--- a/docker/puppet-agent-centos/Dockerfile
+++ b/docker/puppet-agent-centos/Dockerfile
@@ -1,0 +1,28 @@
+FROM centos:7
+
+ENV PUPPET_AGENT_VERSION="5.5.1"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Agent (Centos)" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_AGENT_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:10:12Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN rpm -Uvh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm && \
+    yum upgrade -y && \
+    yum update -y && \
+    yum install -y puppet-agent-"$PUPPET_AGENT_VERSION" && \
+    yum clean all
+
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+
+ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+
+COPY Dockerfile /

--- a/docker/puppet-agent-centos/Dockerfile
+++ b/docker/puppet-agent-centos/Dockerfile
@@ -1,16 +1,20 @@
 FROM centos:7
 
-ENV PUPPET_AGENT_VERSION="5.5.1"
+ARG vcs_ref
+ARG build_date
+ARG version="5.5.1"
+
+ENV PUPPET_AGENT_VERSION="$version"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-agent" \
       org.label-schema.name="Puppet Agent (Centos)" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version=$PUPPET_AGENT_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:10:12Z" \
+      org.label-schema.version="$PUPPET_AGENT_VERSION" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-agent" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
@@ -23,6 +27,6 @@ RUN rpm -Uvh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm 
 ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
-CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize"]
 
 COPY Dockerfile /

--- a/docker/puppet-agent-centos/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-centos/spec/dockerfile_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'using centos'
+  include_context 'with a docker image'
+
+  describe yumrepo('puppet5') do
+    it { should exist }
+  end
+
+  describe package('puppet-agent.x86_64') do
+    it { is_expected.to be_installed }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppet') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe command('/opt/puppetlabs/bin/puppet help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppet-agent-centos/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-centos/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppet-agent-centos/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-centos/spec/dockerfile_spec.rb
@@ -20,10 +20,6 @@ describe 'Dockerfile' do
   end
 
   describe 'Dockerfile#running' do
-    include_context 'with a docker container'
-
-    describe command('/opt/puppetlabs/bin/puppet help') do
-      its(:exit_status) { should eq 0 }
-    end
+    it_should_behave_like 'a running container', 'help', 0
   end
 end

--- a/docker/puppet-agent-centos/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-centos/spec/dockerfile_spec.rb
@@ -3,23 +3,26 @@ require 'puppet_docker_tools/spec_helper'
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 
 describe 'Dockerfile' do
-  include_context 'using centos'
   include_context 'with a docker image'
-
-  describe yumrepo('puppet5') do
-    it { should exist }
+  include_context 'with a docker container' do
+    def docker_run_options
+      "--entrypoint /bin/bash"
+    end
   end
 
-  describe package('puppet-agent.x86_64') do
-    it { is_expected.to be_installed }
+  describe 'the puppet5 repo is installed' do
+    it_should_behave_like 'a running container', 'ls /etc/yum.repos.d/puppet5.repo', 0
   end
 
-  describe file('/opt/puppetlabs/bin/puppet') do
-    it { should exist }
-    it { should be_executable }
+  describe 'puppet-agent is installed' do
+    it_should_behave_like 'a running container', 'rpm -q puppet-agent', 0
+  end
+
+  describe 'has /opt/puppetlabs/bin/puppet' do
+    it_should_behave_like 'a running container', 'stat -L /opt/puppetlabs/bin/puppet', 0, 'Access: \(0755\/\-rwxr\-xr\-x\)'
   end
 
   describe 'Dockerfile#running' do
-    it_should_behave_like 'a running container', 'help', 0
+    it_should_behave_like 'a running container', 'puppet help', 0
   end
 end

--- a/docker/puppet-agent-debian/Dockerfile
+++ b/docker/puppet-agent-debian/Dockerfile
@@ -1,21 +1,26 @@
 FROM debian:9
 
-ENV PUPPET_AGENT_VERSION="5.5.1" DEBIAN_CODENAME="stretch"
+ARG vcs_ref
+ARG build_date
+ARG version="5.5.1"
+
+ENV PUPPET_AGENT_VERSION="$version"
+ENV DEBIAN_CODENAME="stretch"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-agent" \
       org.label-schema.name="Puppet Agent (Debian)" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_AGENT_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:10:23Z" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-agent" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y --no-install-recommends wget ca-certificates && \
     wget https://apt.puppetlabs.com/puppet5-release-"$DEBIAN_CODENAME".deb && \
     dpkg -i puppet5-release-"$DEBIAN_CODENAME".deb && \
     rm puppet5-release-"$DEBIAN_CODENAME".deb && \
@@ -27,6 +32,6 @@ RUN apt-get update && \
 ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
-CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize"]
 
 COPY Dockerfile /

--- a/docker/puppet-agent-debian/Dockerfile
+++ b/docker/puppet-agent-debian/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:9
+
+ENV PUPPET_AGENT_VERSION="5.5.1" DEBIAN_CODENAME="stretch"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Agent (Debian)" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_AGENT_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:10:23Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget https://apt.puppetlabs.com/puppet5-release-"$DEBIAN_CODENAME".deb && \
+    dpkg -i puppet5-release-"$DEBIAN_CODENAME".deb && \
+    rm puppet5-release-"$DEBIAN_CODENAME".deb && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$DEBIAN_CODENAME" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+
+ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+
+COPY Dockerfile /

--- a/docker/puppet-agent-debian/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-debian/spec/dockerfile_spec.rb
@@ -15,10 +15,6 @@ describe 'Dockerfile' do
   end
 
   describe 'Dockerfile#running' do
-    include_context 'with a docker container'
-
-    describe command('/opt/puppetlabs/bin/puppet help') do
-      its(:exit_status) { should eq 0 }
-    end
+    it_should_behave_like 'a running container', 'help', 0
   end
 end

--- a/docker/puppet-agent-debian/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-debian/spec/dockerfile_spec.rb
@@ -4,17 +4,21 @@ CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 
 describe 'Dockerfile' do
   include_context 'with a docker image'
-
-  describe package('puppet-agent') do
-    it { is_expected.to be_installed }
+  include_context 'with a docker container' do
+    def docker_run_options
+      "--entrypoint /bin/bash"
+    end
   end
 
-  describe file('/opt/puppetlabs/bin/puppet') do
-    it { should exist }
-    it { should be_executable }
+  describe 'has puppet-agent installed' do
+    it_should_behave_like 'a running container', 'dpkg -l puppet-agent', 0
+  end
+
+  describe 'has /opt/puppetlabs/bin/puppet' do
+    it_should_behave_like 'a running container', 'stat -L /opt/puppetlabs/bin/puppet', 0, 'Access: \(0755\/\-rwxr\-xr\-x\)'
   end
 
   describe 'Dockerfile#running' do
-    it_should_behave_like 'a running container', 'help', 0
+    it_should_behave_like 'a running container', 'puppet help', 0
   end
 end

--- a/docker/puppet-agent-debian/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-debian/spec/dockerfile_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'with a docker image'
+
+  describe package('puppet-agent') do
+    it { is_expected.to be_installed }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppet') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe command('/opt/puppetlabs/bin/puppet help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppet-agent-debian/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-debian/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppet-agent-ubuntu/Dockerfile
+++ b/docker/puppet-agent-ubuntu/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+ENV PUPPET_AGENT_VERSION="5.5.1" UBUNTU_CODENAME="xenial"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Agent (Ubuntu)" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_AGENT_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:06:11Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y wget ca-certificates lsb-release && \
+    wget https://apt.puppetlabs.com/puppet5-release-"$UBUNTU_CODENAME".deb && \
+    dpkg -i puppet5-release-"$UBUNTU_CODENAME".deb && \
+    rm puppet5-release-"$UBUNTU_CODENAME".deb && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$UBUNTU_CODENAME" && \
+    apt-get remove --purge -y wget && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+
+ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+
+COPY Dockerfile /

--- a/docker/puppet-agent-ubuntu/Dockerfile
+++ b/docker/puppet-agent-ubuntu/Dockerfile
@@ -1,16 +1,21 @@
 FROM ubuntu:16.04
 
-ENV PUPPET_AGENT_VERSION="5.5.1" UBUNTU_CODENAME="xenial"
+ARG version="5.5.1"
+ARG vcs_ref
+ARG build_date
+
+ENV PUPPET_AGENT_VERSION="$version"
+ENV UBUNTU_CODENAME="xenial"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-agent" \
       org.label-schema.name="Puppet Agent (Ubuntu)" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_AGENT_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:06:11Z" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-agent" \
+      org.label-schema.vcs-ref="vcs_ref" \
+      org.label-schema.build-date="build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
@@ -29,6 +34,6 @@ RUN apt-get update && \
 ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
-CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize" ]
+CMD ["agent", "--verbose", "--onetime", "--no-daemonize", "--summarize"]
 
 COPY Dockerfile /

--- a/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'with a docker image'
+
+  ['puppet-agent', 'lsb-release'].each do |package_name|
+    describe package(package_name) do
+      it { is_expected.to be_installed }
+    end
+  end
+
+  describe package('wget') do
+    it { is_expected.not_to be_installed }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppet') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe command('/opt/puppetlabs/bin/puppet help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
@@ -21,10 +21,6 @@ describe 'Dockerfile' do
   end
 
   describe 'Dockerfile#running' do
-    include_context 'with a docker container'
-
-    describe command('/opt/puppetlabs/bin/puppet help') do
-      its(:exit_status) { should eq 0 }
-    end
+    it_should_behave_like 'a running container', 'help', 0
   end
 end

--- a/docker/puppet-agent/Dockerfile
+++ b/docker/puppet-agent/Dockerfile
@@ -1,0 +1,14 @@
+FROM puppet/puppet-agent-ubuntu:5.5.1
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.name="Puppet Agent" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version=$PUPPET_AGENT_VERSION \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
+      org.label-schema.build-date="2018-05-09T20:10:27Z" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+

--- a/docker/puppet-agent/Dockerfile
+++ b/docker/puppet-agent/Dockerfile
@@ -1,14 +1,19 @@
-FROM puppet/puppet-agent-ubuntu:5.5.1
+ARG version="5.5.1"
+ARG namespace="puppet"
+FROM "$namespace"/puppet-agent-ubuntu:"$version"
+
+ARG vcs_ref
+ARG build_date
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
-      org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
+      org.label-schema.url="https://github.com/puppetlabs/puppet-agent" \
       org.label-schema.name="Puppet Agent" \
       org.label-schema.license="Apache-2.0" \
       org.label-schema.version=$PUPPET_AGENT_VERSION \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-in-docker" \
-      org.label-schema.vcs-ref="b75674e1fbf52f7821f7900ab22a19f1a10cafdb" \
-      org.label-schema.build-date="2018-05-09T20:10:27Z" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-agent" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 

--- a/docker/puppet-agent/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent/spec/dockerfile_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
+
+describe 'Dockerfile' do
+  include_context 'with a docker image'
+
+  ['puppet-agent', 'lsb-release'].each do |package_name|
+    describe package(package_name) do
+      it { is_expected.to be_installed }
+    end
+  end
+
+  describe package('wget') do
+    it { is_expected.not_to be_installed }
+  end
+
+  describe file('/opt/puppetlabs/bin/puppet') do
+    it { should exist }
+    it { should be_executable }
+  end
+
+  describe 'Dockerfile#running' do
+    include_context 'with a docker container'
+
+    describe command('/opt/puppetlabs/bin/puppet help') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end

--- a/docker/puppet-agent/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent/spec/dockerfile_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'puppet_docker_tools/spec_helper'
 
 CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 

--- a/docker/puppet-agent/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent/spec/dockerfile_spec.rb
@@ -21,10 +21,6 @@ describe 'Dockerfile' do
   end
 
   describe 'Dockerfile#running' do
-    include_context 'with a docker container'
-
-    describe command('/opt/puppetlabs/bin/puppet help') do
-      its(:exit_status) { should eq 0 }
-    end
+    it_should_behave_like 'a running container', 'help', 0
   end
 end


### PR DESCRIPTION
These were migrated from https://github.com/puppetlabs/puppet-in-docker