### PR TITLE
(maint) Merge 5.3.x -> 5.5.x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -139,6 +139,5 @@ repo_name: 'puppet5'
 apt_repo_name: 'puppet5'
 yum_repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
-repo_link_target: 'puppet'
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
The conflict in configs/components/puppet.json was resolved by maintaining the
state of the current branch. The conflict in ext/build_defaults.yaml was
resolved by taking changes from 5.3.x.