### PR TITLE
(maint) Remove mco reference

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -126,11 +126,6 @@ public_binaries = {
   :win   => ['puppet.bat', 'facter.bat', 'hiera.bat']
 }
 
-if @options[:type] != 'git' then
-  public_binaries[:posix].concat ['mco']
-  public_binaries[:win].concat ['mco.bat']
-end
-
 def locations(platform, ruby_arch, type)
   if type == 'foss'
     return '/usr/bin'


### PR DESCRIPTION
The test was migrated from puppet to puppet-agent in 5.5.x, but we
removed mco in 6, so remove the expectation for those binaries.