### PR TITLE
(MODULES-7753) Update scheduled_task ref for 1.0.0

### DIFF
--- a/acceptance/tests/validate_vendored_modules.rb
+++ b/acceptance/tests/validate_vendored_modules.rb
@@ -25,6 +25,7 @@ test_name "PA-1998: Validate that vendored modules are installed" do
       cron
       host
       mount
+      scheduled_task
       selboolean
       selmodule
       ssh_authorized_key

--- a/configs/components/module-puppetlabs-scheduled_task.json
+++ b/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/0.4.0"}
+{"url":"git://github.com/puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}


### PR DESCRIPTION
This commit updates the reference to the `scheduled_task` module to 1.0.0 in
anticipation of the first supported release of that module.