### PR TITLE
(PA-2112) Rewrite permissions custom actions in VBScript

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -13,14 +13,14 @@ platform "windows-2012r2-x64" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"
   # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
   # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
   # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
@@ -29,7 +29,7 @@ platform "windows-2012r2-x64" do |plat|
   # Note that the unruly \'s in the following string escape the following sequence to literal chars: "\" and then \""
   plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -13,7 +13,7 @@ platform "windows-2012r2-x64" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -13,14 +13,14 @@ platform "windows-2012r2-x86" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\""
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"
   # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
   # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
   # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
@@ -29,7 +29,7 @@ platform "windows-2012r2-x86" do |plat|
   # Note that the unruly /'s in the following string escape the following sequence to literal chars: "\" and then \""
   plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
 
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y"
+  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -13,7 +13,7 @@ platform "windows-2012r2-x86" do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe update -y chocolatey --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -257,10 +257,14 @@ Sub ExecuteCommand (Command)
   End If
 End Sub
 
-Sub ResetPermissionsIfExists (Path)
+Sub ResetPermissionsIfExists (Path, GrantAdmins)
 
   If (fso.FolderExists(Path)) Then
     Log "Modifying found directory : " & Path, False
+
+    If GrantAdmins = True Then
+      ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
+    End If
 
     ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /reset /T /C 2>&1"
   Else
@@ -291,20 +295,17 @@ If (fso.FolderExists(dataDirectory)) Then
   ' while it is possible to call takeown directly, we avoid a WshShell stream problem with stderr this way
   ' https://machine-cycle.blogspot.com/2008/06/pipe-dreams-or-vbscript-spawned.html
   ExecuteCommand comspec & " /C " & takeown & " /F """ & dataDirectory & "\*"" /R /A /D N 2>&1"
-
-  ' Due to PUP-6729, now that we can modify the DACL
-  ' ensure admins and system have full control
-  ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
-
-  ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /reset /T /C 2>&1"
 End If
 
 ' Leave root APPDATADIR as-is
 
-ResetPermissionsIfExists appDataPath & "\PuppetLabs\code"
-ResetPermissionsIfExists appDataPath & "\PuppetLabs\facter"
-ResetPermissionsIfExists appDataPath & "\PuppetLabs\pxp-agent"
-ResetPermissionsIfExists appDataPath & "\PuppetLabs\mcollective"
+' Due to PUP-6729, now that we can modify the DACL
+' ensure admins and system have full control
+ResetPermissionsIfExists dataDirectory, True
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\code", False
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\facter", False
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\pxp-agent", False
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\mcollective", False
       ]]>
     </CustomAction>
   </Fragment>

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -305,21 +305,16 @@ If (fso.FolderExists(facterDirectory)) Then
 
   ExecuteCommand comspec & " /C " & icacls & "  """ & facterDirectory & "\*"" /reset /T /C 2>&1"
 End If
+
+Dim pxpAgentDirectory : pxpAgentDirectory = appDataPath & "\PuppetLabs\pxp-agent"
+
+If (fso.FolderExists(pxpAgentDirectory)) Then
+  Log "Modifying found directory : " & pxpAgentDirectory, False
+
+  ExecuteCommand comspec & " /C " & icacls & "  """ & pxpAgentDirectory & "\*"" /reset /T /C 2>&1"
+End If
       ]]>
     </CustomAction>
-
-    <CustomAction
-        Id="SetResetPxpAgentPermissions"
-        Property="ResetPxpAgentPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\pxp-agent&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\pxp-agent\*&quot; /reset /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="ResetPxpAgentPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
 
     <CustomAction
         Id="SetResetPuppetPermissions"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -242,19 +242,23 @@ Sub ExecuteCommand (Command)
 
   Log "Executing Command : " & Command, False
 
