### PR TITLE
(PA-1923) Update Windows install paths to more closely match equivalent *nix paths

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -14,11 +14,7 @@ component "hiera" do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
-    configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"
-    flags = " --bindir=#{settings[:hiera_bindir]} \
-              --sitelibdir=#{settings[:hiera_libdir]} \
-              --ruby=#{File.join(settings[:ruby_bindir], 'ruby')} "
   end
 
   pkg.install do

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -55,7 +55,7 @@ component "leatherman" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG'"
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
-    pkg.environment "PATH", "$(shell cygpath -u #{settings[:prefix]}/lib):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
+    pkg.environment "PATH", "$(shell cygpath -u #{settings[:libdir]}):$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
     pkg.environment "CYGWIN", settings[:cygwin]
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""

--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -11,5 +11,5 @@ component "nssm" do |pkg, settings, platform|
     ]
   end
 
-  pkg.install_file "out/nssm.exe", "#{settings[:service_dir]}/nssm.exe"
+  pkg.install_file "out/nssm.exe", "#{settings[:bindir]}/nssm.exe"
 end

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -63,8 +63,8 @@ component 'puppet-runtime' do |pkg, settings, platform|
     # privileges it needs to run
     pkg.add_source "file://resources/files/windows/elevate.exe.config", sum: "a5aecf3f7335fa1250a0f691d754d561"
     pkg.add_source "#{settings[:buildsources_url]}/windows/elevate/elevate.exe", sum: "bd81807a5c13da32dd2a7157f66fa55d"
-    pkg.install_file 'elevate.exe.config', "#{settings[:windows_tools]}/elevate.exe.config"
-    pkg.install_file 'elevate.exe', "#{settings[:windows_tools]}/elevate.exe"
+    pkg.install_file 'elevate.exe.config', "#{settings[:bindir]}/elevate.exe.config"
+    pkg.install_file 'elevate.exe', "#{settings[:bindir]}/elevate.exe"
 
     # We need to make sure we're setting permissions correctly for the executables
     # in the ruby bindir since preserving permissions in archives in windows is
@@ -72,7 +72,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
     # so cmd.exe was not working as expected.
     install_command = [
       "gunzip -c #{tarball_name} | tar -k -C /cygdrive/c/ -xf -",
-      "chmod 755 #{settings[:ruby_bindir].sub(/C:/, '/cygdrive/c')}/*"
+      "chmod 755 #{settings[:bindir].sub(/C:/, '/cygdrive/c')}/*"
     ]
   elsif platform.is_macos?
     # We can't untar into '/' because of SIP on macOS; Just copy the contents

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -55,7 +55,7 @@ component "puppet" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\sys\\ruby\\bin\\ruby.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\ruby.exe"
   else
     fail "need to know where to put service files"
   end
@@ -137,9 +137,7 @@ component "puppet" do |pkg, settings, platform|
   end
 
   if platform.is_windows?
