### PR TITLE
(maint) Pin puppet to 4.10.12

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"48433efcf9ce9d6c7886badb6c870ba74cfde6e0"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"refs/tags/4.10.12"}


### PR DESCRIPTION
this commit re-pins puppet to 4.10.12 since there were no actual code changes
between the last tag and the current SHA