### PR TITLE
(PA-1865) Add Fedora 28 to build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,8 +17,8 @@ foss_platforms:
   - el-7-ppc64le
   - el-7-aarch64
   - eos-4-i386
-  - fedora-f26-x86_64
-  - fedora-f27-x86_64
+  - fedora-26-x86_64
+  - fedora-27-x86_64
   - osx-10.12-x86_64
   - osx-10.13-x86_64
   - sles-11-i386

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -19,6 +19,7 @@ foss_platforms:
   - eos-4-i386
   - fedora-26-x86_64
   - fedora-27-x86_64
+  - fedora-28-x86_64
   - osx-10.12-x86_64
   - osx-10.13-x86_64
   - sles-11-i386
@@ -90,6 +91,8 @@ platform_repos:
     repo_location: repos/fedora/26/**/x86_64
   - name: fedora-27-x86_64
     repo_location: repos/fedora/27/**/x86_64
+  - name: fedora-28-x86_64
+    repo_location: repos/fedora/28/**/x86_64
   - name: debian-8-i386
     repo_location: repos/apt/jessie
   - name: debian-8-amd64


### PR DESCRIPTION
Adds Fedora 28 to build_defaults.yaml -- Also corrects Fedora platform names still using an `f` prefix there (pretty sure this just wasn't caught during the `f` removal efforts previously).