-    pkg.environment "FACTERDIR", settings[:facter_root]
     pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:ruby_bindir]}):$(shell cygpath -u #{settings[:bindir]}):/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0"
-    pkg.environment "RUBYLIB", "#{settings[:hiera_libdir]};#{settings[:facter_root]}/lib"
   end
 
   if platform.is_windows?

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -44,7 +44,6 @@ component "pxp-agent" do |pkg, settings, platform|
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     pkg.environment "CYGWIN", settings[:cygwin]
 
-    special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
   elsif platform.name =~ /sles-15/
@@ -79,49 +78,12 @@ component "pxp-agent" do |pkg, settings, platform|
     ["#{make} -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install"]
   end
 
-  if platform.is_windows?
-    # In PA-1850, it was found that when there is a system version of openssl
-    # installed on Windows, then the pxp-agent will fail to start properly if
-    # the user tries to restart it. Specifically, Puppet shows the service as
-    # being in the "paused" state. The reason this happened is because when Windows
-    # executes the pxp-agent.exe file, it searches for its required .dll files first
-    # in the .exe file's directory, then in the system library directory
-    # (e.g. C:\Windows:\System32), and then the custom PATH last (as a rough approximation,
-    # it actually searches some other locations, but the relative ordering of ".exe directory"
-    # => "system library directory" => PATH is still there). See https://msdn.microsoft.com/en-us/library/7d83bc18.aspx
-    # for more details. Since we do not have any .dll files in pxp-agent/bin, the system
-    # openssl is detected as pxp-agent's openssl library instead of Puppet's openssl, which
-    # is installed in [INSTALLDIR]\Puppet\puppet\bin. Of course, pxp-agent is not built to work
-    # with the system openssl, so it fails to start properly.
-    #
-    # By copying the dependent .dll files in the puppet/bin directory to pxp-agent/bin,
-    # we ensure that Windows uses our in-house .dll files to start up pxp-agent.
-    #
-    # See https://tickets.puppetlabs.com/browse/PA-1850 for all the details.
-    if platform.architecture == "x64"
-      gcc_postfix = 'seh'
-      ssl_postfix = '-x64'
-    else
-      gcc_postfix = 'sjlj'
-      ssl_postfix = ''
-    end
-    [
-      "libssl-1_1#{ssl_postfix}.dll",
-      "libcrypto-1_1#{ssl_postfix}.dll",
-      "libgcc_s_#{gcc_postfix}-1.dll",
-      "libstdc++-6.dll"
-    ].each do |dll|
-      pkg.install_file "#{settings[:prefix]}/bin/#{dll}", "#{settings[:pxp_root]}/bin/#{dll}"
-    end
-  end
-
   pkg.directory File.join(settings[:sysconfdir], 'pxp-agent')
   if platform.is_windows?
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'etc', 'modules')
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'spool')
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'tasks-cache')
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'log')
-    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'var', 'run')
+    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'modules')
+    pkg.directory File.join(settings[:install_root], 'pxp-agent', 'spool')
+    pkg.directory File.join(settings[:install_root], 'pxp-agent', 'tasks-cache')
+    pkg.directory File.join(settings[:sysconfdir], 'pxp-agent', 'log')
   else
     # Output directories (spool, tasks-cache, logdir) are restricted to root agent.
     # Modules is left readable so non-root agents can also use the installed modules.
@@ -157,7 +119,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\service\\nssm.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm.exe"
   else
     fail "need to know where to put #{pkg.get_name} service files"
   end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -53,9 +53,6 @@ component "runtime" do |pkg, settings, platform|
     pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
     pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll", "#{settings[:facter_root]}/lib/libgcc_s_#{lib_type}-1.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:facter_root]}/lib/libstdc++-6.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:facter_root]}/lib/libwinpthread-1.dll"
 
     # Curl is dynamically linking against zlib, so we need to include this file until we
     # update curl to statically link against zlib
@@ -63,11 +60,16 @@ component "runtime" do |pkg, settings, platform|
 
     # gdbm and iconv are runtime dependancies of ruby, and their libraries need
     # To exist inside our vendored ruby
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:bindir]}/libgdbm-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:bindir]}/libgdbm_compat-4.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:bindir]}/libiconv-2.dll"
+    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:bindir]}/libffi-6.dll"
 
+    # Copy the boost dlls into the bindir
+    settings[:boost_libs].each do |name|
+      pkg.install_file "#{settings[:prefix]}/lib/libboost_#{name}.dll",   "#{settings[:bindir]}/libboost_#{name}.dll"
+      pkg.install_file "#{settings[:prefix]}/lib/libboost_#{name}.dll.a", "#{settings[:bindir]}/libboost_#{name}.dll.a"
+    end
   else # Linux and Solaris systems
     pkg.install do
       "bash runtime.sh #{libdir}"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -48,16 +48,8 @@ project "puppet-agent" do |proj|
     # Directory IDs
     proj.setting(:bindir_id, "bindir")
 
-    # We build for windows not in the final destination, but in the paths that correspond
-    # to the directory ids expected by WIX. This will allow for a portable installation (ideally).
-    proj.setting(:facter_root, File.join(proj.install_root, "facter"))
-    proj.setting(:hiera_root, File.join(proj.install_root, "hiera"))
-    proj.setting(:hiera_bindir, File.join(proj.hiera_root, "bin"))
-    proj.setting(:hiera_libdir, File.join(proj.hiera_root, "lib"))
     proj.setting(:pxp_root, File.join(proj.install_root, "pxp-agent"))
     proj.setting(:service_dir, File.join(proj.install_root, "service"))
-    proj.setting(:ruby_dir, File.join(proj.install_root, "sys/ruby"))
-    proj.setting(:ruby_bindir, File.join(proj.ruby_dir, "bin"))
   end
 
   proj.setting(:puppet_configdir, File.join(proj.sysconfdir, 'puppet'))

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -1,29 +1,23 @@
 @ECHO OFF
-REM This is the parent directory of the directory containing this script.
+REM This is the parent directory of the directory containing this script (resolves to :install_root/Puppet)
 SET PL_BASEDIR=%~dp0..
 REM Avoid the nasty \..\ littering the paths.
 SET PL_BASEDIR=%PL_BASEDIR:\bin\..=%
 
