### PR TITLE
(maint) Pin puppet to 5.3.7

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"28b7f1d0fae2c0ee21118c7b6fd3c84d31329a4c"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"refs/tags/5.3.7"}


### PR DESCRIPTION
this commit pins the puppet component back to 5.3.7 since there are no actual
code changes between 5.3.7 and the current SHA