### PR TITLE
(maint) Build facter jar on Ubuntu 18.04

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -61,7 +61,7 @@ component "facter" do |pkg, settings, platform|
   when /(debian-8|ubuntu-14)/
     pkg.build_requires 'openjdk-7-jdk'
     java_home = "/usr/lib/jvm/java-7-openjdk-#{platform.architecture}"
-  when /(debian-9|ubuntu-(15|16))/
+  when /(debian-9|ubuntu-(15|16|18))/
     pkg.build_requires 'openjdk-8-jdk'
     java_home = "/usr/lib/jvm/java-8-openjdk-#{platform.architecture}"
   when /sles-12/


### PR DESCRIPTION
This commits updates facter's java requirement so puppet-agent will
provide the facter jar needed to support running puppetserver on
Ubuntu 18.04.