### PR TITLE
(maint) piddir not required on solaris

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -27,7 +27,7 @@ def setup_build_environment(agent)
   when /el-5/
     # PA-1638
     gem_install_sqlite3 += " -v 1.3.11"
-  when /solaris-11-i386/
+  when /solaris-11(.4|)-i386/
     # for some reason pkg install does not install developer/gcc-48 for sol 11, so need
     # to use the one provided by pl-build-tools instead.
     on(agent, "curl -O http://pl-build-tools.delivery.puppetlabs.net/solaris/11/sol-11-i386-compiler.tar.gz")

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -122,7 +122,7 @@ project "puppet-agent" do |proj|
   proj.directory proj.sysconfdir
   proj.directory proj.link_bindir
   proj.directory proj.logdir unless platform.is_windows?
-  proj.directory proj.piddir unless platform.is_windows?
+  proj.directory proj.piddir unless platform.is_windows? || platform.is_solaris?
   if platform.is_windows? || platform.is_macos?
     proj.directory proj.bindir
   end


### PR DESCRIPTION
This commit had previously landed only on 5.5.x and newer, but is required for the build to work with newer versions of Vanagon.