### PR TITLE
(maint) fix regex to allow for build numbers other than 1

### DIFF
--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -75,7 +75,7 @@ function start_puppetdb() {
   on_master ${master_vm} "puppet agent -t"
   local exit_code="$?"
   set -e
-  if [[ ! "${exit_code}" = 2 && ! "${exit_code}" = 0 ]]; then
+  if [[ "${exit_code}" -ne 2 && "${exit_code}" -ne 0 ]]; then
     echo "Failed to start-up PuppetDB on ${which_master}!"
     echo "Exiting the script with a failure ..."
     exit 1
@@ -108,9 +108,9 @@ function install_puppetdb_from_module() {
   # puppet agent -t returns an exit code of 2 if changes are successfully applied
   set +e
   on_master ${master_vm} "puppet agent -t"
+  local exit_code="$?"
   set -e
-  exited="$?"
-  if [[ "$exited" -ne 2 && "$exited" -ne 0 ]]; then
+  if [[ "${exit_code}" -ne 2 && "${exit_code}" -ne 0 ]]; then
     echo "Failed to install PuppetDB from the module on ${which_master}!"
     echo "Exiting the script with a failure ..."
     exit 1

--- a/ext/smoke/repos/steps/setup-masters.sh
+++ b/ext/smoke/repos/steps/setup-masters.sh
@@ -55,8 +55,8 @@ for master_vm in ${master_vm1} ${master_vm2}; do
   on_master ${master_vm} "puppet resource service puppetserver ensure=running"
   set +e
   on_master ${master_vm} "puppet agent -t"
-  set -e
   exitcode=$?
+  set -e
   if [[ "$exitcode" -ne 0 && "$exitcode" -ne 2 ]]; then
     echo "FAILED to run puppet on master"
     exit 1
@@ -89,13 +89,15 @@ done
 for master_vm in ${master_vm1} ${master_vm2}; do
   which_master=`identify_master ${master_vm}`
   SEMANTIC_VERSION_RE="[0-9]+\.[0-9]+\.[0-9]+"
-  REQUIRED_PACKAGES="${collection}-release-${SEMANTIC_VERSION_RE}-1.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-1\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-1\.el7\.noarch"
+  REQUIRED_PACKAGES="${collection}-release-${SEMANTIC_VERSION_RE}-[0-9]+\.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-[0-9]+\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-[0-9]+\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-[0-9]+\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-[0-9]+\.el7\.noarch"
 
   echo "STEP: Verify that the required puppet packages are installed on ${which_master}!"
   grep_results=`on_master "${master_vm}" "rpm -qa | grep puppet"`
   for required_package in  ${REQUIRED_PACKAGES}; do
 
+    set +e
     concrete_package=`echo "${grep_results}" | grep -E  "${required_package}"`
+    set -e
     if [[ -n "${concrete_package}" ]]; then
       echo "The required puppet package is present on ${which_master} as ${concrete_package}!"
     else

--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -79,8 +79,8 @@ echo ""
 echo "STEP: Run puppet to get the catalog"
 set +e
 on_agent "puppet agent -t"
-set -e
 exitcode=$?
+set -e
 if [[ "$exitcode" = 0 || "$exitcode" = 2 ]]; then
   echo "Successfully set-up the agent VM!"
 else


### PR DESCRIPTION
Also move some exit status captures to be adjacent to the command of interest,
and make some exit code processing consistent.