### PR TITLE
(maint) Update internal test forge URI

### DIFF
--- a/acceptance/.beaker.yml
+++ b/acceptance/.beaker.yml
@@ -7,7 +7,7 @@ xml:                         true
 timesync:                    false
 repo_proxy:                  true
 add_el_extras:               false
-forge_host:                  forge-aio01-petest.puppetlabs.com
+forge_host:                  api-forge-aio02-petest.puppet.com
 'master-start-curl-retries': 30
 log_level:                   debug
 preserve_hosts:              onfail


### PR DESCRIPTION
`forge-aio01-petest.puppetlabs.com` has been redirected to `api-forge-aio02-petest.puppet.com`. This update seems to fix some 502 errors we've been seeing in the 5.5.x pipelines. There's an ad-hoc run of this branch [here](https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/200/) (with unrelated transient error on cisco).