### PR TITLE
(maint) Update puppet for PUP-9250 fix

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"3bf8d22a79b556f0534400bf31965adc073438f9"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"52686683542c504d0e4e91ded0f34cf6eebba217"}


### PR DESCRIPTION
This is a manual bump on the release branch for 5.5.7, to fix a ship-stopper bug.