### PR TITLE
(maint) Fix resource-api component

### DIFF
--- a/configs/components/puppet-resource_api.rb
+++ b/configs/components/puppet-resource_api.rb
@@ -1,5 +1,5 @@
-component "rubygem-puppet-resource_api" do |pkg, settings, platform|
-  pkg.load_from_json("configs/components/rubygem-puppet-resource_api.json")
+component "puppet-resource_api" do |pkg, settings, platform|
+  pkg.load_from_json("configs/components/puppet-resource_api.json")
 
   pkg.build_requires "puppet-runtime"
 


### PR DESCRIPTION
There were some entries in the resource api component that were not fixed in
the attempt to rename the component