### PR TITLE
(PUP-8351) Update bash wrappers to keep LD_LIBRARY_PATH with RHSCL

### DIFF
--- a/acceptance/tests/ensure_SCL_python_pip_works.rb
+++ b/acceptance/tests/ensure_SCL_python_pip_works.rb
@@ -1,0 +1,18 @@
+test_name 'PUP-8351: Ensure pip provider works with RHSCL python' do
+  confine :to, :platform => /centos-(6|7)/
+  tag 'audit:medium',
+      'audit:acceptance'
+
+  teardown do
+      on agent, 'yum remove python27-python-pip -y'
+  end
+
+  step 'install and enable RHSCL python' do
+    on agent, 'yum install centos-release-scl -y'
+    on agent, 'yum install python27-python-pip -y'
+  end
+
+  step 'With with the SCL python enabled: Attempt \'resource package\' with a python package and the pip provider' do
+    on(agent, 'source /opt/rh/python27/enable && puppet resource package vulture ensure=present provider=\'pip\'')
+  end
+end

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 
-unset LD_LIBRARY_PATH
+# We keep around any paths in LD_LIBRARY_PATH that start with /opt/rh/. Those paths are
+# from redhat software collections packages and are required for things like SCL python
+# to work. See PUP-8351.
+STRIP_LDLYP_COMMAND=" \
+if ENV['LD_LIBRARY_PATH']; \
+  print ENV['LD_LIBRARY_PATH'].split(':', -1).keep_if { |path| path.start_with?('/opt/rh/') }.join(':') \
+end"
+export LD_LIBRARY_PATH=$(/opt/puppetlabs/puppet/bin/ruby -e "$STRIP_LDLYP_COMMAND")
 unset LD_PRELOAD
 
 COMMAND=`basename "${0}"`


### PR DESCRIPTION
When users want to make use of python (and other tools) from the redhat
software collections, those packages _do_ require that the LD_LIBRARY_PATH be
set to include directories containing those packages.

Since we unset LD_LIBRARY_PATH we have broken any customer using RHSCL
packages. This commit updates the wrapper script for puppet and friends to
search through each existing path in LD_LIBRARY_PATH for any path that starts
with /opt/rh/ (the canonical place for these packages to be installed) and
keep those paths in LD_LIBRARY_PATH as puppet and friends' run