### PR TITLE
(maint) SHA/tag pinning for 6.0.0

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "c710b8cd407339f7f6f3215028fc51cf50695f06"}
+{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.2.0"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/hiera.git","ref":"e3ad877a8b7de1dc6af5430fcb7f396b9222492a"}
+{"url":"git://github.com/puppetlabs/hiera.git","ref":"715ae4039e4cc7d248ccd9a1cf74c65d8b7f6226"}

--- a/configs/components/libwhereami.json
+++ b/configs/components/libwhereami.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/libwhereami.git","ref":"61624edb4ef4132ccf206ee4b81db715bb1a356a"}
+{"url":"git://github.com/puppetlabs/libwhereami.git","ref":"refs/tags/0.2.2"}

--- a/configs/components/rubygem-puppet-resource_api.json
+++ b/configs/components/rubygem-puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"55f8851ec840785f34844a9eb00ddcf1483fdc15"}
+{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.5.0"}


### PR DESCRIPTION
This cleans up a few things that were still pointed to master branches
instead of the older branches that we'd decided to stick with for
6.0.0.