### PR TITLE
(PA-2108) Remove AIX 7.1 repos from build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -34,7 +34,6 @@ foss_platforms:
   - windows-2012-x64
 pe_platforms:
   - aix-6.1-power
-  - aix-7.1-power
   - el-6-s390x
   - el-7-s390x
   - redhatfips-7-x86_64
@@ -47,8 +46,6 @@ pe_platforms:
 platform_repos:
   - name: aix-6.1-power
     repo_location: repos/aix/6.1/**/ppc
-  - name: aix-7.1-power
-    repo_location: repos/aix/7.1/**/ppc
   - name: cumulus-amd64
     repo_location: repos/apt/cumulus
   - name: eos-4-i386


### PR DESCRIPTION
AIX 7.1 and 7.2 hosts will use AIX 6.1 packages in puppet 6