### PR TITLE
(maint) Pin leatherman back to 1.5.2

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/leatherman.git","ref":"369fbd6f459e7f69a9f22b54234a9d3fea6b859d"}
+{"url":"git://github.com/puppetlabs/leatherman.git","ref":"refs/tags/1.5.2"}


### PR DESCRIPTION
1.5.2 was manually tagged, and the bump to 1.5.3 put up too quickly
afterwards. That meant that the no-promote version bump commit was run
through CI at the same time as the promotable code change, and was
pulled in since there was at least one not-no-promote commit in the
run.