### PR TITLE
(maint) Revert dmg package path updates

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -15,5 +15,5 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/osx-deps pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1012-x86_64"
-  plat.output_dir File.join("mac", "10.12", "puppet5", "x86_64")
+  plat.output_dir File.join("apple", "10.12", "puppet5", "x86_64")
 end

--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -15,5 +15,5 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with '/usr/local/bin/osx-deps pkg-config'
   plat.install_build_dependencies_with "/usr/local/bin/osx-deps "
   plat.vmpooler_template "osx-1012-x86_64"
-  plat.output_dir File.join("mac", "10.13", "puppet5", "x86_64")
+  plat.output_dir File.join("apple", "10.13", "puppet5", "x86_64")
 end


### PR DESCRIPTION
Other tooling is not ready for a rename of 'apple' to 'mac'