### PR TITLE
Add Release Lead helpers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require 'packaging'
 
+load './ext/release-lead.rake'
+
 Pkg::Util::RakeUtils.load_packaging_tasks
 
 namespace :package do

--- a/ext/release-lead.rake
+++ b/ext/release-lead.rake
@@ -1,0 +1,118 @@
+require 'json'
+require 'optparse'
+
+namespace :release_lead do
+  desc "Find platforms added and removed between releases"
+  task :platform_diff, [:from, :to] do |t, args|
+    abort ('`from` argument is required') unless args.from
+    abort ('`to` argument is required') unless args.to
+    puts `git diff --summary #{args.from}..#{args.to} configs/platforms`.
+        gsub('configs/platforms/', '').gsub(/mode \d+ /, '').
+        gsub('delete', 'Retired').gsub('create', 'Added').
+        gsub('rename', 'Renamed')
+  end
+
+  # Calculate name of repository from the .git URL.
+  def url_to_component_name(url)
+    url.split('/').last.split('.').first
+  end
+
+  # Calculate name of repository from the name of the component's .json file.
+  def json_name_to_component_name(json_filename)
+    json_filename.split('/').last.split('.').first
+  end
+
+  # Input a git repository, a SHA or tag to check out, and a place where it can be cloned.
+  # Output the resulting `git describe` for that reference.
+  def git_describe_repo(name, url, sha_or_tag, where_to_clone, show_extra_commits)
+    Dir.chdir(where_to_clone) do
+      puts "Cloning #{name}..."
+      `git clone #{url} 2> /dev/null`
+      # `git clone --local '../../#{name}' 2> /dev/null`
+      # 0 for successful clone, 128 for already exists.
+      unless [0, 128].include? $?.exitstatus
+        next 'Could not find remote repository'
+      end
+      Dir.chdir(name) do
+        `git fetch 2> /dev/null`
+        `git checkout #{sha_or_tag} 2> /dev/null`
+        unless $?.exitstatus == 0
+          puts "Could not find reference #{sha_or_tag}"
+          exit
+        end
+        `git describe --tags`.strip +
+            if show_extra_commits
+              lines = `git log \`git describe --tags --abbrev=0\`..HEAD --oneline`.split("\n")
+              lines.map do |value|
+                if value.include?('[no-promote]')
+                  # Output these in red.
+                  "\e[31m#{value}\e[0m"
+                else
+                  value
+                end
+              end.join("\n  ")
+            else
+              ''
+            end
+      end
+    end
+  end
+
+  def check_components(args, show_extra_commits = false)
+    result = {}
+    abort('Error: puppet_agent_branch argument is required') unless args.puppet_agent_branch
+
+    where_to_clone = File.join(File.dirname(__FILE__), 'pkg')
+    Dir.mkdir(where_to_clone) unless Dir.exists?(where_to_clone)
+
+    # Let's ensure puppet-agent is on the right branch.
+    `git fetch`
+    begin
+      `git checkout #{args.puppet_agent_branch} 2> /dev/null`
+
+      Dir.glob("./configs/components/*.json").each do |component|
+        json = JSON.parse(File.read(component))
+        url = json['url']
+        if url.nil?
+          name = json_name_to_component_name(component)
+          result[name] = 'No URL provided'
+          next
+        end
+        name = url_to_component_name(url)
+        ref = json['ref']
+        sha_or_tag = ref =~ /^refs\/tags/ ? ref.gsub('refs/tags/', '') : ref
+        result[name] = git_describe_repo(name, url, sha_or_tag, where_to_clone, show_extra_commits)
+      end
+
+      max_length = result.keys.map(&:length).max
+      puts "\n** Latest versions in #{args.puppet_agent_branch}:\n"
+      result.map do |name, value|
+        puts name.ljust(max_length + 1) + ': ' + value
+      end
+    ensure
+      `git checkout @{-1} 2> /dev/null`
+    end
+  end
+
+  # This task performs the following for each repository:
+  # - Looks up each component
+  # - Clones the component into the 'pkg' directory, if not done already
+  # - Checks out the git reference that's in the component's .json.
+  # - Outputs the `git describe` for that reference.
+  # This is useful for determining tag versions for an upcoming release.
+  desc "Output `git describe` for each component's git branch"
+  task :check_components_diff, [:puppet_agent_branch] do |t, args|
+    check_components(args, true)
+  end
+
+  # This task performs the following for each repository:
+  # - Looks up each component
+  # - Clones the component into the 'pkg' directory, if not done already
+  # - Checks out the git reference that's in the component's .json.
+  # - Outputs the `git describe` for that reference.
+  # This is useful for determining tag versions for an upcoming release.
+  desc "Output `git describe` for each component's git branch"
+  task :check_components, [:puppet_agent_branch] do |t, args|
+    check_components(args, false)
+  end
+end

