### PR TITLE
(PA-2158) Add el-7-ppc64 build support for 5.5.x

### DIFF
--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -33,7 +33,7 @@ component "runtime" do |pkg, settings, platform|
 
   if platform.is_cross_compiled?
     libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
-    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64le/
+    libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|s390x|ppc64/
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/
     libdir = "/opt/pl-build-tools/lib"
   elsif platform.architecture =~ /64/

--- a/configs/components/virt-what.rb
+++ b/configs/components/virt-what.rb
@@ -24,6 +24,8 @@ component "virt-what" do |pkg, settings, platform|
   if platform.is_linux?
     if platform.architecture =~ /ppc64le$/
       host_opt = '--host powerpc64le-unknown-linux-gnu'
+    elsif platform.architecture =~ /ppc64$/
+      host_opt = '--host powerpc64-unknown-linux-gnu'
     end
   end
 

--- a/configs/platforms/el-7-ppc64.rb
+++ b/configs/platforms/el-7-ppc64.rb
@@ -1,0 +1,14 @@
+platform "el-7-ppc64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/ppc64/pl-build-tools-ppc64.repo"
+  #plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
+
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+
+  plat.cross_compiled true
+  plat.vmpooler_template "redhat-7-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -107,7 +107,7 @@ project "puppet-agent" do |proj|
   # These utilites don't really work on unix
   if platform.is_linux?
     proj.component "virt-what"
-    proj.component "dmidecode" unless platform.architecture =~ /ppc64(?:le|el)/
+    proj.component "dmidecode" unless platform.architecture =~ /ppc64/
     proj.component "shellpath"
   end
 