-  ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/2f38xsxe%28v%3dvs.84%29
-  ' Exec rather than Run to be able to capture stdout
-  Dim wshScriptExec : Set wshScriptExec = wshShell.Exec(Command)
+  Dim tempFilePath : tempFilePath = fso.GetTempName()
+  ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/d5fk67ky%28v%3dvs.84%29
+  ' intWindows Style - 0 - Hides the window and activates another window.
+  ' bWaitOnReturn - True - waits for program termination
+  Dim exitCode : exitCode = wshShell.Run(Command & " 2>&1 > """ & tempFilePath & """", 0, True)
 
-  Do While Not wshScriptExec.StdOut.AtEndOfStream
-    Log wshScriptExec.StdOut.ReadLine(), False
+  Dim outFile : Set outFile = fso.OpenTextFile(tempFilePath)
+  Do While Not outFile.AtEndOfStream
+    Log outFile.ReadLine(), False
   Loop
+  outFile.Close()
 
-  Log wshScriptExec.StdOut.ReadAll(), False
-
-  If wshScriptExec.ExitCode <> 0 Then
-    Log "Execution Failed With Code: " & wshScriptExec.ExitCode, True
+  If exitCode <> 0 Then
+    Log "Execution Failed With Code: " & exitCode, True
   End If
+
+  fso.DeleteFile(tempFilePath)
 End Sub
 
 Sub ResetPermissionsIfExists (Path, GrantAdmins)
@@ -263,10 +267,10 @@ Sub ResetPermissionsIfExists (Path, GrantAdmins)
     Log "Modifying found directory : " & Path, False
 
     If GrantAdmins = True Then
-      ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
+      ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C"
     End If
 
-    ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /reset /T /C 2>&1"
+    ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /reset /T /C"
   Else
     Log "Nothing to reset, directory not found : " & Path, False
   End If
@@ -294,7 +298,7 @@ If (fso.FolderExists(dataDirectory)) Then
 
   ' while it is possible to call takeown directly, we avoid a WshShell stream problem with stderr this way
   ' https://machine-cycle.blogspot.com/2008/06/pipe-dreams-or-vbscript-spawned.html
-  ExecuteCommand comspec & " /C " & takeown & " /F """ & dataDirectory & "\*"" /R /A /D N 2>&1"
+  ExecuteCommand comspec & " /C " & takeown & " /F """ & dataDirectory & "\*"" /R /A /D N"
 End If
 
 ' Leave root APPDATADIR as-is

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -297,21 +297,16 @@ If (fso.FolderExists(codeDirectory)) Then
 
   ExecuteCommand comspec & " /C " & icacls & "  """ & codeDirectory & "\*"" /reset /T /C 2>&1"
 End If
+
+Dim facterDirectory : facterDirectory = appDataPath & "\PuppetLabs\facter"
+
+If (fso.FolderExists(facterDirectory)) Then
+  Log "Modifying found directory : " & facterDirectory, False
+
+  ExecuteCommand comspec & " /C " & icacls & "  """ & facterDirectory & "\*"" /reset /T /C 2>&1"
+End If
       ]]>
     </CustomAction>
-
-    <CustomAction
-        Id="SetResetFacterPermissions"
-        Property="ResetFacterPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\facter&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\facter\*&quot; /reset /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="ResetFacterPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
 
     <CustomAction
         Id="SetResetPxpAgentPermissions"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -197,7 +197,7 @@ End If
 
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->
     <CustomAction
-      Id="TakeownPuppetPermissions"
+      Id="ResetDataPermissions"
       Script="vbscript"
       Execute="deferred"
       Return="check"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -314,20 +314,15 @@ If (fso.FolderExists(pxpAgentDirectory)) Then
 
   ExecuteCommand comspec & " /C " & icacls & "  """ & pxpAgentDirectory & "\*"" /reset /T /C 2>&1"
 End If
+
+Dim mcoDirectory : mcoDirectory = appDataPath & "\PuppetLabs\mcollective"
+
+If (fso.FolderExists(mcoDirectory)) Then
+  Log "Modifying found directory : " & mcoDirectory
+
+  ExecuteCommand comspec & " /C " & icacls & "  """ & mcoDirectory & "\*"" /reset /T /C 2>&1"
+End If
       ]]>
     </CustomAction>
-
-    <CustomAction
-        Id="SetResetMcoPermissions"
-        Property="ResetMcoPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\mcollective&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\mcollective\*&quot; /reset /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="ResetMcoPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
   </Fragment>
 </Wix>

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -286,6 +286,7 @@ If (fso.FolderExists(dataDirectory)) Then
   ' ensure admins and system have full control
   ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
 
