### PR TITLE
(maint) Remove repo_link_target and nonfinal_repo_link_target params

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -139,7 +139,5 @@ apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
-repo_link_target: 'puppet'
-nonfinal_repo_link_target: 'puppet-nightly'
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
This commit removes the `repo_link_target` and `nonfinal_repo_link_target`
params from build_defaults. These params are used by the packaging repo to link
our rolling puppet repo to the latest repo. Since puppet6 is now the latest
repo, we need to remove this or else every time we ship, the puppet repo will
get linked back to puppet5.