--- a/resources/files/ruby_243/rbconfig/rbconfig-ppc64-redhat-linux.rb
+++ b/resources/files/ruby_243/rbconfig/rbconfig-ppc64-redhat-linux.rb
@@ -1,0 +1,313 @@
+# encoding: ascii-8bit
+# frozen-string-literal: false
+#
+# The module storing Ruby interpreter configurations on building.
+#
+# This file was created from a native ruby build on a RHEL 7.3 ppc64 system.
+# It contains build information for ruby which is used e.g. by mkmf to build
+# compatible native extensions.  Any changes made to this file will be
+# lost the next time ruby is built.
+
+module RbConfig
+  RUBY_VERSION.start_with?("2.4.") or
+    raise "ruby lib version (2.4.3) doesn't match executable version (#{RUBY_VERSION})"
+
+  # Ruby installed directory.
+  TOPDIR = File.dirname(__FILE__).chomp!("/lib/ruby/2.4.0/powerpc64-linux")
+  # DESTDIR on make install.
+  DESTDIR = '' unless defined? DESTDIR
+  # The hash configurations stored.
+  CONFIG = {}
+  CONFIG["DESTDIR"] = DESTDIR
+  CONFIG["MAJOR"] = "2"
+  CONFIG["MINOR"] = "4"
+  CONFIG["TEENY"] = "3"
+  CONFIG["PATCHLEVEL"] = "205"
+  CONFIG["INSTALL"] = '/usr/bin/install -c'
+  CONFIG["EXEEXT"] = ""
+  CONFIG["prefix"] = (TOPDIR || DESTDIR + "/opt/puppetlabs/puppet")
+  CONFIG["ruby_install_name"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_INSTALL_NAME"] = "$(RUBY_BASE_NAME)"
+  CONFIG["RUBY_SO_NAME"] = "$(RUBY_BASE_NAME)"
+  CONFIG["exec"] = "exec"
+  CONFIG["ruby_pc"] = "ruby-2.4.pc"
+  CONFIG["PACKAGE"] = "ruby"
+  CONFIG["BUILTIN_TRANSSRCS"] = " enc/trans/newline.c"
+  CONFIG["USE_RUBYGEMS"] = "YES"
+  CONFIG["MANTYPE"] = "doc"
+  CONFIG["NROFF"] = "/usr/bin/nroff"
+  CONFIG["vendorarchhdrdir"] = "$(vendorhdrdir)/$(sitearch)"
+  CONFIG["sitearchhdrdir"] = "$(sitehdrdir)/$(sitearch)"
+  CONFIG["rubyarchhdrdir"] = "$(rubyhdrdir)/$(arch)"
+  CONFIG["vendorhdrdir"] = "$(rubyhdrdir)/vendor_ruby"
+  CONFIG["sitehdrdir"] = "$(rubyhdrdir)/site_ruby"
+  CONFIG["rubyhdrdir"] = "$(includedir)/$(RUBY_VERSION_NAME)"
+  CONFIG["RUBY_SEARCH_PATH"] = ""
+  CONFIG["UNIVERSAL_INTS"] = ""
+  CONFIG["UNIVERSAL_ARCHNAMES"] = ""
+  CONFIG["configure_args"] = " '--prefix=/opt/puppetlabs/puppet' '--with-opt-dir=/opt/puppetlabs/puppet' '--enable-shared' '--enable-bundled-libyaml' '--disable-install-doc' '--disable-install-rdoc'"
+  CONFIG["CONFIGURE"] = "configure"
+  CONFIG["vendorarchdir"] = "$(vendorlibdir)/$(sitearch)"
+  CONFIG["vendorlibdir"] = "$(vendordir)/$(ruby_version)"
+  CONFIG["vendordir"] = "$(rubylibprefix)/vendor_ruby"
+  CONFIG["sitearchdir"] = "$(sitelibdir)/$(sitearch)"
+  CONFIG["sitelibdir"] = "$(sitedir)/$(ruby_version)"
+  CONFIG["sitedir"] = "$(rubylibprefix)/site_ruby"
+  CONFIG["rubyarchdir"] = "$(rubylibdir)/$(arch)"
+  CONFIG["rubylibdir"] = "$(rubylibprefix)/$(ruby_version)"
+  CONFIG["ruby_version"] = "2.4.0"
+  CONFIG["sitearch"] = "$(arch)"
+  CONFIG["arch"] = "powerpc64-linux"
+  CONFIG["sitearchincludedir"] = "$(includedir)/$(sitearch)"
+  CONFIG["archincludedir"] = "$(includedir)/$(arch)"
+  CONFIG["sitearchlibdir"] = "$(libdir)/$(sitearch)"
+  CONFIG["archlibdir"] = "$(libdir)/$(arch)"
+  CONFIG["libdirname"] = "libdir"
+  CONFIG["RUBY_EXEC_PREFIX"] = "/opt/puppetlabs/puppet"
+  CONFIG["RUBY_LIB_VERSION"] = ""
+  CONFIG["RUBY_LIB_VERSION_STYLE"] = "3\t/* full */"
+  CONFIG["RI_BASE_NAME"] = "ri"
+  CONFIG["ridir"] = "$(datarootdir)/$(RI_BASE_NAME)"
+  CONFIG["rubysitearchprefix"] = "$(rubylibprefix)/$(sitearch)"
+  CONFIG["rubyarchprefix"] = "$(rubylibprefix)/$(arch)"
+  CONFIG["MAKEFILES"] = "Makefile GNUmakefile"
+  CONFIG["PLATFORM_DIR"] = ""
+  CONFIG["THREAD_MODEL"] = "pthread"
+  CONFIG["SYMBOL_PREFIX"] = ""
+  CONFIG["EXPORT_PREFIX"] = ""
+  CONFIG["COMMON_HEADERS"] = ""
+  CONFIG["COMMON_MACROS"] = ""
+  CONFIG["COMMON_LIBS"] = ""
+  CONFIG["MAINLIBS"] = ""
+  CONFIG["ENABLE_SHARED"] = "yes"
+  CONFIG["DLDLIBS"] = " -lc"
+  CONFIG["SOLIBS"] = "$(LIBS)"
+  CONFIG["LIBRUBYARG_SHARED"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)"
+  CONFIG["LIBRUBYARG_STATIC"] = "-Wl,-R$(libdir) -L$(libdir) -l$(RUBY_SO_NAME)-static"
+  CONFIG["LIBRUBYARG"] = "$(LIBRUBYARG_SHARED)"
+  CONFIG["LIBRUBY"] = "$(LIBRUBY_SO)"
+  CONFIG["LIBRUBY_ALIASES"] = "lib$(RUBY_SO_NAME).so.$(MAJOR).$(MINOR) lib$(RUBY_SO_NAME).so"
+  CONFIG["LIBRUBY_SO"] = "lib$(RUBY_SO_NAME).so.$(RUBY_PROGRAM_VERSION)"
+  CONFIG["LIBRUBY_A"] = "lib$(RUBY_SO_NAME)-static.a"
+  CONFIG["RUBYW_INSTALL_NAME"] = ""
+  CONFIG["rubyw_install_name"] = ""
+  CONFIG["EXTDLDFLAGS"] = ""
+  CONFIG["EXTLDFLAGS"] = ""
+  CONFIG["strict_warnflags"] = "-std=gnu99"
+  CONFIG["warnflags"] = "-Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wno-tautological-compare -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-self-assign -Wunused-variable -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -Wsuggest-attribute=noreturn -Wsuggest-attribute=format"
+  CONFIG["debugflags"] = "-ggdb3"
+  CONFIG["optflags"] = "-O3 -fno-fast-math"
+  CONFIG["NULLCMD"] = ":"
+  CONFIG["DLNOBJ"] = "dln.o"
+  CONFIG["INSTALL_STATIC_LIBRARY"] = "no"
+  CONFIG["EXECUTABLE_EXTS"] = ""
+  CONFIG["ARCHFILE"] = ""
+  CONFIG["LIBRUBY_RELATIVE"] = "no"
+  CONFIG["EXTOUT"] = ".ext"
+  CONFIG["PREP"] = "miniruby$(EXEEXT)"
+  CONFIG["CROSS_COMPILING"] = "no"
+  CONFIG["TEST_RUNNABLE"] = "yes"
+  CONFIG["rubylibprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"
+  CONFIG["setup"] = "Setup"
+  CONFIG["ENCSTATIC"] = ""
+  CONFIG["EXTSTATIC"] = ""
+  CONFIG["STRIP"] = "strip -S -x"
+  CONFIG["TRY_LINK"] = ""
+  CONFIG["PRELOADENV"] = "LD_PRELOAD"
+  CONFIG["LIBPATHENV"] = "LD_LIBRARY_PATH"
+  CONFIG["RPATHFLAG"] = " -Wl,-R%1$-s"
+  CONFIG["LIBPATHFLAG"] = " -L%1$-s"
+  CONFIG["LINK_SO"] = ""
+  CONFIG["ASMEXT"] = "S"
+  CONFIG["LIBEXT"] = "a"
+  CONFIG["DLEXT2"] = ""
+  CONFIG["DLEXT"] = "so"
+  CONFIG["LDSHAREDXX"] = "$(CXX) -shared"
+  CONFIG["LDSHARED"] = "$(CC) -shared"
+  CONFIG["CCDLFLAGS"] = "-fPIC"
+  CONFIG["STATIC"] = ""
+  CONFIG["ARCH_FLAG"] = ""
+  CONFIG["DLDFLAGS"] = "-L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
+  CONFIG["ALLOCA"] = ""
+  CONFIG["codesign"] = ""
+  CONFIG["POSTLINK"] = ":"
+  CONFIG["WERRORFLAG"] = "-Werror"
+  CONFIG["CHDIR"] = "cd -P"
+  CONFIG["RMALL"] = "rm -fr"
+  CONFIG["RMDIRS"] = "rmdir --ignore-fail-on-non-empty -p"
+  CONFIG["RMDIR"] = "rmdir --ignore-fail-on-non-empty"
+  CONFIG["CP"] = "cp"
+  CONFIG["RM"] = "rm -f"
+  CONFIG["PKG_CONFIG"] = "pkg-config"
+  CONFIG["PYTHON"] = ""
+  CONFIG["DOXYGEN"] = ""
+  CONFIG["DOT"] = ""
+  CONFIG["MAKEDIRS"] = "/usr/bin/mkdir -p"
+  CONFIG["MKDIR_P"] = "/usr/bin/mkdir -p"
+  CONFIG["INSTALL_DATA"] = "$(INSTALL) -m 644"
+  CONFIG["INSTALL_SCRIPT"] = "$(INSTALL)"
+  CONFIG["INSTALL_PROGRAM"] = "$(INSTALL)"
+  CONFIG["SET_MAKE"] = ""
+  CONFIG["LN_S"] = "ln -s"
+  CONFIG["NM"] = "nm"
+  CONFIG["DLLWRAP"] = ""
+  CONFIG["WINDRES"] = ""
+  CONFIG["OBJCOPY"] = ":"
+  CONFIG["OBJDUMP"] = "objdump"
+  CONFIG["ASFLAGS"] = ""
+  CONFIG["AS"] = "as"
+  CONFIG["ARFLAGS"] = "rcD "
+  CONFIG["AR"] = "ar"
+  CONFIG["RANLIB"] = "ranlib"
+  CONFIG["try_header"] = ""
+  CONFIG["CC_VERSION_MESSAGE"] = "gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16)\nCopyright (C) 2015 Free Software Foundation, Inc.\nThis is free software; see the source for copying conditions.  There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+  CONFIG["CC_VERSION"] = "$(CC) --version"
+  CONFIG["CSRCFLAG"] = ""
+  CONFIG["COUTFLAG"] = "-o "
+  CONFIG["OUTFLAG"] = "-o "
+  CONFIG["CPPOUTFILE"] = "-o conftest.i"
+  CONFIG["GNU_LD"] = "yes"
+  CONFIG["LD"] = "ld"
+  CONFIG["GCC"] = "yes"
+  CONFIG["EGREP"] = "/usr/bin/grep -E"
+  CONFIG["GREP"] = "/usr/bin/grep"
+  CONFIG["CPP"] = "$(CC) -E"
+  CONFIG["CXXFLAGS"] = "$(cxxflags)"
+  CONFIG["OBJEXT"] = "o"
+  CONFIG["CPPFLAGS"] = " -I/opt/puppetlabs/puppet/include $(DEFS) $(cppflags)"
+  CONFIG["LDFLAGS"] = "-L. -fstack-protector -rdynamic -Wl,-export-dynamic -L/opt/puppetlabs/puppet/lib  -Wl,-R/opt/puppetlabs/puppet/lib"
+  CONFIG["CFLAGS"] = "$(cflags)  -fPIC"
+  CONFIG["CXX"] = "g++"
+  CONFIG["CC"] = "gcc"
+  CONFIG["NACL_LIB_PATH"] = ""
+  CONFIG["NACL_SDK_VARIANT"] = ""
+  CONFIG["NACL_SDK_ROOT"] = ""
+  CONFIG["NACL_TOOLCHAIN"] = ""
+  CONFIG["target_os"] = "linux"
+  CONFIG["target_vendor"] = "unknown"
+  CONFIG["target_cpu"] = "powerpc64"
+  CONFIG["target"] = "powerpc64-redhat-linux-gnu"
+  CONFIG["host_os"] = "linux-gnu"
+  CONFIG["host_vendor"] = "unknown"
+  CONFIG["host_cpu"] = "powerpc64"
+  CONFIG["host"] = "powerpc64-redhat-linux-gnu"
+  CONFIG["RUBY_VERSION_NAME"] = "$(RUBY_BASE_NAME)-$(ruby_version)"
+  CONFIG["RUBYW_BASE_NAME"] = "rubyw"
+  CONFIG["RUBY_BASE_NAME"] = "ruby"
+  CONFIG["build_os"] = "linux-gnu"
+  CONFIG["build_vendor"] = "unknown"
+  CONFIG["build_cpu"] = "powerpc64"
+  CONFIG["build"] = "powerpc64-redhat-linux-gnu"
+  CONFIG["RUBY_PROGRAM_VERSION"] = "2.4.3"
+  CONFIG["cxxflags"] = "$(optflags) $(debugflags) $(warnflags)"
+  CONFIG["cppflags"] = ""
+  CONFIG["cflags"] = "$(optflags) $(debugflags) $(warnflags)"
+  CONFIG["target_alias"] = ""
+  CONFIG["host_alias"] = ""
+  CONFIG["build_alias"] = ""
+  CONFIG["LIBS"] = "-lpthread -ldl -lcrypt -lm "
+  CONFIG["ECHO_T"] = ""
+  CONFIG["ECHO_N"] = "-n"
+  CONFIG["ECHO_C"] = ""
+  CONFIG["DEFS"] = ""
+  CONFIG["mandir"] = "$(datarootdir)/man"
+  CONFIG["localedir"] = "$(datarootdir)/locale"
+  CONFIG["libdir"] = "$(exec_prefix)/lib"
+  CONFIG["psdir"] = "$(docdir)"
+  CONFIG["pdfdir"] = "$(docdir)"
+  CONFIG["dvidir"] = "$(docdir)"
+  CONFIG["htmldir"] = "$(docdir)"
+  CONFIG["infodir"] = "$(datarootdir)/info"
+  CONFIG["docdir"] = "$(datarootdir)/doc/$(PACKAGE)"
+  CONFIG["oldincludedir"] = "/usr/include"
+  CONFIG["includedir"] = "$(prefix)/include"
+  CONFIG["localstatedir"] = "$(prefix)/var"
+  CONFIG["sharedstatedir"] = "$(prefix)/com"
+  CONFIG["sysconfdir"] = "$(prefix)/etc"
+  CONFIG["datadir"] = "$(datarootdir)"
+  CONFIG["datarootdir"] = "$(prefix)/share"
+  CONFIG["libexecdir"] = "$(exec_prefix)/libexec"
+  CONFIG["sbindir"] = "$(exec_prefix)/sbin"
+  CONFIG["bindir"] = "$(exec_prefix)/bin"
+  CONFIG["exec_prefix"] = "$(prefix)"
+  CONFIG["PACKAGE_URL"] = ""
+  CONFIG["PACKAGE_BUGREPORT"] = ""
+  CONFIG["PACKAGE_STRING"] = ""
+  CONFIG["PACKAGE_VERSION"] = ""
+  CONFIG["PACKAGE_TARNAME"] = ""
+  CONFIG["PACKAGE_NAME"] = ""
+  CONFIG["PATH_SEPARATOR"] = ":"
+  CONFIG["SHELL"] = "/bin/sh"
+  CONFIG["UNICODE_VERSION"] = "9.0.0"
+  CONFIG["archdir"] = "$(rubyarchdir)"
+  CONFIG["topdir"] = File.dirname(__FILE__)
+  # Almost same with CONFIG. MAKEFILE_CONFIG has other variable
+  # reference like below.
+  #
+  #   MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
+  #
+  # The values of this constant is used for creating Makefile.
+  #
+  #   require 'rbconfig'
+  #
+  #   print <<-END_OF_MAKEFILE
+  #   prefix = #{Config::MAKEFILE_CONFIG['prefix']}
+  #   exec_prefix = #{Config::MAKEFILE_CONFIG['exec_prefix']}
+  #   bindir = #{Config::MAKEFILE_CONFIG['bindir']}
+  #   END_OF_MAKEFILE
+  #
+  #   => prefix = /usr/local
+  #      exec_prefix = $(prefix)
+  #      bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
+  #
+  # RbConfig.expand is used for resolving references like above in rbconfig.
+  #
+  #   require 'rbconfig'
+  #   p Config.expand(Config::MAKEFILE_CONFIG["bindir"])
+  #   # => "/usr/local/bin"
+  MAKEFILE_CONFIG = {}
+  CONFIG.each{|k,v| MAKEFILE_CONFIG[k] = v.dup}
+
+  # call-seq:
+  #
+  #   RbConfig.expand(val)         -> string
+  #   RbConfig.expand(val, config) -> string
+  #
+  # expands variable with given +val+ value.
+  #
+  #   RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
+  def RbConfig::expand(val, config = CONFIG)
+    newval = val.gsub(/\$\$|\$\(([^()]+)\)|\$\{([^{}]+)\}/) {
+      var = $&
+      if !(v = $1 || $2)
+	'$'
+      elsif key = config[v = v[/\A[^:]+(?=(?::(.*?)=(.*))?\z)/]]
+	pat, sub = $1, $2
+	config[v] = false
+	config[v] = RbConfig::expand(key, config)
+	key = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
+	key
+      else
+	var
+      end
+    }
+    val.replace(newval) unless newval == val
+    val
+  end
+  CONFIG.each_value do |val|
+    RbConfig::expand(val)
+  end
+
+  # call-seq:
+  #
+  #   RbConfig.ruby -> path
+  #
+  # returns the absolute pathname of the ruby command.
+  def RbConfig.ruby
+    File.join(
+      RbConfig::CONFIG["bindir"],
+      RbConfig::CONFIG["ruby_install_name"] + RbConfig::CONFIG["EXEEXT"]
+    )
+  end
+end
+CROSS_COMPILING = nil unless defined? CROSS_COMPILING


### PR DESCRIPTION
This patch adds support for RHEL 7 on big-endian powerpc systems. In particular, it has been built for a POWER8 environment running RHEL 7.5. Changes are focused on including ppc64 in all areas of the config which currently target ppc64le.

This is an alternative to #1524. @ScottGarman I reworked my original 5.5.x changes into a clean commit instead of rebasing my other branch that targeted 6.x.

Thanks,
Phil
