### PR TITLE
(packaging) Pin puppet for 6.0.0 release

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"42c5a1b4684c598996774c18e4b3cec3e4333367"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"06ad255754a38f22fb3a22c7c4f1e2ce453d01cb"}


### PR DESCRIPTION
We had one change land late that we're not comfortable with the risk
of shipping untested. We're pinning back to just before that change.