--- a/ext/smoke/README.md
+++ b/ext/smoke/README.md
@@ -1,0 +1,34 @@
+## Release Validation
+
+These scripts will help with steps leading up to a new puppet-agent
+release.
+
+### Overview
+
+This folder contains scripts to help with two smoke testing stages of
+the release process.
+
+#### Manually smoke test platform components installed from packages
+
+To run these smoke tests, check out 2 redhat-7-x86_64 VMs.
+Then run the `packages/run-smoke-test.sh` script as follows, where
+VM names should not include the domain, as that will be appended in the
+script:
+
+```
+./packages/run-smoke-test.sh <VM> <VM> <agent_version> <server_version> <puppetdb_version>
+
+```
+
+#### Manually smoke test platform components installed from shared respository
+
+These tests will ensure that released packages can run. There are two
+scenarios, one where puppetdb is installed via packages and one where
+puppetdb is installed via module.
+
+To run these smoke tests, check out 4 redhat-7-x86_64 VMs.
+Then run the `repos/run-smoke-test.sh` script as follows:
+
+```
+./repos/run-smoke-test.sh <VM> <VM> <VM> <VM> <agent_version> <server_version> <puppetdb_version>
+```

--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+function on_host() {
+  host="$1"
+  label="$2"
+  cmd="$3"
+  suppress="$4"
+
+  echo ""
+  echo "### DEBUG: Running the following command on the ${label}"
+  echo "  ${cmd}"
+  echo "###"
+
+  if [[ -z "${suppress}" || "${suppress}" == "false" ]]; then
+    ssh -oStrictHostKeyChecking=no root@${host} "${cmd}" 2>/dev/null
+  else
+    ssh -oStrictHostKeyChecking=no root@${host} "${cmd}" 2>/dev/null 1>/dev/null
+  fi
+}
+
+function on_master() {
+  host="$1"
+  cmd="$2"
+  suppress="$3"
+  on_host "${host}" "master" "${cmd}" "${suppress}"
+}
+
+function on_agent() {
+  host="$1"
+  cmd="$2"
+  suppress="$3"
+  on_host "${host}" "agent" "${cmd}" "${suppress}"
+}
+
+function start_puppetdb() {
+  local master_vm="$1"
+  local which_master=`identify_master ${master_vm}`
+
+  echo "STEP: Start PuppetDB and point it to puppetserver"
+  on_master ${master_vm} "puppet resource service puppetdb ensure=running enable=true"
+  local puppetdb_conf="/etc/puppetlabs/puppet/puppetdb.conf"
+  on_master ${master_vm} "echo [main] > ${puppetdb_conf}"
+  on_master ${master_vm} "echo server_urls = https://\`facter fqdn\`:8081 >> ${puppetdb_conf}"
+  echo ""
+  echo ""
+
+  echo "STEP: Adding PuppetDB to storeconfigs and reports settings in puppet.conf"
+  local puppet_conf="/etc/puppetlabs/puppet/puppet.conf"
+  on_master ${master_vm} "echo storeconfigs = true >> ${puppet_conf}"
+  on_master ${master_vm} "echo storeconfigs_backend = puppetdb >> ${puppet_conf}"
+  on_master ${master_vm} "echo reports = store,puppetdb >> ${puppet_conf}"
+  echo ""
+  echo ""
+
+  echo "STEP: Creating route_file with puppetdb terminus for facts"
+  local route_file
+  route_file=`on_master ${master_vm} "puppet master --configprint route_file" | tail -n 1`
+  on_master ${master_vm} "echo --- > ${route_file}"
+  on_master ${master_vm} "echo master: >> ${route_file}"
+  on_master ${master_vm} "echo \"  facts:\" >> ${route_file}"
+  on_master ${master_vm} "echo \"    terminus: puppetdb\" >> ${route_file}"
+  on_master ${master_vm} "echo \"    cache: yaml\" >> ${route_file}"
+  echo ""
+  echo ""
+
+  echo "STEP: Setting ownership on everything"
+  on_master ${master_vm} 'chown -R puppet:puppet `puppet config print confdir`'
+  echo ""
+  echo ""
+
+  echo "STEP: Restart puppetserver and perform a puppet run to ensure that facts and reports are sent to PuppetDB"
+  on_master ${master_vm} "puppet resource service puppetserver ensure=stopped"
+  on_master ${master_vm} "puppet resource service puppetserver ensure=running"
+  set +e
+  on_master ${master_vm} "puppet agent -t"
+  local exit_code="$?"
+  set -e
+  if [[ ! "${exit_code}" = 2 && ! "${exit_code}" = 0 ]]; then
+    echo "Failed to start-up PuppetDB on ${which_master}!"
+    echo "Exiting the script with a failure ..."
+    exit 1
+  fi
+  on_master ${master_vm} "grep 'replace facts' /var/log/puppetlabs/puppetdb/puppetdb.log && echo '### Facts successfully sent to PuppetDB ###'"
+  on_master ${master_vm} "grep 'replace catalog' /var/log/puppetlabs/puppetdb/puppetdb.log && echo '### Reports successfully sent to PuppetDB ###'"
+  echo ""
+  echo ""
+}
+
+
+function install_puppetdb_from_module() {
+  local master_vm="$1"
+  local which_master=`identify_master ${master_vm}`
+
+  echo "STEP: Install PuppetDB from the module on ${which_master}!"
+  on_master ${master_vm} "puppet module install puppetlabs-puppetdb"
+  local site_pp="/etc/puppetlabs/code/environments/production/manifests/site.pp"
+  FILE="node '\`facter fqdn\`' {
+    class { 'puppetdb::globals':
+    version => '${puppetdb_version}'
+    }
+  include puppetdb
+  include puppetdb::master::config
+  }
+  node default {
+    notify { 'hello': message => 'hello world' }
+  }"
+  on_master ${master_vm} "echo \"$FILE\" > ${site_pp}"
+  # puppet agent -t returns an exit code of 2 if changes are successfully applied
+  set +e
+  on_master ${master_vm} "puppet agent -t"
+  set -e
+  exited="$?"
+  if [[ "$exited" -ne 2 && "$exited" -ne 0 ]]; then
+    echo "Failed to install PuppetDB from the module on ${which_master}!"
+    echo "Exiting the script with a failure ..."
+    exit 1
+  fi
+  echo ""
+  echo ""
+
+  start_puppetdb ${master_vm}
+  echo "Finished installing PuppetDB via. the module on ${which_master}!"
+  echo ""
+  echo ""
+}
+
+
+function install_puppetdb_from_package() {
+  local master_vm="$1"
+  # Either "dev" (packages on builds.puppetlabs.lan) or "repo" (packages released).
+  local type="$2"
+  local collection="$3"
+  local which_master=`identify_master ${master_vm}`
+
+  echo "STEP: Install PuppetDB from package on ${which_master}!"
+
+  # FIXME: Parametrize on postgres version?
+  echo "STEP: Set-up postgresql 9.6 to use with PuppetDB"
+  on_master ${master_vm} "rpm --query --quiet pgdg-redhat96-9.6-3.noarch || yum install -y https://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm"
+  on_master ${master_vm} "rpm --query --quiet postgresql96-server || yum install -y postgresql96-server"
+  on_master ${master_vm} "rpm --query --quiet postgresql96-contrib || yum install -y postgresql96-contrib"
+  on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=stopped"
+  on_master ${master_vm} "rm -rf /var/lib/pgsql/9.6/data && /usr/pgsql-9.6/bin/postgresql96-setup initdb"
+  on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=running enable=true"
+
+  # Enters 'puppet' as the password.
+  on_master ${master_vm} "runuser -l postgres -c '(echo puppet && echo puppet) | createuser -DRSP puppetdb'"
+  on_master ${master_vm} "runuser -l postgres -c 'createdb -E UTF8 -O puppetdb puppetdb'"
+  on_master ${master_vm} "runuser -l postgres -c \"psql puppetdb -c 'create extension pg_trgm'\""
+
+  # Edit pg_hba.conf to use md5 authentication for all DB connections
+  local pg_hba_path
+  pg_hba_path=`on_master ${master_vm} "find / -name *pg_hba.conf | head -n 1" | tail -n 1`
+  on_master ${master_vm} "echo local all all md5 > ${pg_hba_path}"
+  on_master ${master_vm} "echo host all all 127.0.0.1/32 md5 >> ${pg_hba_path}"
+  on_master ${master_vm} "echo host all all ::1/128 md5 >> ${pg_hba_path}"
+
+  # Restart postgresql and ensure that the puppetdb user can authenticate
+  # (you will need to enter the password then hit exit)
+  on_master ${master_vm} 'service postgresql-9.6 restart'
+  # Should list puppetdb as one of the users
+  on_master ${master_vm} "echo puppet | psql -h localhost puppetdb puppetdb -c '\\du' | grep puppetdb"
+  echo ""
+  echo ""
+
+  # Install the PuppetDB package
+  echo "STEP: Installing the PuppetDB package ..."
+  if [[ "$type" = "dev" ]]; then
+    on_master ${master_vm} "curl -f -O http://builds.puppetlabs.lan/puppetdb/${puppetdb_version}/artifacts/el/7/${collection}/x86_64/puppetdb-termini-${puppetdb_version}-1.el7.noarch.rpm"
+    on_master ${master_vm} "curl -f -O http://builds.puppetlabs.lan/puppetdb/${puppetdb_version}/artifacts/el/7/${collection}/x86_64/puppetdb-${puppetdb_version}-1.el7.noarch.rpm"
+    on_master ${master_vm} "rpm -ivh puppetdb-${puppetdb_version}-1.el7.noarch.rpm puppetdb-termini-${puppetdb_version}-1.el7.noarch.rpm"
+  elif [[ "$type" = "repo" ]]; then
+    on_master ${master_vm} "rpm --quiet --query puppetdb-${puppetdb_version} || yum install -y puppetdb-${puppetdb_version}"
+    on_master ${master_vm} "rpm --quiet --query puppetdb-termini-${puppetdb_version} || yum install -y puppetdb-termini-${puppetdb_version}"
+  else
+    echo "Unexpected type '${type}' supplied to install_puppetdb_from_package"
+    exit 1
+  fi
+  echo ""
+  echo ""
+
+  # Configure PuppetDB
+  echo "STEP: Configuring the PuppetDB package ..."
+  local puppetdb_database_ini="/etc/puppetlabs/puppetdb/conf.d/database.ini"
+  on_master ${master_vm} "echo subname = //localhost:5432/puppetdb >> ${puppetdb_database_ini}"
+  on_master ${master_vm} "echo username = puppetdb >> ${puppetdb_database_ini}"
+  on_master ${master_vm} "echo password = puppet >> ${puppetdb_database_ini}"
+  echo ""
+  echo ""
+
+  start_puppetdb ${master_vm}
+  echo "Finished installing PuppetDB via. the package on ${which_master}!"
+  echo ""
+  echo ""
+}

