### PR TITLE
Delete any stale .pkg-old backups before making a new backup

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -273,14 +273,17 @@ component "puppet" do |pkg, settings, platform|
 # can drop them back in place if the package manager
 # tries to remove it.
 if [ -e #{old_hiera} ]; then
+  [ -e #{old_hiera}.pkg-old ] && rm -f #{old_hiera}.pkg-old
   #{cp_cmd} #{old_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi
 if [ -e #{cnf_hiera} ]; then
+  [ -e #{cnf_hiera}.pkg-old ] && rm -f #{cnf_hiera}.pkg-old
   #{cp_cmd} #{cnf_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi
 if [ -e #{env_hiera} ]; then
+  [ -e #{env_hiera}.pkg-old ] && rm -f #{env_hiera}.pkg-old
   #{cp_cmd} #{env_hiera}{,.pkg-old}
   touch #{rmv_hiera}
 fi


### PR DESCRIPTION
This is a small change to the RPM scripts to fix a small problem that bit me this morning.

Historically, our Puppet environment first existed using Hiera v3, we had it set up thus:
```
/etc/puppetlabs/code/environments/master/hiera.yaml
/etc/puppetlabs/code/hiera.yaml -> /etc/puppetlabs/code/environments/master/hiera.yaml
```
Each environment was a git checkout and we symlinked the global (read: only) Hiera configuration to the copy in the master branch. Recently I completed the upgrade to Hiera v5 (proper per-environment configuration 👍 ) so I replaced the above symlink and made the global configuration simply:
```yaml
---
version: 5
```
These changes got rolled out after the last time I updated the `puppet-agent` package and over this past weekend, it got updated again (to the latest 5.5.6 release). What I found was there was a stale symlink, presumably left over from a previous upgrade:
```
/etc/puppetlabs/code/hiera.yaml.pkg-old -> /etc/puppetlabs/code/environments/master/hiera.yaml
```
This matches our Hiera v3 setup as described above. Now what happened when `puppet-agent` was upgraded, instead of making a copy of `/etc/puppetlabs/code/hiera.yaml`, it followed the existing symlink and clobbered the per-environment configuration.

So this change simply deletes the `.pkg-old` backups if they exist before making a new copy. This should delete any stale copy leftover from a previous upgrade.

Obviously GNU `cp` has `--remove-destination` which would probably work however it seems this code might be used on non-GNU platforms so I did it the long way.
