### PR TITLE
(PA-2157) Add support for sles-15-x86_64

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -27,6 +27,10 @@ component "cpp-hocon" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -39,6 +39,11 @@ component "cpp-pcp-client" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
   elsif platform.is_cisco_wrlinux?
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end

--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -9,6 +9,9 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires "cmake"
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "pl-cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -18,13 +18,16 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "cmake"
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
     pkg.build_requires "pl-gettext-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-gettext"
   end
 
   pkg.build_requires "puppet-runtime" # Provides boost, curl, ruby
-  pkg.build_requires "runtime"
+  pkg.build_requires "runtime" unless platform.name =~ /sles-15/
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
 
@@ -60,6 +63,10 @@ component "leatherman" do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -27,6 +27,10 @@ component "libwhereami" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -25,6 +25,21 @@ component 'puppet-runtime' do |pkg, settings, platform|
   pkg.replaces 'pe-rubygem-deep-merge'
   pkg.replaces 'pe-rubygem-net-ssh'
 
+  # These platforms are built with the default OS distro toolchain, and
+  # thus have additional package deps
+  if platform.name =~ /sles-15/
+    pkg.requires 'libboost_atomic1_66_0'
+    pkg.requires 'libboost_chrono1_66_0'
+    pkg.requires 'libboost_date_time1_66_0'
+    pkg.requires 'libboost_filesystem1_66_0'
+    pkg.requires 'libboost_locale1_66_0'
+    pkg.requires 'libboost_log1_66_0'
+    pkg.requires 'libboost_program_options1_66_0'
+    pkg.requires 'libboost_random1_66_0'
+    pkg.requires 'libboost_regex1_66_0'
+    pkg.requires 'libyaml-cpp0_6'
+  end
+
   pkg.install_only true
 
   if platform.is_cross_compiled_linux? || platform.is_solaris? || platform.is_aix?

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -12,6 +12,9 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   elsif !platform.is_solaris?
     pkg.build_requires "pl-gettext"
   end
@@ -107,6 +110,8 @@ component "puppet" do |pkg, settings, platform|
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
+    elsif platform.name =~ /sles-15/
+      msgfmt = "msgfmt"
     else
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"
     end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -47,6 +47,11 @@ component "pxp-agent" do |pkg, settings, platform|
     special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
+  elsif platform.name =~ /sles-15/
+    # These platforms use the default OS toolchain, rather than pl-build-tools
+    cmake = "cmake"
+    toolchain = ""
+    special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
   elsif platform.is_cisco_wrlinux?
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -24,6 +24,9 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
     # We only need zlib because curl is dynamically linking against zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
+  elsif platform.name =~ /sles-15/
+    # These platforms use their default OS toolchain and have package
+    # dependencies configured in the platform provisioning step.
   else
     pkg.build_requires "pl-gcc"
   end

--- a/configs/platforms/sles-15-x86_64.rb
+++ b/configs/platforms/sles-15-x86_64.rb
@@ -1,0 +1,9 @@
+platform "sles-15-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc gcc-c++ make rpm-build libboost_atomic1_66_0-devel libboost_chrono1_66_0-devel libboost_container1_66_0-devel libboost_date_time1_66_0-devel libboost_filesystem1_66_0-devel libboost_graph1_66_0-devel libboost_iostreams1_66_0-devel libboost_locale1_66_0-devel libboost_log1_66_0-devel libboost_math1_66_0-devel libboost_program_options1_66_0-devel libboost_random1_66_0-devel libboost_regex1_66_0-devel libboost_serialization1_66_0-devel libboost_signals1_66_0-devel libboost_system1_66_0-devel libboost_test1_66_0-devel libboost_thread1_66_0-devel libboost_timer1_66_0-devel libboost_wave1_66_0-devel gettext-tools cmake yaml-cpp-devel"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-15-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -114,7 +114,7 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime"
+  proj.component "runtime" unless platform.name =~ /sles-15/
 
   # Windows doesn't need these wrappers, only unix platforms
   unless platform.is_windows?

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -24,6 +24,7 @@ foss_platforms:
   - sles-11-x86_64
   - sles-12-x86_64
   - sles-12-ppc64le
+  - sles-15-x86_64
   - ubuntu-14.04-amd64
   - ubuntu-14.04-i386
   - ubuntu-16.04-amd64
@@ -82,6 +83,8 @@ platform_repos:
     repo_location: repos/sles/12/**/x86_64
   - name: sles-12-ppc64le
     repo_location: repos/sles/12/**/ppc64le
+  - name: sles-15-x86_64
+    repo_location: repos/sles/15/**/x86_64
   - name: fedora-26-x86_64
     repo_location: repos/fedora/26/**/x86_64
   - name: fedora-27-x86_64


### PR DESCRIPTION
This platform is being built with the default OS toolchain, and doesn't
rely on pl-build-tools packages.