### PR TITLE
(maint) Increase the clone depth to 150 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+git:
+  depth: 150
 language: ruby
 bundler_args: --without development
 before_script:


### PR DESCRIPTION
(maint) Increase the clone depth to 150 for Travis CI

The default clone depth of 50 can cause Travis CI to fail if more
than 50 commits of work have landed since the last tag. Many of the
commits in the puppet-agent repo correspond to automated component
promotions, so this threshold is a bit low. This commit increases
the clone depth to 150.