--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <server-version> <puppetdb-version>"
+domain=".delivery.puppetlabs.net"
+
+master_vm="$1"
+agent_vm="$2"
+agent_version="$3"
+server_version="$4"
+puppetdb_version="$5"
+
+if [[ -z "${master_vm}" || -z "${agent_vm}" || -z "${agent_version}" || \
+      -z "${server_version}" || -z "${puppetdb_version}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+# Append domains after validation.
+master_vm="$1$domain"
+agent_vm="$2$domain"
+
+echo "#### Setting up master..."
+$(dirname $0)/steps/setup-master.sh ${master_vm} ${agent_version} ${server_version} ${puppetdb_version}
+
+echo "#### Setting up agent..."
+$(dirname $0)/../steps/setup-agent.sh ${master_vm} ${agent_vm} ${agent_version} "package"
+
+echo "#### Running validation..."
+$(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}
+
+echo "All done!"

--- a/ext/smoke/packages/steps/setup-master.sh
+++ b/ext/smoke/packages/steps/setup-master.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -e
+set -x
+
+source "$(dirname $0)/../../helpers.sh"
+
+USAGE="USAGE: $0 <master-vm> <agent-version> <server-version> <puppetdb-version> [collection-name]"
+
+master_vm="$1"
+agent_version="$2"
+server_version="$3"
+puppetdb_version="$4"
+collection="${5:-puppet5}"
+
+if [[ -z "${master_vm}" || -z "${agent_version}" || -z "${server_version}" || -z "${puppetdb_version}}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+echo "Running the script with the following package versions ..."
+echo "  puppet-agent version: ${agent_version}"
+echo "  puppetserver version: ${server_version}"
+echo "  puppetdb version: ${puppetdb_version}"
+echo ""
+
+
+## PUPPET AGENT
+
+# Install puppet-agent package
+echo "STEP (1): Install the puppet-agent package"
+on_master ${master_vm} "curl -f -O http://builds.puppetlabs.lan/puppet-agent/${agent_version}/artifacts/el/7/${collection}/x86_64/puppet-agent-${agent_version}-1.el7.x86_64.rpm"
+on_master ${master_vm} "rpm -ivh puppet-agent-${agent_version}-1.el7.x86_64.rpm"
+echo ""
+echo ""
+
+## PUPPETSERVER
+
+# Install puppetserver
+echo "STEP (2): Install puppetserver"
+on_master ${master_vm} "curl -f -O http://builds.puppetlabs.lan/puppetserver/${server_version}/artifacts/el/7/${collection}/x86_64/puppetserver-${server_version}-1.el7.noarch.rpm"
+# FIXME: Might need to parametrize on Java?
+on_master ${master_vm} "yum install -y java-1.8.0-openjdk-headless"
+on_master ${master_vm} "rpm -ivh puppetserver-${server_version}-1.el7.noarch.rpm"
+on_master ${master_vm} "echo \`facter ipaddress\` puppet > /etc/hosts"
+echo ""
+echo ""
+
+# Start-up puppetserver and perform a puppet run to ensure that it is running
+echo "STEP (3): Start-up puppetserver and perform a puppet run to ensure that it is running."
+on_master ${master_vm} "puppet resource service puppetserver ensure=running"
+on_master ${master_vm} "puppet agent -t"
+echo ""
+echo ""
+
+## PUPPETDB
+
+# Here we install puppetdb. To do so, we first set-up postgresql 9.6
+# and use that to set-up the puppetdb user and database
+
+# FIXME: Parametrize on postgres version?
+echo "STEP (4): Set-up postgresql 9.6 to use with PuppetDB"
+install_puppetdb_from_package ${master_vm} "dev" ${collection}
+
+# Add PuppetDB to storeconfigs and reports settings in puppet.conf file
+echo "STEP (5): Adding PuppetDB to storeconfigs and reports settings in puppet.conf"
+puppet_conf="/etc/puppetlabs/puppet/puppet.conf"
+on_master ${master_vm} "echo storeconfigs = true >> ${puppet_conf}"
+on_master ${master_vm} "echo storeconfigs_backend = puppetdb >> ${puppet_conf}"
+on_master ${master_vm} "echo reports = store,puppetdb >> ${puppet_conf}"
+echo ""
+echo ""
+
+# Create route_file with puppetdb terminus for facts
+echo "STEP (6): Creating route_file with puppetdb terminus for facts"
+route_file=`on_master ${master_vm} "puppet master --configprint route_file" | tail -n 1`
+on_master ${master_vm} "echo --- > ${route_file}"
+on_master ${master_vm} "echo master: >> ${route_file}"
+on_master ${master_vm} "echo \"  facts:\" >> ${route_file}"
+on_master ${master_vm} "echo \"    terminus: puppetdb\" >> ${route_file}"
+on_master ${master_vm} "echo \"    cache: yaml\" >> ${route_file}"
+echo ""
+echo ""
+
+# Set ownership on everything
+echo "STEP (7): Setting ownership on everything"
+on_master ${master_vm} 'chown -R puppet:puppet `puppet config print confdir`'
+echo ""
+echo ""
+
+# Restart puppetserver and perform a puppet run to ensure that facts and
+# reports are sent to PuppetDB
+echo "STEP (8): Restart puppetserver and perform a puppet run to ensure that facts and reports are sent to PuppetDB"
+on_master ${master_vm} "puppet resource service puppetserver ensure=stopped"
+on_master ${master_vm} "puppet resource service puppetserver ensure=running"
+on_master ${master_vm} "puppet agent -t"
+on_master ${master_vm} "grep 'replace facts' /var/log/puppetlabs/puppetdb/puppetdb.log && echo '### Facts successfully sent to PuppetDB ###'"
+on_master ${master_vm} "grep 'replace catalog' /var/log/puppetlabs/puppetdb/puppetdb.log && echo '### Reports successfully sent to PuppetDB ###'"
+echo ""
+echo ""
+
+echo "Successfully set-up the master VM!"

--- a/ext/smoke/repos/run-smoke-test.sh
+++ b/ext/smoke/repos/run-smoke-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+set -x
+
+USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-vm1> <agent-vm2> <agent-version> <server-version> <puppetdb-version>"
+domain=".delivery.puppetlabs.net"
+
+master_vm1="$1"
+master_vm2="$2"
+agent_vm1="$3"
+agent_vm2="$4"
+agent_version="$5"
+server_version="$6"
+puppetdb_version="$7"
+
+if [[ -z "${master_vm1}" || -z "${master_vm2}" || -z "${agent_vm1}" || \
+      -z "${agent_vm2}" || -z "${agent_version}" || -z "${server_version}" || \
+      -z "${puppetdb_version}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+# Append domains after validation.
+master_vm1="$1$domain"
+master_vm2="$2$domain"
+agent_vm1="$3$domain"
+agent_vm2="$4$domain"
+
+echo "##### Setting up masters..."
+$(dirname $0)/steps/setup-masters.sh ${master_vm1} ${master_vm2} ${agent_version} ${server_version} ${puppetdb_version}
+
+# One agent starts with master 1, one agent starts with master 2
+echo "##### Master 1 (PuppetDB Module) + Agent 1"
+$(dirname $0)/../steps/setup-agent.sh          ${master_vm1} ${agent_vm1} ${agent_version} "repo"
+$(dirname $0)/../steps/run-validation-tests.sh ${master_vm1} ${agent_vm1}
+echo "##### Master 2 (PuppetDB Package) + Agent 2"
+$(dirname $0)/../steps/setup-agent.sh          ${master_vm2} ${agent_vm2} ${agent_version} "repo"
+$(dirname $0)/../steps/run-validation-tests.sh ${master_vm2} ${agent_vm2}
+
+echo "All done!"

--- a/ext/smoke/repos/steps/setup-masters.sh
+++ b/ext/smoke/repos/steps/setup-masters.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -e
+set -x
+
+source "$(dirname $0)/../../helpers.sh"
+
+USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-version> <server-version> <puppetdb-version> [<collection>]"
+
+master_vm1="$1"
+master_vm2="$2"
+agent_version="$3"
+server_version="$4"
+puppetdb_version="$5"
+collection="${6:-puppet5}"
+
+if [[ -z "${master_vm1}" || -z "${master_vm2}" || -z "${agent_version}" || -z "${server_version}" || -z "${puppetdb_version}}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+echo "Running the script with the following master hosts ..."
+echo "  Master with PuppetDB installed via. module (master1): ${master_vm1}"
+echo "  Master with PuppetDB installed via. package (master2): ${master_vm2}"
+echo ""
+
+echo "Running the script with the following package versions ..."
+echo "  puppet-agent version: ${agent_version}"
+echo "  puppetserver version: ${server_version}"
+echo "  puppetdb version: ${puppetdb_version}"
+echo ""
+
+function identify_master() {
+  local master_vm="$1"
+
+  if [[ "${master_vm}" == "${master_vm1}" ]]; then
+    echo "master1"
+  else
+    echo "master2"
+  fi
+}
+
+echo "STEP: Install puppetserver and puppet-agent on both masters"
+for master_vm in ${master_vm1} ${master_vm2}; do
+  which_master=`identify_master ${master_vm}`
+  on_master ${master_vm} "rpm -Uvh http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm --force"
+
+  echo "STEP: Install puppet-agent on ${which_master}"
+  on_master ${master_vm} "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"
+  on_master ${master_vm} "echo \`facter ipaddress\` puppet > /etc/hosts"
+  echo ""
+  echo ""
+
+  echo "STEP: Install puppetserver on ${which_master}"
+  on_master ${master_vm} "rpm --quiet --query puppetserver-${server_version} || yum install -y puppetserver-${server_version}"
+  on_master ${master_vm} "puppet resource service puppetserver ensure=running"
+  set +e
+  on_master ${master_vm} "puppet agent -t"
+  set -e
+  exitcode=$?
+  if [[ "$exitcode" -ne 0 && "$exitcode" -ne 2 ]]; then
+    echo "FAILED to run puppet on master"
+    exit 1
+  fi
+  echo ""
+  echo ""
+done
+
+install_puppetdb_from_module "${master_vm1}"
+install_puppetdb_from_package "${master_vm2}" "repo" ${collection}
+
+for master_vm in ${master_vm1} ${master_vm2}; do
+  which_master=`identify_master ${master_vm}`
+  enable_firewall="puppet apply -e \"firewall { '100 allow http and https access': dport => [80, 443, 8140], proto => tcp, action => accept, }\""
+
+  echo "STEP: Open firewall for puppetserver on ${which_master}"
+  if [[ "${master_vm}" == "${master_vm1}" ]]; then
+    on_master "${master_vm}" "${enable_firewall}"
+  else
+    # Per the docs, this is expected to fail on the master that has PuppetDB
+    # installed from the package.
+    set +e
+    on_master "${master_vm}" "${enable_firewall}"
+    set -e
+  fi
+  echo ""
+  echo ""
+done
+
+for master_vm in ${master_vm1} ${master_vm2}; do
+  which_master=`identify_master ${master_vm}`
+  SEMANTIC_VERSION_RE="[0-9]+\.[0-9]+\.[0-9]+"
+  REQUIRED_PACKAGES="puppet5-release-${SEMANTIC_VERSION_RE}-1.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-1\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-1\.el7\.noarch"
+
+  echo "STEP: Verify that the required puppet packages are installed on ${which_master}!"
+  grep_results=`on_master "${master_vm}" "rpm -qa | grep puppet"`
+  for required_package in  ${REQUIRED_PACKAGES}; do
+
+    concrete_package=`echo "${grep_results}" | grep -E  "${required_package}"`
+    if [[ -n "${concrete_package}" ]]; then
+      echo "The required puppet package is present on ${which_master} as ${concrete_package}!"
+    else
+      echo "The required puppet package ${required_package} is not found on ${which_master}!"
+      echo ""
+      echo "### EXPECTED TO MATCH: ####"
+      echo "${REQUIRED_PACKAGES}" | tr " " "\n"
+      echo "###"
+      echo ""
+      echo "### ACTUAL: ###" 
+      echo "${grep_results}"
+      echo "###"
+      echo ""
+      echo "Failing the tests ..."
+      exit 1
+    fi
+  done
+  echo ""
+  echo ""
+done

--- a/ext/smoke/steps/run-validation-tests.sh
+++ b/ext/smoke/steps/run-validation-tests.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -e
+set -x
+
+function on_host() {
+  host="$1"
+  cmd="$2"
+  suppress="$3"
+
+  if [[ -z "${suppress}" || "${suppress}" == "false" ]]; then
+    ssh -oStrictHostKeyChecking=no root@${host} "${cmd}" 2>/dev/null
+  else
+    ssh -oStrictHostKeyChecking=no root@${host} "${cmd}" 2>/dev/null 1>/dev/null
+  fi
+}
+
+function on_master() {
+  cmd="$1"
+  suppress="$2"
+
+  on_host ${master_vm} "${cmd}" "${suppress}"
+}
+
+function on_agent() {
+  cmd="$1"
+  suppress="$2"
+
+  on_host ${agent_vm} "${cmd}" "${suppress}"
+}
+
+function run_dataset_count_test() {
+  test_name="$1"
+  endpoint="$2"
+
+  echo "### TEST: ${test_name} ###"
+  result=`on_master "curl -f -G http://localhost:8080/pdb/query/v4/${endpoint} | /bin/jq \". | length\""`
+  echo "Result is: ${result}"
+  if [[ "${result}" == "2" || "${result}" == "3" ]]; then
+    echo "### RESULT: SUCCESS ###"
+  else
+    echo "### RESULT: FAIL ###"
+    exit 1
+  fi
+  echo ""
+  echo ""
+}
+
+
+USAGE="USAGE: $0 <master-vm> <agent-vm>"
+
+master_vm="$1"
+agent_vm="$2"
+
+if [[ -z "${master_vm}" || -z "${agent_vm}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+echo "Running the product validation tests with the following master-agent pair ..."
+echo "  MASTER: ${master_vm}"
+echo "  AGENT: ${agent_vm}"
+echo ""
+
+echo "Installing jq for use in script"
+on_master "wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -O /bin/jq; chmod +x /bin/jq"
+
+### TESTS ###
+
+echo "### TEST: Query PuppetDB for external node data ###"
+result=`on_master "curl -f -X POST http://localhost:8080/pdb/query/v4/nodes -H 'Content-Type:application/json' -d '{\"query\":[\"=\",\"certname\",\"${agent_vm}\"]}' | /bin/jq ."`
+if [[ "${result}" =~ ${agent_vm} ]]; then
+  echo "### RESULT: SUCCESS ###"
+else
+  echo "### RESULT: FAIL ###"
+fi
+echo ${result}
+echo ""
+echo ""
+
+
+
+echo "### TEST: Query PuppetDB for external fact data ###"
+on_agent "echo foo=bar > /opt/puppetlabs/facter/facts.d/test.txt" "true"
+set +e
+on_agent "puppet agent -t" "true"
+set -e
+result=`on_master "curl -f -X POST http://localhost:8080/pdb/query/v4/facts/foo -H 'Content-Type:application/json' -d '{\"query\":[\"=\",\"certname\",\"${agent_vm}\"]}' | /bin/jq ."`
+if [[ "${result}" =~ ${agent_vm} ]]; then
+  echo "### RESULT: SUCCESS ###"
+else
+  echo "### RESULT: FAIL ###"
+  exit 1
+fi
+echo ""
+echo ""
+
+run_dataset_count_test "Ensure node count is equal to number of agents" "nodes"
+run_dataset_count_test "Ensure factset count is equal to number of agents" "factsets"
+run_dataset_count_test "Ensure catalog count is equal to number of agents" "catalogs"
+
+exitcode=0
+for host in ${master_vm} ${agent_vm}; do
+  echo "### TEST: Ensure that reports are present for ${host} ###"
+  result=`on_master "curl -f -X POST http://localhost:8080/pdb/query/v4/reports -H 'Content-Type:application/json' -d '{\"query\":[\"=\",\"certname\",\"${host}\"]}' | jq \". | length\""`
+  echo ${result}
+  if [[ "${result}" -gt 0 ]]; then
+    echo "### RESULT: SUCCESS ###"
+  else
+    echo "### RESULT: FAIL ###"
+    exitcode=1
+  fi
+  echo ""
+  echo ""
+done
+exit ${exitcode}

--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+source "$(dirname $0)/../helpers.sh"
+
+USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <type>"
+
+master_vm="$1"
+agent_vm="$2"
+agent_version="$3"
+type="$4"
+
+if [[ -z "${master_vm}" || -z "${agent_vm}" || -z "${agent_version}" || -z "${type}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+function on_master() {
+  cmd="$1"
+  suppress="$2"
+  on_host "${master_vm}" "master" "${cmd}" "${suppress}"
+}
+
+function on_agent() {
+  cmd="$1"
+  suppress="$2"
+  on_host "${agent_vm}" "agent" "${cmd}" "${suppress}"
+}
+
+echo "Running the script with the following master-agent pair ..."
+echo "  MASTER: ${master_vm}"
+echo "  AGENT: ${agent_vm}"
+echo ""
+
+echo "Running the script with the following package versions ..."
+echo "  puppet-agent version: ${agent_version}"
+echo ""
+echo "Running with type ${type}"
+echo ""
+
+echo "Clean out the agent's SSL directory so it forgets any old masters"
+on_master "puppet cert clean ${agent_vm}; find /etc/puppetlabs/puppet/ssl -name ${agent_vm}.pem -delete"
+on_agent "rm -rf /etc/puppetlabs/puppet/ssl; sed -i '/puppet/d' /etc/hosts"
+
+echo "STEP: Install the puppet-agent package"
+master_ip=`on_master "facter ipaddress" | tail -n 1`
+on_agent "echo ${master_ip} puppet >> /etc/hosts"
+if [[ "${type}" = "repo" ]]; then
+  on_agent "rpm -Uvh http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm --force"
+  on_agent "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"
+elif [[ "${type}" = "package" ]]; then
+  on_agent "curl -f -O http://builds.puppetlabs.lan/puppet-agent/${agent_version}/artifacts/el/7/puppet5/x86_64/puppet-agent-${agent_version}-1.el7.x86_64.rpm"
+  on_agent "rpm -ivh puppet-agent-${agent_version}-1.el7.x86_64.rpm"
+else
+  echo "Unrecognized type '${type}' supplied"
+  exit 1
+fi
+echo ""
+echo ""
+
+# Run puppet to create SSL keys and have master sign them.
+echo "STEP: Run puppet to create SSL keys, and have master sign them."
+set +e
+echo "Registering agent..."
+on_agent "puppet agent -t"
+set -e
+echo "### DEBUG: Sleeping for 5 seconds to give some time for the agent cert to appear on the master ..."
+sleep 5
+on_master "puppet cert sign --all"
+echo ""
+echo ""
+
+echo "STEP: Run puppet to get the catalog"
+set +e
+on_agent "puppet agent -t"
+set -e
+exitcode=$?
+if [[ "$exitcode" = 0 || "$exitcode" = 2 ]]; then
+  echo "Successfully set-up the agent VM!"
+else
+  echo "FAILED to set up the agent VM"
+  exit 1
+fi
+echo ""
+echo ""


### PR DESCRIPTION
This adds improvements to automate engineering release lead duties:

- A rake task for finding platform additions and removals.
- A rake task for checking component versions included at a SHA for puppet-agent.
- A script for smoke testing puppet-agent from pre-release packages.
- A script for smoke testing puppet-agent from released repos.