### PR TITLE
(packaging) Explicitly set apt & yum repo names

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -132,6 +132,8 @@ osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'
 vanagon_project: TRUE
 repo_name: 'puppet5'
+apt_repo_name: 'puppet5'
+yum_repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 repo_link_target: 'puppet'
 build_tar: FALSE


### PR DESCRIPTION
Other packaging tooling can't determine these automatically yet