+  ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /reset /T /C 2>&1"
 End If
 
 ' Leave root APPDATADIR as-is
@@ -315,19 +316,6 @@ If (fso.FolderExists(pxpAgentDirectory)) Then
 End If
       ]]>
     </CustomAction>
-
-    <CustomAction
-        Id="SetResetPuppetPermissions"
-        Property="ResetPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /reset /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="ResetPuppetPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
 
     <CustomAction
         Id="SetResetMcoPermissions"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -208,6 +208,8 @@ On Error Resume Next
 ' Globals
 ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/aew9yb99%28v%3dvs.84%29
 Dim wshShell : Set wshShell = CreateObject("WScript.Shell")
+' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/z9ty6h50%28v%3dvs.84%29
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 ' https://docs.microsoft.com/en-us/windows/desktop/msi/session-message
 Const msiMessageTypeError   = &H01000000
 Const msiMessageTypeWarning = &H02000000
@@ -255,6 +257,17 @@ Sub ExecuteCommand (Command)
   End If
 End Sub
 
+Sub ResetPermissionsIfExists (Path)
+
+  If (fso.FolderExists(Path)) Then
+    Log "Modifying found directory : " & Path, False
+
+    ExecuteCommand comspec & " /C " & icacls & "  """ & Path & "\*"" /reset /T /C 2>&1"
+  Else
+    Log "Nothing to reset, directory not found : " & Path, False
+  End If
+End Sub
+
 
 ' Main Code Starts Here
 Dim comspec : comspec = wshShell.ExpandEnvironmentStrings("%comspec%")
@@ -269,9 +282,6 @@ Dim systemPath : systemPath = (shellApplication.Namespace(System)).Self.Path
 Dim takeown : takeown = systemPath & "\takeown.exe"
 Dim icacls : icacls = systemPath & "\icacls.exe"
 Dim appDataPath : appDataPath = (shellApplication.Namespace(CommonAppData)).Self.Path
-
-' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/z9ty6h50%28v%3dvs.84%29
-Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
 
 Dim dataDirectory : dataDirectory = appDataPath & "\PuppetLabs\puppet"
 
@@ -291,37 +301,10 @@ End If
 
 ' Leave root APPDATADIR as-is
 
-Dim codeDirectory : codeDirectory = appDataPath & "\PuppetLabs\code"
-
-If (fso.FolderExists(codeDirectory)) Then
-  Log "Modifying found directory : " & codeDirectory, False
-
-  ExecuteCommand comspec & " /C " & icacls & "  """ & codeDirectory & "\*"" /reset /T /C 2>&1"
-End If
-
-Dim facterDirectory : facterDirectory = appDataPath & "\PuppetLabs\facter"
-
-If (fso.FolderExists(facterDirectory)) Then
-  Log "Modifying found directory : " & facterDirectory, False
-
-  ExecuteCommand comspec & " /C " & icacls & "  """ & facterDirectory & "\*"" /reset /T /C 2>&1"
-End If
-
-Dim pxpAgentDirectory : pxpAgentDirectory = appDataPath & "\PuppetLabs\pxp-agent"
-
-If (fso.FolderExists(pxpAgentDirectory)) Then
-  Log "Modifying found directory : " & pxpAgentDirectory, False
-
-  ExecuteCommand comspec & " /C " & icacls & "  """ & pxpAgentDirectory & "\*"" /reset /T /C 2>&1"
-End If
-
-Dim mcoDirectory : mcoDirectory = appDataPath & "\PuppetLabs\mcollective"
-
-If (fso.FolderExists(mcoDirectory)) Then
-  Log "Modifying found directory : " & mcoDirectory
-
-  ExecuteCommand comspec & " /C " & icacls & "  """ & mcoDirectory & "\*"" /reset /T /C 2>&1"
-End If
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\code"
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\facter"
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\pxp-agent"
+ResetPermissionsIfExists appDataPath & "\PuppetLabs\mcollective"
       ]]>
     </CustomAction>
   </Fragment>

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -267,6 +267,7 @@ Const System = &H25&
 Dim shellApplication : Set shellApplication = CreateObject("Shell.Application")
 Dim systemPath : systemPath = (shellApplication.Namespace(System)).Self.Path
 Dim takeown : takeown = systemPath & "\takeown.exe"
