### PR TITLE
(PA-2155) Remove deprecated rubygems flag in WiX templates

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -401,7 +401,6 @@ ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\puppet\etc", appDataPath
 ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\code\environments", appDataPath & "\PuppetLabs\code", SDDL_DIR_INHERITED_ADMIN_ONLY, False
 ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\facter\facts.d", appDataPath & "\PuppetLabs\facter", SDDL_DIR_INHERITED_EVERYONE, False
 ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\pxp-agent\etc", appDataPath & "\PuppetLabs\pxp-agent", SDDL_DIR_INHERITED_ADMIN_ONLY, False
-ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\mcollective\etc", appDataPath & "\PuppetLabs\mcollective", SDDL_DIR_INHERITED_ADMIN_ONLY, False
       ]]>
     </CustomAction>
   </Fragment>

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -26,7 +26,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
+                        Arguments="&quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptions"
                         Start="install"
                         Stop="both"
@@ -57,7 +57,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
+                        Arguments="&quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptionsManual"
                         Stop="both"
                         Remove="uninstall"
@@ -87,7 +87,7 @@
                         Type="ownProcess"
                         ErrorControl="normal"
                         Vital="yes"
-                        Arguments="-rubygems &quot;[INSTALLDIR]service\daemon.rb&quot;" />
+                        Arguments="&quot;[INSTALLDIR]service\daemon.rb&quot;" />
         <ServiceControl Id="ServiceControlOptionsDisabled"
                         Stop="both"
                         Remove="uninstall"


### PR DESCRIPTION
After upgrading to ruby 2.5.1 in master, agent MSIs failed to install without `PUPPET_AGENT_STARTUP_MODE=Manual` (we use this in CI, so it wasn't noted until the agents were consumed elsewhere). This is because the WiX template wasn't updated to remove the deprecated `-rubygems` flag when ruby 2.5.1 was introduced. I've also removed an innocuous but unwanted reference to mcollective (which I suspect arrived via automated mergeup from 5.5.x at some point?)

I built this locally and tested the installation on a windows VM; all seems well without manual startup mode now.