### PR TITLE
(PA-1941) Fix libnames for new OpenSSL dlls

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -211,10 +211,17 @@ component "facter" do |pkg, settings, platform|
     # Copy these into facter's bindir, they've already been copied into ruby's
     # in the runtime component
     pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:facter_root]}/bin/zlib1.dll"
+    if platform.architecture == "x64"
+      gcc_postfix = 'seh'
+      ssl_postfix = '-x64'
+    else
+      gcc_postfix = 'sjlj'
+      ssl_postfix = ''
+    end
     [
-      "libeay32.dll",
-      platform.architecture == "x64" ? "libgcc_s_seh-1.dll" : "libgcc_s_sjlj-1.dll",
-      "ssleay32.dll"
+      "libssl-1_1#{ssl_postfix}.dll",
+      "libcrypto-1_1#{ssl_postfix}.dll",
+      "libgcc_s_#{gcc_postfix}-1.dll"
     ].each do |dll|
       pkg.install_file "#{settings[:prefix]}/bin/#{dll}", "#{settings[:facter_root]}/bin/#{dll}"
     end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -93,17 +93,20 @@ component "pxp-agent" do |pkg, settings, platform|
     # we ensure that Windows uses our in-house .dll files to start up pxp-agent.
     #
     # See https://tickets.puppetlabs.com/browse/PA-1850 for all the details.
-    pkg.install do
-      dependent_dlls = [
-        "libeay32.dll",
-        "ssleay32.dll",
-        platform.architecture == "x64" ? "libgcc_s_seh-1.dll" : "libgcc_s_sjlj-1.dll",
-        "libstdc++-6.dll"
-      ]
-
-      dependent_dlls.map do |dll|
-        "C:/cygwin64/bin/cp.exe #{settings[:prefix]}/bin/#{dll} #{settings[:pxp_root]}/bin"
-      end
+    if platform.architecture == "x64"
+      gcc_postfix = 'seh'
+      ssl_postfix = '-x64'
+    else
+      gcc_postfix = 'sjlj'
+      ssl_postfix = ''
+    end
+    [
+      "libssl-1_1#{ssl_postfix}.dll",
+      "libcrypto-1_1#{ssl_postfix}.dll",
+      "libgcc_s_#{gcc_postfix}-1.dll",
+      "libstdc++-6.dll"
+    ].each do |dll|
+      pkg.install_file "#{settings[:prefix]}/bin/#{dll}", "#{settings[:pxp_root]}/bin/#{dll}"
     end
   end
 


### PR DESCRIPTION
We need to copy openssl dlls around on windows. This commit updates the
names of those dlls since they changed in OpenSSL 1.1

Should be merged at the same time as https://github.com/puppetlabs/puppet-runtime/pull/82