### PR TITLE
(PA-2075) Use ProgramData to resolve puppet's data directory

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -196,13 +196,11 @@ End If
     <%-end-%>
 
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->
-    <SetProperty
-        Id="TakeownPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[$PuppetAppDir]\*&quot; /R /A /D N"
-        Before="TakeownPuppetPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetTakeownPuppetPermissions"
+        Property="TakeownPuppetPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /R /A /D N"
+        Execute="immediate"/>
     <CustomAction
         Id="TakeownPuppetPermissions"
         BinaryKey="WixCA"
@@ -212,13 +210,11 @@ End If
         Impersonate="no"/>
 
     <!-- Due to PUP-6729, now that we can modify the DACL, ensure admins and system have full control -->
-    <SetProperty
-        Id="GrantPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PuppetAppDir]\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
-        Before="GrantPuppetPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetGrantPuppetPermissions"
+        Property="GrantPuppetPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="GrantPuppetPermissions"
         BinaryKey="WixCA"
@@ -228,13 +224,11 @@ End If
         Impersonate="no"/>
 
     <!-- Leave root APPDATADIR as-is -->
-    <SetProperty
-        Id="ResetCodePermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$CodeDir]\*&quot; /reset /T /C"
-        Before="ResetCodePermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetResetCodePermissions"
+        Property="ResetCodePermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\code&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\code\*&quot; /reset /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="ResetCodePermissions"
         BinaryKey="WixCA"
@@ -243,13 +237,11 @@ End If
         Return="check"
         Impersonate="no"/>
 
-    <SetProperty
-        Id="ResetFacterPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$FacterAppDir]\*&quot; /reset /T /C"
-        Before="ResetFacterPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetResetFacterPermissions"
+        Property="ResetFacterPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\facter&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\facter\*&quot; /reset /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="ResetFacterPermissions"
         BinaryKey="WixCA"
@@ -258,13 +250,11 @@ End If
         Return="check"
         Impersonate="no"/>
 
-    <SetProperty
-        Id="ResetPxpAgentPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PXPAgentDataDir]\*&quot; /reset /T /C"
-        Before="ResetPxpAgentPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetResetPxpAgentPermissions"
+        Property="ResetPxpAgentPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\pxp-agent&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\pxp-agent\*&quot; /reset /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="ResetPxpAgentPermissions"
         BinaryKey="WixCA"
@@ -273,13 +263,11 @@ End If
         Return="check"
         Impersonate="no"/>
 
-    <SetProperty
-        Id="ResetPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$PuppetAppDir]\*&quot; /reset /T /C"
-        Before="ResetPuppetPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetResetPuppetPermissions"
+        Property="ResetPuppetPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /reset /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="ResetPuppetPermissions"
         BinaryKey="WixCA"
@@ -288,13 +276,11 @@ End If
         Return="check"
         Impersonate="no"/>
 
-    <SetProperty
-        Id="ResetMcoPermissions"
-        Value="&quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[$MCOAppDir]\*&quot; /reset /T /C"
-        Before="ResetMcoPermissions"
-        Sequence="execute">
-        NOT (REMOVE~="ALL")
-    </SetProperty>
+    <CustomAction
+        Id="SetResetMcoPermissions"
+        Property="ResetMcoPermissions"
+        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\mcollective&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\mcollective\*&quot; /reset /T /C"
+        Execute="immediate"/>
     <CustomAction
         Id="ResetMcoPermissions"
         BinaryKey="WixCA"

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -119,28 +119,49 @@
       </Custom>
 
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
-      <Custom Action='TakeownPuppetPermissions' After='InstallFiles'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='SetTakeownPuppetPermissions' After='InstallFiles'>
+          NOT REMOVE
       </Custom>
-      <Custom Action='GrantPuppetPermissions' After='TakeownPuppetPermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='TakeownPuppetPermissions' After='SetTakeownPuppetPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='SetGrantPuppetPermissions' After='TakeownPuppetPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='GrantPuppetPermissions' After='SetGrantPuppetPermissions'>
+          NOT REMOVE
       </Custom>
 
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='ResetCodePermissions' After='GrantPuppetPermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='SetResetCodePermissions' After='GrantPuppetPermissions'>
+          NOT REMOVE
       </Custom>
-      <Custom Action='ResetFacterPermissions' After='ResetCodePermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='ResetCodePermissions' After='SetResetCodePermissions'>
+          NOT REMOVE
       </Custom>
-      <Custom Action='ResetPxpAgentPermissions' After='ResetFacterPermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='SetResetFacterPermissions' After='ResetCodePermissions'>
+          NOT REMOVE
       </Custom>
-      <Custom Action='ResetPuppetPermissions' After='ResetPxpAgentPermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='ResetFacterPermissions' After='SetResetFacterPermissions'>
+          NOT REMOVE
       </Custom>
-      <Custom Action='ResetMcoPermissions' After='ResetPuppetPermissions'>
-        NOT (REMOVE~="ALL")
+      <Custom Action='SetResetPxpAgentPermissions' After='ResetFacterPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='ResetPxpAgentPermissions' After='SetResetPxpAgentPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='SetResetPuppetPermissions' After='ResetPxpAgentPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='ResetPuppetPermissions' After='SetResetPuppetPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='SetResetMcoPermissions' After='ResetPuppetPermissions'>
+          NOT REMOVE
+      </Custom>
+      <Custom Action='ResetMcoPermissions' After='SetResetMcoPermissions'>
+          NOT REMOVE
       </Custom>
 
       <%- if @platform.architecture == "x86" -%>


### PR DESCRIPTION
7cdb9e8 introduced a change to reference directories in CustomAction
tables by their component name, rather than by their directory name.

However, during a repair `[$componentkey]` resolves to an empty string,
resulting in takeown & icacls running from the root drive, damaging
file permissions system-wide.

MSDN documentation https://msdn.microsoft.com/library/aa368609.aspx
suggests that this is because:

    Note that if a component is already installed, and is not
    reinstalled, removed, or moved during the current installation, the
    action state of the component is null and the string
    [$componentkey] evaluates to Null.

This commit modifies the custom action logic so that it:

 * Uses `[%ProgramData]` which resolves to the value of the ProgramData
   environment variable, and should always be available during all MSI
   stages, e.g. install, repair, upgrade. Note environment variables are
   case insensitive.
 * Includes `PuppetLabs\{code,puppet,facter,pxp-agent,mcollective}` as
   part of the path, so even if ProgramData resolves to empty string,
   the path will be puppet specific.
 * Checks if the directory exists before trying to modify permissions.
 * Changes the custom action condition to `NOT REMOVE` instead of
   `NOT(REMOVE~="ALL")`. Since puppet-agent MSIs only have a single
   feature, the REMOVE property is either absent (during an initial
   install, repair, or the install phase of an upgrade), or it is
   present and has the value "ALL" (during the uninstall phase of a
   major upgrade, or a complete uninstall). So the two forms are
   equivalent, but the `NOT REMOVE` form is easier to reason about.
 * Converts the `SetProperty` WIX elements to the more generic
   `CustomAction` with a `Property` attribute, as that matches other
   properties in our WIX file and moves all of the conditional logic
   and sequencing into one file. The resulting property-based custom
   actions remain as type 51.

Co-authored-by: Ethan J. Brown <ethan@puppet.com>