### PR TITLE
(PA-2019) Change CustomAction directory references

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -198,7 +198,7 @@ End If
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->
     <SetProperty
         Id="TakeownPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[$PuppetAppDir]\*&quot; /R /A /D N"
+        Value="&quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /R /A /D N"
         Before="TakeownPuppetPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -214,7 +214,7 @@ End If
     <!-- Due to PUP-6729, now that we can modify the DACL, ensure admins and system have full control -->
     <SetProperty
         Id="GrantPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PuppetAppDir]\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
         Before="GrantPuppetPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -230,7 +230,7 @@ End If
     <!-- Leave root APPDATADIR as-is -->
     <SetProperty
         Id="ResetCodePermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$CodeDir]\*&quot; /reset /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\code\*&quot; /reset /T /C"
         Before="ResetCodePermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -245,7 +245,7 @@ End If
 
     <SetProperty
         Id="ResetFacterPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$FacterAppDir]\*&quot; /reset /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\facter\*&quot; /reset /T /C"
         Before="ResetFacterPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -260,7 +260,7 @@ End If
 
     <SetProperty
         Id="ResetPxpAgentPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PXPAgentDataDir]\*&quot; /reset /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\pxp-agent\*&quot; /reset /T /C"
         Before="ResetPxpAgentPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -275,7 +275,7 @@ End If
 
     <SetProperty
         Id="ResetPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PuppetAppDir]\*&quot; /reset /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /reset /T /C"
         Before="ResetPuppetPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")
@@ -290,7 +290,7 @@ End If
 
     <SetProperty
         Id="ResetMcoPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$MCOAppDir]\*&quot; /reset /T /C"
+        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\mcollective\*&quot; /reset /T /C"
         Before="ResetMcoPermissions"
         Sequence="execute">
         NOT (REMOVE~="ALL")

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -201,7 +201,7 @@ End If
         Value="&quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /R /A /D N"
         Before="TakeownPuppetPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="TakeownPuppetPermissions"
@@ -217,7 +217,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
         Before="GrantPuppetPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="GrantPuppetPermissions"
@@ -233,7 +233,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\code\*&quot; /reset /T /C"
         Before="ResetCodePermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="ResetCodePermissions"
@@ -248,7 +248,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\facter\*&quot; /reset /T /C"
         Before="ResetFacterPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="ResetFacterPermissions"
@@ -263,7 +263,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\pxp-agent\*&quot; /reset /T /C"
         Before="ResetPxpAgentPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="ResetPxpAgentPermissions"
@@ -278,7 +278,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\puppet\*&quot; /reset /T /C"
         Before="ResetPuppetPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="ResetPuppetPermissions"
@@ -293,7 +293,7 @@ End If
         Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%PROGRAMDATA]\PuppetLabs\mcollective\*&quot; /reset /T /C"
         Before="ResetMcoPermissions"
         Sequence="execute">
-        NOT (REMOVE~="ALL")
+        NOT REMOVE
     </SetProperty>
     <CustomAction
         Id="ResetMcoPermissions"


### PR DESCRIPTION
 - 7cdb9e8b57b93d44b60a4e29f96e40ffcf449d6f introduced a change to
   reference directories in CustomAction tables by their component
   name, rather than by their directory name.

   However, it seems that this is, in some cases, resulting in empty
   strings, which causes takeown / icacls to run against \* instead
   of the desired fully qualified directory. This can damage file
   permissions on a Windows machine in a very destructive manner.

   MSDN documentation https://msdn.microsoft.com/library/aa368609.aspx
   suggests that this is because:

   "
   Note that if a component is already installed, and is not
   reinstalled, removed, or moved during the current installation, the
   action state of the component is null and the string
   [$componentkey] evaluates to Null.
   "