+Dim icacls : icacls = systemPath & "\icacls.exe"
 Dim appDataPath : appDataPath = (shellApplication.Namespace(CommonAppData)).Self.Path
 
 ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/z9ty6h50%28v%3dvs.84%29
@@ -280,23 +281,14 @@ If (fso.FolderExists(dataDirectory)) Then
   ' while it is possible to call takeown directly, we avoid a WshShell stream problem with stderr this way
   ' https://machine-cycle.blogspot.com/2008/06/pipe-dreams-or-vbscript-spawned.html
   ExecuteCommand comspec & " /C " & takeown & " /F """ & dataDirectory & "\*"" /R /A /D N 2>&1"
+
+  ' Due to PUP-6729, now that we can modify the DACL
+  ' ensure admins and system have full control
+  ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
+
 End If
       ]]>
     </CustomAction>
-
-    <!-- Due to PUP-6729, now that we can modify the DACL, ensure admins and system have full control -->
-    <CustomAction
-        Id="SetGrantPuppetPermissions"
-        Property="GrantPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /grant &quot;*S-1-5-32-544:(F)&quot; &quot;*S-1-5-18:(F)&quot; /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="GrantPuppetPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
 
     <!-- Leave root APPDATADIR as-is -->
     <CustomAction

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -287,22 +287,18 @@ If (fso.FolderExists(dataDirectory)) Then
   ExecuteCommand comspec & " /C " & icacls & "  """ & dataDirectory & "\*"" /grant ""*S-1-5-32-544:(F)"" ""*S-1-5-18:(F)"" /T /C 2>&1"
 
 End If
+
+' Leave root APPDATADIR as-is
+
+Dim codeDirectory : codeDirectory = appDataPath & "\PuppetLabs\code"
+
+If (fso.FolderExists(codeDirectory)) Then
+  Log "Modifying found directory : " & codeDirectory, False
+
+  ExecuteCommand comspec & " /C " & icacls & "  """ & codeDirectory & "\*"" /reset /T /C 2>&1"
+End If
       ]]>
     </CustomAction>
-
-    <!-- Leave root APPDATADIR as-is -->
-    <CustomAction
-        Id="SetResetCodePermissions"
-        Property="ResetCodePermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\code&quot; &quot;[%WINDIR]\System32\icacls.exe&quot; &quot;[%ProgramData]\PuppetLabs\code\*&quot; /reset /T /C"
-        Execute="immediate"/>
-    <CustomAction
-        Id="ResetCodePermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
 
     <CustomAction
         Id="SetResetFacterPermissions"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -197,17 +197,92 @@ End If
 
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->
     <CustomAction
