### PR TITLE
(maint) Bump to packaging 0.99.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.11')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
 gem 'artifactory'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This commit bumps the packaging gem dependency to be more specific. Without
this, older versions of packaging get pulled in, which don't include necessary
updates for shipping.