### PR TITLE
(PA-2157) Add support for sles-15-x86_64

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -4,6 +4,7 @@ component "cpp-hocon" do |pkg, settings, platform|
   pkg.build_requires('leatherman')
 
   make = platform[:make]
+  boost_static_flag = "-DBOOST_STATIC=ON"
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
@@ -27,6 +28,11 @@ component "cpp-hocon" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -45,7 +51,7 @@ component "cpp-hocon" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        #{boost_static_flag} \
         ."]
   end
 

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -18,6 +18,8 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   end
   pkg.build_requires "leatherman"
 
+  boost_static_flag = "-DBOOST_STATIC=ON"
+
   if platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
@@ -40,6 +42,12 @@ component "cpp-pcp-client" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
+    platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
   elsif platform.is_cisco_wrlinux?
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end
@@ -55,7 +63,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
           -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
-          -DBOOST_STATIC=ON \
+          #{boost_static_flag} \
           ."
     ]
   end

--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -12,6 +12,9 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
     pkg.build_requires "pl-boost-#{platform.architecture}"
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "pl-cmake"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -20,7 +20,7 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires 'puppet-runtime' # Provides openssl, ruby, augeas, curl
   pkg.build_requires 'leatherman'
-  pkg.build_requires 'runtime'
+  pkg.build_requires 'runtime' unless platform.name =~ /sles-15/
   pkg.build_requires 'cpp-hocon'
   pkg.build_requires 'libwhereami'
 
@@ -47,6 +47,9 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-yaml-cpp"
   end
@@ -115,6 +118,8 @@ component "facter" do |pkg, settings, platform|
   cp = platform[:cp]
 
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
+  boost_static_flag = "-DBOOST_STATIC=ON"
+  yamlcpp_static_flag = "-DYAMLCPP_STATIC=ON"
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
@@ -144,6 +149,12 @@ component "facter" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags = "-DCMAKE_INSTALL_PREFIX=#{settings[:facter_root]} \
                      -DRUBY_LIB_INSTALL=#{settings[:facter_root]}/lib "
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
+    yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -172,8 +183,8 @@ component "facter" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
-        -DYAMLCPP_STATIC=ON \
+        #{boost_static_flag} \
+        #{yamlcpp_static_flag} \
         -DWITHOUT_CURL=#{skip_curl} \
         -DWITHOUT_BLKID=#{skip_blkid} \
         -DWITHOUT_JRUBY=#{skip_jruby} \
@@ -213,8 +224,11 @@ component "facter" do |pkg, settings, platform|
     tests << "LD_LIBRARY_PATH=#{settings[:libdir]} LIBPATH=#{settings[:libdir]} #{make} test ARGS=-V"
   end
 
-  pkg.check do
-    tests
+  # Disable tests for platforms that use the default OS toolchain
+  unless platform.name =~ /sles-15/
+    pkg.check do
+      tests
+    end
   end
 
   pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -23,6 +23,9 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
     pkg.build_requires "pl-boost-#{platform.architecture}"
     pkg.build_requires "pl-gettext-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-boost"
@@ -30,11 +33,12 @@ component "leatherman" do |pkg, settings, platform|
   end
 
   pkg.build_requires "puppet-runtime" # Provides curl and ruby
-  pkg.build_requires "runtime"
+  pkg.build_requires "runtime" unless platform.name =~ /sles-15/
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
 
   leatherman_locale_var = ""
+  boost_static_flag = "-DBOOST_STATIC=ON"
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
@@ -66,6 +70,11 @@ component "leatherman" do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -91,7 +100,7 @@ component "leatherman" do |pkg, settings, platform|
         #{leatherman_locale_var} \
         -DLEATHERMAN_SHARED=TRUE \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        #{boost_static_flag} \
         ."]
   end
 

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -4,6 +4,7 @@ component "libwhereami" do |pkg, settings, platform|
   pkg.build_requires('leatherman')
 
   make = platform[:make]
+  boost_static_flag = "-DBOOST_STATIC=ON"
 
   # cmake on OSX is provided by brew
   # a toolchain is not currently required for OSX since we're building with clang.
@@ -27,6 +28,11 @@ component "libwhereami" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -45,7 +51,7 @@ component "libwhereami" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
-        -DBOOST_STATIC=ON \
+        #{boost_static_flag} \
         ."]
   end
 

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -25,6 +25,20 @@ component 'puppet-runtime' do |pkg, settings, platform|
   pkg.replaces 'pe-rubygem-deep-merge'
   pkg.replaces 'pe-rubygem-net-ssh'
 
+  # These platforms are built with the default OS distro toolchain, and
+  # thus have additional package deps
+  if platform.name =~ /sles-15/
+    pkg.requires 'libboost_atomic1_66_0'
+    pkg.requires 'libboost_chrono1_66_0'
+    pkg.requires 'libboost_date_time1_66_0'
+    pkg.requires 'libboost_filesystem1_66_0'
+    pkg.requires 'libboost_locale1_66_0'
+    pkg.requires 'libboost_log1_66_0'
+    pkg.requires 'libboost_program_options1_66_0'
+    pkg.requires 'libboost_regex1_66_0'
+    pkg.requires 'libyaml-cpp0_6'
+  end
+
   pkg.install_only true
 
   if platform.is_cross_compiled_linux? || platform.is_solaris? || platform.is_aix?

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -12,6 +12,9 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   elsif !platform.is_solaris?
     pkg.build_requires "pl-gettext"
   end
@@ -107,6 +110,8 @@ component "puppet" do |pkg, settings, platform|
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
+    elsif platform.name =~ /sles-15/
+      msgfmt = "msgfmt"
     else
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"
     end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -22,6 +22,7 @@ component "pxp-agent" do |pkg, settings, platform|
 
   make = platform[:make]
 
+  boost_static_flag = "-DBOOST_STATIC=ON"
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
 
   if platform.is_aix?
@@ -47,6 +48,12 @@ component "pxp-agent" do |pkg, settings, platform|
     special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    boost_static_flag = "-DBOOST_STATIC=OFF"
+    special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
   elsif platform.is_cisco_wrlinux?
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end
@@ -62,7 +69,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           #{special_flags} \
-          -DBOOST_STATIC=ON \
+          #{boost_static_flag} \
           ."
     ]
   end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -24,6 +24,9 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
     # We only need zlib because curl is dynamically linking against zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-gcc"
   end

--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -1,0 +1,9 @@
+platform "sles-15-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make rpm-build libboost_atomic1_66_0-devel libboost_chrono1_66_0-devel libboost_container1_66_0-devel libboost_date_time1_66_0-devel libboost_filesystem1_66_0-devel libboost_graph1_66_0-devel libboost_iostreams1_66_0-devel libboost_locale1_66_0-devel libboost_log1_66_0-devel libboost_math1_66_0-devel libboost_program_options1_66_0-devel libboost_random1_66_0-devel libboost_regex1_66_0-devel libboost_serialization1_66_0-devel libboost_signals1_66_0-devel libboost_system1_66_0-devel libboost_test1_66_0-devel libboost_thread1_66_0-devel libboost_timer1_66_0-devel libboost_wave1_66_0-devel gettext-tools cmake yaml-cpp-devel"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-15-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -111,7 +111,7 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime"
+  proj.component "runtime" unless platform.name =~ /sles-15/
 
   # Windows doesn't need these wrappers, only unix platforms
   unless platform.is_windows?


### PR DESCRIPTION
This platform is being built with the default OS toolchain, and doesn't
rely on pl-build-tools packages.