### PR TITLE
(maint) Bump puppet-resource_api to 1.6.2

### DIFF
--- a/configs/components/rubygem-puppet-resource_api.json
+++ b/configs/components/rubygem-puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.6.0"}
+{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.6.2"}


### PR DESCRIPTION
This commit updates the embedded resource_api dependency to the latest
released version.