### PR TITLE
(maint) Mark platforms which are community-supported

### DIFF
--- a/configs/platforms/debian-8-armel.rb
+++ b/configs/platforms/debian-8-armel.rb
@@ -1,4 +1,6 @@
 platform "debian-8-armel" do |plat|
+  # Note: This is a community-maintained platform. It is not tested in Puppet's
+  # CI pipelines, and does not receive official releases.
   plat.servicedir "/lib/systemd/system"
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"

--- a/configs/platforms/debian-8-armhf.rb
+++ b/configs/platforms/debian-8-armhf.rb
@@ -1,4 +1,6 @@
 platform "debian-8-armhf" do |plat|
+  # Note: This is a community-maintained platform. It is not tested in Puppet's
+  # CI pipelines, and does not receive official releases.
   plat.servicedir "/lib/systemd/system"
   plat.defaultdir "/etc/default"
   plat.servicetype "systemd"

--- a/configs/platforms/el-7-s390.rb
+++ b/configs/platforms/el-7-s390.rb
@@ -1,4 +1,6 @@
 platform "el-7-s390" do |plat|
+  # Note: This is a community-maintained platform. It is not tested in Puppet's
+  # CI pipelines, and does not receive official releases.
   plat.servicedir "/usr/lib/systemd/system"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"


### PR DESCRIPTION
Add a note to the platform config for community-supported OS platforms.

And yes, the "s390" platform was never officially supported, just the "s390x" ones.