-        Id="SetTakeownPuppetPermissions"
-        Property="TakeownPuppetPermissions"
-        Value="&quot;[%WINDIR]\System32\cmd.exe&quot; /c IF EXIST &quot;[%ProgramData]\PuppetLabs\puppet&quot; &quot;[%WINDIR]\System32\takeown.exe&quot; /F &quot;[%ProgramData]\PuppetLabs\puppet\*&quot; /R /A /D N"
-        Execute="immediate"/>
-    <CustomAction
-        Id="TakeownPuppetPermissions"
-        BinaryKey="WixCA"
-        DllEntry="<%= @platform.architecture == "x64" ? "WixQuietExec64" : "WixQuietExec" %>"
-        Execute="deferred"
-        Return="check"
-        Impersonate="no"/>
+      Id="TakeownPuppetPermissions"
+      Script="vbscript"
+      Execute="deferred"
+      Return="check"
+      Impersonate="no">
+      <![CDATA[
+On Error Resume Next
+
+' Globals
+' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/aew9yb99%28v%3dvs.84%29
+Dim wshShell : Set wshShell = CreateObject("WScript.Shell")
+' https://docs.microsoft.com/en-us/windows/desktop/msi/session-message
+Const msiMessageTypeError   = &H01000000
+Const msiMessageTypeWarning = &H02000000
+Const msiMessageTypeInfo    = &H04000000
+
+Sub Log (Message, IsError)
+
+  ' Logs through cscript
+  If IsObject(WScript) Then
+    If IsObject(WScript.StdErr) And IsError = True Then
+      WScript.StdErr.WriteLine(Message)
+    ElseIf IsObject(WScript.StdOut) Then
+      WScript.StdOut.WriteLine(Message)
+    End If
+  End If
+
+  ' Logs through MSI
+  If IsObject(Session) Then
+    ' https://docs.microsoft.com/en-us/windows/desktop/msi/installer-createrecord
+    Dim logRecord : Set logRecord = Installer.CreateRecord(1) ' 1 entry
+    logRecord.StringData(1) = Message ' Set Index 1
+    Dim kind : kind = msiMessageTypeInfo
+    If IsError = True Then kind = msiMessageTypeError
+    Session.Message kind, logRecord
+  End If
+End Sub
+
+' Executes command, sending its stdout / stderr to the WScript host
+Sub ExecuteCommand (Command)
+
+  Log "Executing Command : " & Command, False
+
+  ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/2f38xsxe%28v%3dvs.84%29
+  ' Exec rather than Run to be able to capture stdout
+  Dim wshScriptExec : Set wshScriptExec = wshShell.Exec(Command)
+
+  Do While Not wshScriptExec.StdOut.AtEndOfStream
+    Log wshScriptExec.StdOut.ReadLine(), False
+  Loop
+
+  Log wshScriptExec.StdOut.ReadAll(), False
+
+  If wshScriptExec.ExitCode <> 0 Then
+    Log "Execution Failed With Code: " & wshScriptExec.ExitCode, True
+  End If
+End Sub
+
+
+' Main Code Starts Here
+Dim comspec : comspec = wshShell.ExpandEnvironmentStrings("%comspec%")
+
+' https://docs.microsoft.com/en-us/windows/desktop/api/Shldisp/ne-shldisp-shellspecialfolderconstants
+Const CommonAppData = &H23&  ' second & means long integer '
+Const System = &H25&
+
+' https://docs.microsoft.com/en-us/windows/desktop/shell/shell
+Dim shellApplication : Set shellApplication = CreateObject("Shell.Application")
+Dim systemPath : systemPath = (shellApplication.Namespace(System)).Self.Path
+Dim takeown : takeown = systemPath & "\takeown.exe"
+Dim appDataPath : appDataPath = (shellApplication.Namespace(CommonAppData)).Self.Path
+
+' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/z9ty6h50%28v%3dvs.84%29
+Dim fso : Set fso = CreateObject("Scripting.FileSystemObject")
+
+Dim dataDirectory : dataDirectory = appDataPath & "\PuppetLabs\puppet"
+
+If (fso.FolderExists(dataDirectory)) Then
+  Log "Modifying found directory : " & dataDirectory, False
+
+  ' while it is possible to call takeown directly, we avoid a WshShell stream problem with stderr this way
+  ' https://machine-cycle.blogspot.com/2008/06/pipe-dreams-or-vbscript-spawned.html
+  ExecuteCommand comspec & " /C " & takeown & " /F """ & dataDirectory & "\*"" /R /A /D N 2>&1"
+End If
+      ]]>
+    </CustomAction>
 
     <!-- Due to PUP-6729, now that we can modify the DACL, ensure admins and system have full control -->
     <CustomAction

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -120,7 +120,7 @@
 
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
       <!-- Also resets permissions for children beneath each appdir -->
