### PR TITLE
(maint) Update facter to 290783ce6688178bf44177c5d7b2fe272230649c

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"2aa2d1cd6487f73fb8e311cf027dcf30c2166e28"}
+{"url":"git://github.com/puppetlabs/facter.git","ref":"290783ce6688178bf44177c5d7b2fe272230649c"}


### PR DESCRIPTION
Merge order in CI went a little south, and this promotion failed -- the SHA is just the current head of facter#master, which merged up successfully today.