### PR TITLE
(PA-2055) Don't remove OpenSSL headers after building

### DIFF
--- a/configs/components/cleanup.rb
+++ b/configs/components/cleanup.rb
@@ -1,0 +1,38 @@
+# This component exists only to remove unnecessary files that bloat the final puppet-agent package.
+component "cleanup" do |pkg, settings, platform|
+  # This component must depend on all other C++ components in order to be
+  # executed last, after they all finish building.
+  pkg.build_requires "cpp-pcp-client"
+  pkg.build_requires "cpp-hocon"
+  pkg.build_requires "facter"
+  pkg.build_requires "leatherman"
+  pkg.build_requires "libwhereami"
+  pkg.build_requires "pxp-agent"
+
+  unless settings[:dev_build]
+    # Unless the settings specify that this is a development build, remove
+    # unneeded header files (boost headers, for example, increase the size of
+    # the package to an unacceptable degree).
+    #
+    # Note that:
+    # - Ruby is not in this list because its headers are required to build native
+    #   extensions for gems.
+    # - OpenSSL is not in this list because its headers are required to build
+    #   other libraries (e.g. libssh2) in other projects that rely on
+    #   puppet-agent (e.g. pe-r10k-vanagon).
+    unwanted_headers = ["augeas.h", "boost", "cpp-pcp-client", "curl", "fa.h",
+                        "facter", "hocon", "leatherman", "libexslt", "libxml2",
+                        "libxslt", "whereami", "yaml-cpp"]
+
+    # We need a full path on windows because /usr/bin is not in the PATH at this point
+    rm = platform.is_windows? ? '/usr/bin/rm' : 'rm'
+
+    pkg.install do
+      [
+        unwanted_headers.map { |h| "#{rm} -rf #{settings[:includedir]}/#{h}" },
+        # Also remove OpenSSL manpages
+        "#{rm} -rf #{settings[:prefix]}/ssl/man",
+      ]
+    end
+  end
+end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -162,11 +162,15 @@ component "pxp-agent" do |pkg, settings, platform|
   # We're doing this in the pxp-agent component because pxp-agent is the last
   # component to build that requires these headers.
   unless settings[:dev_build]
-    # Note that ruby is _not_ included in this list because its headers are
-    # required to build native extensions for gems.
+    # Note that:
+    # - ruby is not included because its headers are required to build native
+    #   extensions for gems.
+    # - openssl is not included because its headers are required to build other
+    #   libraries (e.g. libssh2) in other projects that rely on puppet-agent
+    #   (e.g. pe-r10k-vanagon).
     unwanted_headers = ["augeas.h", "boost", "cpp-pcp-client", "curl", "fa.h",
                         "facter", "hocon", "leatherman", "libexslt", "libxml2",
-                        "libxslt", "openssl", "whereami", "yaml-cpp"]
+                        "libxslt", "whereami", "yaml-cpp"]
 
     # We need a full path on windows because /usr/bin is not in the PATH at this point
     rm = platform.is_windows? ? '/usr/bin/rm' : 'rm'

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -153,33 +153,4 @@ component "pxp-agent" do |pkg, settings, platform|
   else
     fail "need to know where to put #{pkg.get_name} service files"
   end
-
-  # Unless the settings specify that this is a development build, we remove
-  # unneeded header files so that they don't make it into the final package
-  # (boost headers, for example, increase the size of the package to an
-  # unacceptable degree).
-  #
-  # We're doing this in the pxp-agent component because pxp-agent is the last
-  # component to build that requires these headers.
-  unless settings[:dev_build]
-    # Note that:
-    # - ruby is not included because its headers are required to build native
-    #   extensions for gems.
-    # - openssl is not included because its headers are required to build other
-    #   libraries (e.g. libssh2) in other projects that rely on puppet-agent
-    #   (e.g. pe-r10k-vanagon).
-    unwanted_headers = ["augeas.h", "boost", "cpp-pcp-client", "curl", "fa.h",
-                        "facter", "hocon", "leatherman", "libexslt", "libxml2",
-                        "libxslt", "whereami", "yaml-cpp"]
-
-    # We need a full path on windows because /usr/bin is not in the PATH at this point
-    rm = platform.is_windows? ? '/usr/bin/rm' : 'rm'
-
-    pkg.install do
-      [
-        unwanted_headers.map { |h| "#{rm} -rf #{settings[:includedir]}/#{h}" },
-        "#{rm} -rf #{settings[:prefix]}/ssl/man", # Also remove unwanted OpenSSL manpages
-      ]
-    end
-  end
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -137,6 +137,10 @@ project "puppet-agent" do |proj|
   proj.component "module-puppetlabs-zfs_core"
   proj.component "module-puppetlabs-zone_core"
 
+  # Including headers can make the package unacceptably large; This component
+  # removes files that aren't required:
+  proj.component "cleanup"
+
   proj.directory proj.install_root
   proj.directory proj.prefix
   proj.directory proj.sysconfdir


### PR DESCRIPTION
Most headers are removed after building the last C++ component,
pxp-agent, to reduce the size of the final puppet-agent package. Some
donwstream vanagon projects that consume puppet-agent depend on OpenSSL
headers, so keep those.

(The eventual goal here is to produce separate puppet-agent (without headers) and puppet-agent-dev (with headers) packages, but until that time, we've removed as many headers as possible)