+SET PUPPET_DIR=%PL_BASEDIR%\puppet
+
 REM Set a fact so we can easily source the environment.bat file in the future.
 SET FACTER_env_windows_installdir=%PL_BASEDIR%
 
-SET PUPPET_DIR=%PL_BASEDIR%\puppet
-REM Facter will load FACTER_ env vars as facts, so don't use FACTER_DIR
-SET FACTERDIR=%PL_BASEDIR%\facter
-SET HIERA_DIR=%PL_BASEDIR%\hiera
-SET RUBY_DIR=%PL_BASEDIR%\sys\ruby
-
-SET PATH=%PUPPET_DIR%\bin;%FACTERDIR%\bin;%HIERA_DIR%\bin;%PL_BASEDIR%\bin;%RUBY_DIR%\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
+REM Add puppet's bindirs to the PATH
+SET PATH=%PUPPET_DIR%\bin;%PL_BASEDIR%\bin;%PATH%
 
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%PUPPET_DIR%\lib;%FACTERDIR%\lib;%HIERA_DIR%\lib;%RUBYLIB%
+SET RUBYLIB=%PUPPET_DIR%\lib;%RUBYLIB%
 
 REM Translate all slashes to / style to avoid issue #11930
 SET RUBYLIB=%RUBYLIB:\=/%
 
-
-REM Enable rubygems support
-SET RUBYOPT=rubygems
 REM Now return to the caller.
 
 REM Set SSL variables to ensure trusted locations are used

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -13,7 +13,7 @@
         </Condition>
         <File Id="RubyExeAutomatic"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -44,7 +44,7 @@
         </Condition>
         <File Id="RubyExeManual"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerManual"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -74,7 +74,7 @@
         </Condition>
         <File Id="RubyExeDisabled"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\sys\ruby\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerDisabled"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -9,7 +9,7 @@
         <CreateFolder />
         <File Id="NSSM"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\service\nssm.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm.exe" />
 
         <ServiceInstall Id="PXPServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -25,17 +25,16 @@
         <!-- Various registry keys documented at https://nssm.cc/usage and https://github.com/kirillkovalenko/nssm -->
         <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\pxp-agent\Parameters">
           <RegistryValue Name="AppDirectory"
-                         Value="[INSTALLDIR]pxp-agent\bin"
+                         Value="[INSTALLDIR]puppet\bin"
                          Type="expandable" />
           <RegistryValue Name="Application"
-                         Value="[INSTALLDIR]pxp-agent\bin\pxp-agent.exe"
+                         Value="[INSTALLDIR]puppet\bin\pxp-agent.exe"
                          Type="expandable" />
           <RegistryValue Name="AppParameters"
                          Value=""
                          Type="expandable" />
           <RegistryValue Name="AppEnvironmentExtra" Type="multiString">
-                         <MultiStringValue>PATH=[INSTALLDIR]pxp-agent\bin;[INSTALLDIR]puppet\bin;[INSTALLDIR]facter\bin;[INSTALLDIR]sys\ruby\bin;%PATH%</MultiStringValue>
-                         <MultiStringValue>RUBYLIB=[INSTALLDIR]puppet\lib;[INSTALLDIR]hiera\lib;[INSTALLDIR]facter\lib;%RUBYLIB%</MultiStringValue>
+                         <MultiStringValue>PATH=[INSTALLDIR]puppet\bin;%PATH%</MultiStringValue>
                          <MultiStringValue>OPENSSL_CONF=[INSTALLDIR]puppet\ssl\openssl.cnf</MultiStringValue>
           </RegistryValue>
           <!-- Write stdout/stderr to the same log file to catch startup errors -->


### PR DESCRIPTION
This PR updates install paths for Windows agents in puppet6 so that they more closely match the equivalent paths on Unix/Linux-based platforms.

This PR depends on several others:

A puppet-specifications PR is open here detailing the new paths: 

- https://github.com/puppetlabs/puppet-specifications/pull/123

This beaker-puppet PR adds the new paths to the `PATH`:

- ~~https://github.com/puppetlabs/beaker-puppet/pull/64~~ Merged and released

This puppet-runtime PR must be merged and must promote to puppet-agent#master before this PR can be merged:

- ~~https://github.com/puppetlabs/puppet-runtime/pull/94~~ Merged and promoted

PRs below must be merged at the same time as this PR:

- https://github.com/puppetlabs/puppet/pull/7068
- https://github.com/puppetlabs/pxp-agent/pull/723
