### PR TITLE
(maint) Correct runtime path settings for facter gems

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -1,4 +1,8 @@
 component 'puppet-runtime' do |pkg, settings, platform|
+  unless settings[:puppet_runtime_version] && settings[:puppet_runtime_location] && settings[:puppet_runtime_basename]
+    raise "Expected to find :puppet_runtime_version, :puppet_runtime_location, and :puppet_runtime_basename settings; Please set these in your project file before including puppet-runtime as a component."
+  end
+
   pkg.version settings[:puppet_runtime_version]
 
   tarball_name = "#{settings[:puppet_runtime_basename]}.tar.gz"

--- a/configs/projects/facter-gem.rb
+++ b/configs/projects/facter-gem.rb
@@ -2,6 +2,12 @@ require 'json'
 require 'octokit'
 
 project "facter-gem" do |proj|
+  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
+
+  settings[:puppet_runtime_version] = runtime_details['version']
+  settings[:puppet_runtime_location] = runtime_details['location']
+  settings[:puppet_runtime_basename] = "agent-runtime-5.5.x-#{runtime_details['version']}.#{platform.name}"
+
   platform = proj.get_platform
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag
   # note that we ignore the actual value of release_from_git other than to check

--- a/configs/projects/facter-source-gem.rb
+++ b/configs/projects/facter-source-gem.rb
@@ -2,6 +2,12 @@ require 'json'
 require 'octokit'
 
 project "facter-source-gem" do |proj|
+  runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
+
+  settings[:puppet_runtime_version] = runtime_details['version']
+  settings[:puppet_runtime_location] = runtime_details['location']
+  settings[:puppet_runtime_basename] = "agent-runtime-5.5.x-#{runtime_details['version']}.#{platform.name}"
+
   platform = proj.get_platform
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag
   # note that we ignore the actual value of release_from_git other than to check


### PR DESCRIPTION
The puppet-runtime component was changed to expect details about the
puppet-runtime version and location to be recorded as settings in the
project file, but the facter gem projects weren't updated to do the same
-- this corrects the settings and adds a specific error message in the
runtime component for cases where they haven't been set.