### PR TITLE
(PA-2158) Add el-7-ppc64 build support for 6.x

### DIFF
--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -30,7 +30,7 @@ component "runtime" do |pkg, settings, platform|
 
   if platform.is_cross_compiled?
     libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
-    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64le/
+    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64|ppc64le/
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/
     libdir = "/opt/pl-build-tools/lib"
   elsif platform.architecture =~ /64/

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -24,6 +24,8 @@ component "virt-what" do |pkg, settings, platform|
   if platform.is_linux?
     if platform.architecture =~ /ppc64le$/
       host_opt = '--host powerpc64le-unknown-linux-gnu'
+    elsif platform.architecture =~ /ppc64$/
+      host_opt = '--host powerpc64-unknown-linux-gnu'
     end
   end
 

--- a/configs/platforms/el-7-ppc64.rb
+++ b/configs/platforms/el-7-ppc64.rb
@@ -1,0 +1,12 @@
+platform "el-7-ppc64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/ppc64le/pl-build-tools-ppc64le.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.cross_compiled true
+  plat.vmpooler_template "redhat-7-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -110,7 +110,7 @@ project "puppet-agent" do |proj|
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"
-    proj.component "dmidecode" unless platform.architecture =~ /ppc64(?:le|el)/
+    proj.component "dmidecode" unless platform.architecture =~ /ppc64(?:le|el)/ || platform.architecture == "ppc64"
     proj.component "shellpath"
   end
 


### PR DESCRIPTION
Hello,

This patch adds support for RHEL 7 on big-endian powerpc systems. In particular,
this has been built for a POWER8 environment running RHEL 7.5. Changes are
focused on adding the ppc64 architecture to various locations in the config
files which explicitly check for ppc64le instead.

Note that I do not run any instances of the 6.x series agent in my environment
as the series has yet to be released officially, however, it does build successfully.

I also have a set of similar changes available for the 5.5.x branch - should I create a separate pull request for those as well?

This request is related to both of the following requests:
* [puppet-runtime](https://github.com/puppetlabs/puppet-runtime/pull/93)
* [pl-build-tools-vanagon](https://github.com/puppetlabs/pl-build-tools-vanagon/pull/56)

Thanks!
Phil