### PR TITLE
(maint) piddir not required on solaris

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -30,7 +30,7 @@ def setup_build_environment(agent)
   when /el-5/
     # PA-1638
     gem_install_sqlite3 += " -v 1.3.11"
-  when /solaris-11-i386/
+  when /solaris-11(.4|)-i386/
     # for some reason pkg install does not install developer/gcc-48 for sol 11, so need
     # to use the one provided by pl-build-tools instead.
     on(agent, "curl -O http://pl-build-tools.delivery.puppetlabs.net/solaris/11/sol-11-i386-compiler.tar.gz")

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -128,7 +128,7 @@ project "puppet-agent" do |proj|
   proj.directory proj.sysconfdir
   proj.directory proj.link_bindir
   proj.directory proj.logdir unless platform.is_windows?
-  proj.directory proj.piddir unless platform.is_windows?
+  proj.directory proj.piddir unless platform.is_windows? || platform.is_solaris?
   if platform.is_windows? || platform.is_macos?
     proj.directory proj.bindir
   end


### PR DESCRIPTION
Solaris uses SMF(https://www.oracle.com/technetwork/articles/servers-storage-admin/intro-smf-basics-s11-1729181.html) for managing services instead of the init script start-up mechanism. 
SMF does not require a PID files for managing a service.

If there is a helper script that requires a PID file and is passed to SMF instead of the application itself, the creation of the PID dir/file should be handled in the script. Example: https://github.com/puppetlabs/puppet/pull/7176/files#diff-6a024706b7725919079035ac75eb7621R29
this mechanism is similar as an init script for other platforms:
https://github.com/puppetlabs/pxp-agent/blob/master/ext/redhat/pxp-agent.init#L39
