### PR TITLE
(PA-1995) Use location & version in puppet-runtime.json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def vanagon_location_for(place)
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.4')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.11')
 gem 'packaging', :github => 'puppetlabs/packaging', :branch => '1.0.x'
 gem 'artifactory'
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you wish to build puppet-agent or the facter gem yourself:
 
 1. First, build the
    [puppet-runtime](https://github.com/puppetlabs/puppet-runtime) for your
-   target platform, and take note of the path of the finished tarball.
+   target platform and agent version.
 2. Run `bundle install` to install required ruby dependencies.
 3. When building puppet-agent or the cfacter gem on infrastructure outside of
    Puppet, you will need to make a few edits in the component and project
@@ -70,10 +70,13 @@ If you wish to build puppet-agent or the facter gem yourself:
      equivalent installable packages on your target operating system. In many
      cases, you can drop the `pl-` prefix and ensure that CXX or CC envrionment
      variables are what they should be.
-4. Update the `pkg.url` and `pkg.sha1sum` in the [puppet-runtime
-   component](configs/components/puppet-runtime.rb) so that they refer to the
-   output of your puppet-runtime build. You can use a `file://` url with a full
-   path in place of the default url.
+4. Update the `location` and `version` in the [puppet-runtime
+   component json file](configs/components/puppet-runtime.json) as follows:
+   - `location` should be a file URL to your local puppet-runtime output
+     directory, for example: `file:///home/you/puppet-runtime/output`
+   - `version` should be the version of puppet-runtime that you built; You
+     can find this value at the top level of the json metadata file produced by
+     the build in your puppet-runtime output directory.
   - You also may need to change the source URIs for some other components. We
     recognize this is less than ideal at this point, but we wanted to err on
     the side of getting this work out in public rather than having everything

--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-runtime.git","ref":"refs/tags/201806131"}
+{"location":"https://builds.delivery.puppetlabs.net/puppet-runtime/201806131/artifacts","version":"201806131"}

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -1,13 +1,9 @@
 component 'puppet-runtime' do |pkg, settings, platform|
-  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  pkg.version runtime_tag
+  pkg.version settings[:puppet_runtime_version]
 
-  tarball_name = "agent-runtime-1.10.x-#{pkg.get_version}.#{platform.name}.tar.gz"
-
-  pkg.sha1sum "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}.sha1"
-  pkg.url "http://builds.puppetlabs.lan/puppet-runtime/#{pkg.get_version}/artifacts/#{tarball_name}"
+  tarball_name = "#{settings[:puppet_runtime_basename]}.tar.gz"
+  pkg.url File.join(settings[:puppet_runtime_location], tarball_name)
+  pkg.sha1sum File.join(settings[:puppet_runtime_location], "#{tarball_name}.sha1")
 
   # The contents of the runtime replace the following:
   pkg.replaces 'pe-augeas'

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -1,13 +1,18 @@
 project "puppet-agent" do |proj|
+  platform = proj.get_platform
+
   # puppet-agent inherits most build settings from puppetlabs/puppet-runtime:
   # - Modifications to global settings like flags and target directories should be made in puppet-runtime.
   # - Settings included in this file should apply only to local components in this repository.
-  runtime_details = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', 'components/puppet-runtime.json')))
-  runtime_tag = runtime_details['ref'][/refs\/tags\/(.*)/, 1]
-  raise "Unable to determine a tag for puppet-runtime (given #{runtime_details['ref']})" unless runtime_tag
-  proj.inherit_settings 'agent-runtime-1.10.x', runtime_details['url'], runtime_tag
+  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
 
-  platform = proj.get_platform
+  settings[:puppet_runtime_version] = runtime_details['version']
+  settings[:puppet_runtime_location] = runtime_details['location']
+  settings[:puppet_runtime_basename] = "agent-runtime-1.10.x-#{runtime_details['version']}.#{platform.name}"
+
+  settings_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.settings.yaml")
+  sha1sum_uri = "#{settings_uri}.sha1"
+  proj.inherit_yaml_settings(settings_uri, sha1sum_uri)
 
   # (PA-678) pe-r10k versions prior to 2.5.0.0 ship gettext gems.
   # Since we also ship those gems as part of puppet-agent


### PR DESCRIPTION
Replaces the git ref and url values in puppet-runtime.json with version
and location values instead. This obviates the need to push, tag, and
ship runtime revisions before using them to build an agent; The README
has been updated with instructions on using a local puppet-runtime
output directory as a tarball source instead of Puppet's internal build
sources.