### PR TITLE
Revert "(maint) Use yum to install build/test dependencies on AIX"

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -8,7 +8,7 @@ def package_installer(agent)
   # need to manually set up the package installer for these platforms.
   case agent['platform']
   when /aix/
-    lambda { |package| on(agent, "yum install -y #{package}") }
+    lambda { |package| on(agent, "rpm -Uvh #{package}") }
   when /solaris-10/
     lambda { |package| on(agent, "opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf  -y -i #{package}") }
   else
@@ -106,7 +106,15 @@ def install_dependencies(agent)
     'yum' => ['gcc', 'make', 'sqlite-devel'],
     'zypper' => ['gcc', 'sqlite3-devel'],
     'opt/csw/bin/pkgutil' => ['sqlite3', 'libsqlite3_dev'],
-    'rpm' => [ 'gcc', 'pkg-config', 'info', 'readline', 'readline-devel', 'sqlite', 'sqlite-devel']
+    'rpm' => [
+      'http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/pl-gcc-5.2.0-11.aix6.1.ppc.rpm',
+      'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/pkg-config-0.19-6.aix5.2.ppc.rpm',
+      'http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/info-4.6-1.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/readline/readline-7.0-3.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/readline/readline-devel-7.0-3.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/sqlite/sqlite-3.20.0-1.aix5.1.ppc.rpm',
+      'http://www.oss4aix.org/download/RPMS/sqlite/sqlite-devel-3.20.0-1.aix5.1.ppc.rpm'
+    ]
   }
 
   provider = dependencies.keys.find do |_provider|

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -21,6 +21,9 @@ component "cpp-pcp-client" do |pkg, settings, platform|
   boost_static_flag = "-DBOOST_STATIC=ON"
 
   if platform.is_aix?
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
     # This should be moved to the toolchain file
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
   elsif platform.is_macos?

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -42,7 +42,9 @@ component "facter" do |pkg, settings, platform|
   elsif platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
   elsif platform.is_aix?
-    #
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
   elsif platform.name =~ /sles-15/

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -14,7 +14,10 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "pl-boost-#{platform.architecture}"
     pkg.build_requires "pl-cmake"
   elsif platform.is_aix?
-    #
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-boost-1.58.0-7.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "cmake"
     pkg.build_requires "pl-toolchain-#{platform.architecture}"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -11,7 +11,7 @@ component "puppet" do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.is_aix?
-    #
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
   elsif platform.name =~ /sles-15/
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.
@@ -108,8 +108,6 @@ component "puppet" do |pkg, settings, platform|
   unless platform.is_solaris?
     if platform.is_windows?
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
-    elsif platform.is_aix?
-      msgfmt = "/opt/freeware/bin/msgfmt"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
     elsif platform.name =~ /sles-15/

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -26,7 +26,8 @@ component "pxp-agent" do |pkg, settings, platform|
   special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} "
 
   if platform.is_aix?
-    #
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-cmake-3.2.3-2.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -15,6 +15,7 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc-#{platform.architecture}"
     pkg.build_requires "pl-binutils-#{platform.architecture}"
   elsif platform.is_aix?
+    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_windows?
     pkg.build_requires "pl-gdbm-#{platform.architecture}"

--- a/configs/platforms/aix-6.1-ppc.rb
+++ b/configs/platforms/aix-6.1-ppc.rb
@@ -3,30 +3,18 @@ platform "aix-6.1-ppc" do |plat|
 
   plat.make "gmake"
   plat.tar "/opt/freeware/bin/tar"
-  plat.rpmbuild "/usr/bin/rpmbuild"
+  plat.rpmbuild "/usr/bin/rpm"
   plat.patch "/opt/freeware/bin/patch"
-  plat.mktemp "/opt/freeware/bin/mktemp --directory --tmpdir=/var/tmp"
-  os_version = 6.1
-  plat.environment "CC", "/opt/pl-build-tools/bin/gcc"
 
