### PR TITLE
(maint) Pin puppet to 5.5.2

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"65004cb07acc89f9218e419d798f044e36bc76aa"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"refs/tags/5.5.2"}


### PR DESCRIPTION
This commit pins the puppet component to 5.5.2 in preperation of the agent
5.5.3 release