### PR TITLE
(MODULES-8255) switch vendored module git urls from git to https

### DIFF
--- a/configs/components/module-puppetlabs-augeas_core.json
+++ b/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.0.4"}
+{"url":"https://github.com/puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.0.4"}

--- a/configs/components/module-puppetlabs-cron_core.json
+++ b/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.2"}
+{"url":"https://github.com/puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.2"}

--- a/configs/components/module-puppetlabs-host_core.json
+++ b/configs/components/module-puppetlabs-host_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.2"}
+{"url":"https://github.com/puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.2"}

--- a/configs/components/module-puppetlabs-mount_core.json
+++ b/configs/components/module-puppetlabs-mount_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.2"}
+{"url":"https://github.com/puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.2"}

--- a/configs/components/module-puppetlabs-scheduled_task.json
+++ b/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}
+{"url":"https://github.com/puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}

--- a/configs/components/module-puppetlabs-selinux_core.json
+++ b/configs/components/module-puppetlabs-selinux_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.0.1"}
+{"url":"https://github.com/puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.0.1"}

--- a/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/1.0.2"}
+{"url":"https://github.com/puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/1.0.2"}

--- a/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.3"}
+{"url":"https://github.com/puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.3"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.0.1"}
+{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.0.1"}

--- a/configs/components/module-puppetlabs-zone_core.json
+++ b/configs/components/module-puppetlabs-zone_core.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/1.0.1"}
+{"url":"https://github.com/puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/1.0.1"}


### PR DESCRIPTION
git:// urls use the default git protocol and are plaintext. To increase
the security during builds, I am switching it to https. This prodives
transport encryption and makes man in the middle attacks harder. The PR
is related to https://tickets.puppetlabs.com/browse/MODULES-8255 but
does not completely resolve it.