### PR TITLE
(PA-619) open puppet command prompt in puppet appdata dir

### DIFF
--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -57,7 +57,7 @@
           Target="[%ComSpec]"
           Arguments='/E:ON /K "[INSTALLDIR]bin\puppet_shell.bat"'
           Icon="PuppetShellShortcutIcon"
-          WorkingDirectory="bin">
+          WorkingDirectory="APPDATADIR">
           <Icon
             Id="PuppetShellShortcutIcon"
             SourceFile="wix\icon\puppet.ico"/>


### PR DESCRIPTION
This commit updates the script used for "Start Command Prompt with Puppet" to
start in the appdata directory rather than C:\Windows\system32 (which is
where the script would start by default with no changes)