### PR TITLE
(packaging) Bump cpp-hocon to 0.1.7

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.5"}
+{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.1.7"}


### PR DESCRIPTION
Incorporates fixes to substitution from 0.1.7.