### PR TITLE
(maint) Bump augeas_core module to 1.0.2

### DIFF
--- a/configs/components/module-puppetlabs-augeas_core.json
+++ b/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.0.1"}
+{"url":"git://github.com/puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.0.2"}


### PR DESCRIPTION
PUP-9112 changed :undef/nil handling in puppet6, which broke the augeas
provider. This was fixed in MODULES-7814, so bump the module to 1.0.2.