-      <Custom Action='TakeownPuppetPermissions' After='InstallFiles'>
+      <Custom Action='ResetDataPermissions' After='InstallFiles'>
           NOT REMOVE
       </Custom>
 

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -123,13 +123,7 @@
           NOT REMOVE
       </Custom>
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetFacterPermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='ResetFacterPermissions' After='SetResetFacterPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='SetResetPxpAgentPermissions' After='ResetFacterPermissions'>
+      <Custom Action='SetResetPxpAgentPermissions' After='TakeownPuppetPermissions'>
           NOT REMOVE
       </Custom>
       <Custom Action='ResetPxpAgentPermissions' After='SetResetPxpAgentPermissions'>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -119,10 +119,7 @@
       </Custom>
 
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
-      <Custom Action='SetTakeownPuppetPermissions' After='InstallFiles'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='TakeownPuppetPermissions' After='SetTakeownPuppetPermissions'>
+      <Custom Action='TakeownPuppetPermissions' After='InstallFiles'>
           NOT REMOVE
       </Custom>
       <Custom Action='SetGrantPuppetPermissions' After='TakeownPuppetPermissions'>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -123,13 +123,7 @@
           NOT REMOVE
       </Custom>
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetPuppetPermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='ResetPuppetPermissions' After='SetResetPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='SetResetMcoPermissions' After='ResetPuppetPermissions'>
+      <Custom Action='SetResetMcoPermissions' After='TakeownPuppetPermissions'>
           NOT REMOVE
       </Custom>
       <Custom Action='ResetMcoPermissions' After='SetResetMcoPermissions'>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -122,15 +122,8 @@
       <Custom Action='TakeownPuppetPermissions' After='InstallFiles'>
           NOT REMOVE
       </Custom>
-      <Custom Action='SetGrantPuppetPermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='GrantPuppetPermissions' After='SetGrantPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetCodePermissions' After='GrantPuppetPermissions'>
+      <Custom Action='SetResetCodePermissions' After='TakeownPuppetPermissions'>
           NOT REMOVE
       </Custom>
       <Custom Action='ResetCodePermissions' After='SetResetCodePermissions'>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -119,14 +119,8 @@
       </Custom>
 
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
+      <!-- Also resets permissions for children beneath each appdir -->
       <Custom Action='TakeownPuppetPermissions' After='InstallFiles'>
-          NOT REMOVE
-      </Custom>
-      <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetMcoPermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='ResetMcoPermissions' After='SetResetMcoPermissions'>
           NOT REMOVE
       </Custom>
 

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -123,13 +123,7 @@
           NOT REMOVE
       </Custom>
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetCodePermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='ResetCodePermissions' After='SetResetCodePermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='SetResetFacterPermissions' After='ResetCodePermissions'>
+      <Custom Action='SetResetFacterPermissions' After='TakeownPuppetPermissions'>
           NOT REMOVE
       </Custom>
       <Custom Action='ResetFacterPermissions' After='SetResetFacterPermissions'>

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -123,13 +123,7 @@
           NOT REMOVE
       </Custom>
       <!-- Reset permissions for children beneath each appdir -->
-      <Custom Action='SetResetPxpAgentPermissions' After='TakeownPuppetPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='ResetPxpAgentPermissions' After='SetResetPxpAgentPermissions'>
-          NOT REMOVE
-      </Custom>
-      <Custom Action='SetResetPuppetPermissions' After='ResetPxpAgentPermissions'>
+      <Custom Action='SetResetPuppetPermissions' After='TakeownPuppetPermissions'>
           NOT REMOVE
       </Custom>
       <Custom Action='ResetPuppetPermissions' After='SetResetPuppetPermissions'>


### PR DESCRIPTION
 - Merge the 7 individual custom actions responsible for setting
   permissions, merging them into a single custom action, now called
   `ResetDataPermissions`, including:

   * takeown against %ProgramData%\PuppetLabs\puppet
   * icacls against %ProgramData%\PuppetLabs\puppet to set ownership to Administrators / SYSTEM
   * icacls reset against %ProgramData%\PuppetLabs\puppet
   * icacls reset against %ProgramData%\PuppetLabs\code
   * icacls reset against %ProgramData%\PuppetLabs\facter
   * icacls reset against %ProgramData%\PuppetLabs\pxp-agent
   * icacls reset against %ProgramData%\PuppetLabs\mcollective

 - The existing WixQuietExec64 / WixQuietExec Custom Actions are replaced
   with a vbscript custom action.

   Note a few important changes:

   * Shell.Application is used to resolve the systems constants for
     CommonAppData and System folders, rather than using environment
     variables.
   * cmd.exe is resolved by using %comspec%
   * stdout and stderr are merged so that the WshShell object can
     properly capture / read StdOut attached to the WshShell.Exec call

- This is a precursor to the work in PA-2113, which will prevent running commands unnecessarily.