-  # Bootstrap yum
-  plat.provision_with "curl -O http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/rpm.rte && installp -acXYgd . rpm.rte all"
-  plat.provision_with "curl http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/openssl-1.0.2.1500.tar | tar xvf - && cd openssl-1.0.2.1500 && installp -acXYgd . openssl.base all"
-  plat.provision_with "rpm --rebuilddb && updtvpkg"
-  plat.provision_with "mkdir -p /tmp/yum_bundle && cd /tmp/yum_bundle/ && curl -O http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/yum_bundle.tar && tar xvf yum_bundle.tar && rpm -Uvh /tmp/yum_bundle/*.rpm"
+  # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
+  plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
-  # Add pl-build-tools repo config
-  plat.provision_with "echo '[pl-build-tools]\nname=Puppet Labs Build Tools Repository for AIX 6\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/aix/6.1/$basearch\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/pl-build-tools.repo"
-
-  # Use artifactory mirror for AIX toolbox packages
-  plat.provision_with "/usr/bin/sed 's/enabled=1/enabled=0/g' /opt/freeware/etc/yum/yum.conf > tmp.$$ && mv tmp.$$ /opt/freeware/etc/yum/yum.conf"
-  plat.provision_with "echo '[AIX_Toolbox_mirror]\nname=AIX Toolbox local mirror\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-generic-mirror.repo"
-  plat.provision_with "echo '[AIX_Toolbox_noarch_mirror]\nname=AIX Toolbox noarch repository\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/noarch/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-noarch-mirror.repo"
-  plat.provision_with "echo '[AIX_Toolbox_61_mirror]\nname=AIX 61 specific repository\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc-6.1/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-61-mirror.repo"
-
-  # Install build dependencies
-  plat.provision_with "yum install -y pl-gcc pl-cmake pl-yaml-cpp pl-boost coreutils autoconf gawk-3.1.3-1 pkg-config-0.19-6 rsync sed make tar glib2 perl zlib-1.2.3-4 zlib-devel-1.2.3-4"
-
-  plat.install_build_dependencies_with "yum install -y"
+  # We use --force with rpm because the pl-gettext and pl-autoconf
+  # packages conflict with a charset.alias file.
+  #
+  # Until we get those packages to not conflict (or we remove the need
+  # for pl-autoconf) we'll need to force the installation
+  #                                         Sean P. McD.
+  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
   plat.vmpooler_template "aix-6.1-power"
 end

--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -3,30 +3,18 @@ platform "aix-7.1-ppc" do |plat|
 
   plat.make "gmake"
   plat.tar "/opt/freeware/bin/tar"
-  plat.rpmbuild "/usr/bin/rpmbuild"
+  plat.rpmbuild "/usr/bin/rpm"
   plat.patch "/opt/freeware/bin/patch"
-  plat.mktemp "/opt/freeware/bin/mktemp --directory --tmpdir=/var/tmp"
-  os_version = 7.1
-  plat.environment "CC", "/opt/pl-build-tools/bin/gcc"
 
-  # Bootstrap yum
-  plat.provision_with "curl -O http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/rpm.rte && installp -acXYgd . rpm.rte all"
-  plat.provision_with "curl http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/openssl-1.0.2.1500.tar | tar xvf - && cd openssl-1.0.2.1500 && installp -acXYgd . openssl.base all"
-  plat.provision_with "rpm --rebuilddb && updtvpkg"
-  plat.provision_with "mkdir -p /tmp/yum_bundle && cd /tmp/yum_bundle/ && curl -O http://pl-build-tools.delivery.puppetlabs.net/aix/yum_bootstrap/yum_bundle.tar && tar xvf yum_bundle.tar && rpm -Uvh /tmp/yum_bundle/*.rpm"
+  # Basic vanagon operations require mktemp, rsync, coreutils, tar and sed so leave this in there
+  plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
-  # Add pl-build-tools repo config
-  plat.provision_with "echo '[pl-build-tools]\nname=Puppet Labs Build Tools Repository for AIX 7\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/aix/7.1/$basearch\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/pl-build-tools.repo"
-
-  # Use artifactory mirror for AIX toolbox packages
-  plat.provision_with "/usr/bin/sed 's/enabled=1/enabled=0/g' /opt/freeware/etc/yum/yum.conf > tmp.$$ && mv tmp.$$ /opt/freeware/etc/yum/yum.conf"
-  plat.provision_with "echo '[AIX_Toolbox_mirror]\nname=AIX Toolbox local mirror\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-generic-mirror.repo"
-  plat.provision_with "echo '[AIX_Toolbox_noarch_mirror]\nname=AIX Toolbox noarch repository\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/noarch/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-noarch-mirror.repo"
-  plat.provision_with "echo '[AIX_Toolbox_71_mirror]\nname=AIX 71 specific repository\nbaseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc-7.1/\ngpgcheck=0' > /opt/freeware/etc/yum/repos.d/toolbox-71-mirror.repo"
-
-  # Install build dependencies
-  plat.provision_with "yum install -y pl-gcc pl-cmake pl-yaml-cpp pl-boost coreutils autoconf gawk-3.1.3-1 pkg-config-0.19-6 rsync sed make tar glib2 perl zlib-1.2.3-4 zlib-devel-1.2.3-4"
-
-  plat.install_build_dependencies_with "yum install -y"
+  # We use --force with rpm because the pl-gettext and pl-autoconf
+  # packages conflict with a charset.alias file.
+  #
+  # Until we get those packages to not conflict (or we remove the need
+  # for pl-autoconf) we'll need to force the installation
+  #                                         Sean P. McD.
+  plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
   plat.vmpooler_template "aix-7.1-power"
 end


### PR DESCRIPTION
There are some issues with the supporting changeset in beaker-puppet, so we need to revert this for now.  

Reverts puppetlabs/puppet-agent#1553