### PR TITLE
(maint) Use beaker 4 by default in acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,8 +12,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.34')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 0.13')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem "rake", "~> 10.1"


### PR DESCRIPTION
These versions reflect what's being used in CI now.