### PR TITLE
(PA-2349) Remove Fedora 27 x86_64 platform from build defaults.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ acceptance/log/*
 acceptance/tmp/*
 acceptance/merged_options.rb
 acceptance/.beaker/*
+.idea

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -13,7 +13,6 @@ foss_platforms:
   - el-7-x86_64
   - el-7-ppc64le
   - el-7-aarch64
-  - fedora-27-x86_64
   - fedora-28-x86_64
   - osx-10.12-x86_64
   - osx-10.13-x86_64
@@ -66,8 +65,6 @@ platform_repos:
     repo_location: repos/sles/12/**/ppc64le
   - name: sles-15-x86_64
     repo_location: repos/sles/15/**/x86_64
-  - name: fedora-27-x86_64
-    repo_location: repos/fedora/27/**/x86_64
   - name: fedora-28-x86_64
     repo_location: repos/fedora/28/**/x86_64
   - name: debian-8-i386


### PR DESCRIPTION
Removed Fedora 27 x86_64 from ext/build_dafaults.yaml