### PR TITLE
(PA-2241) Rewrite the pxp-agent service's AppExit configuration

### DIFF
--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -58,10 +58,12 @@
                         Value="1"
                         Type="integer" />
           <RegistryKey Key="AppExit">
-            <!-- Stop the service completely on exit(2) (Invalid configuration) otherwise restart with NSSM service throttling -->
+            <!-- Restart the service on an exit code of 1 since that will likely  -->
+            <!-- correspond to a crash or an unexpected failure. Stop the service -->
+            <!-- for all other exit codes. -->
             <!-- nssm AppExit codes reference https://nssm.cc/usage#exit -->
-            <RegistryValue Value="Restart" Type="string" />
-            <RegistryValue Name="2" Value="Exit" Type="string" />
+            <RegistryValue Value="Exit" Type="string" />
+            <RegistryValue Name="1" Value="Restart" Type="string" />
           </RegistryKey>
         </RegistryKey>
         <ServiceControl Id="PXPStartService"


### PR DESCRIPTION
Previously, NSSM would restart the pxp-agent service if it fails
for any other reason besides an invalid service configuration.
If the failure happens when the service is starting up, then
there's a chance that the restart is stuck in an infinite loop.
We've seen this happen in Puppet 6.

This commit configures NSSM to restart the service on an exit code
of 1, and stop for all other exit codes. An exit code of 1 likely
corresponds to a crash or an unexpected failure, so restarting the
service here makes sense. The other exit codes correspond to failures
in the setup, so stopping the service for those exit codes also makes
sense. Note that pxp-agent returned an exit code of 3 during the
infinite loop scenario, so the changes here should fix that.