### PR TITLE
(maint) Confine SCL pip test to 64 bit centos

### DIFF
--- a/acceptance/tests/ensure_SCL_python_pip_works.rb
+++ b/acceptance/tests/ensure_SCL_python_pip_works.rb
@@ -1,5 +1,5 @@
 test_name 'PUP-8351: Ensure pip provider works with RHSCL python' do
-  confine :to, :platform => /centos-(6|7)/
+  confine :to, :platform => /centos-(6|7)-x86_64/
   tag 'audit:medium',
       'audit:acceptance'
 


### PR DESCRIPTION
The ensure_SCL_python_pip_works test uses redhat SCL packages to perform a
python 'pip' install so we can test that the pip provider still works with SCL
python.

However, the test uses actual SCL packages on centos and those are only
available for 64 bit platforms.

This commit updates the test to confine to 64 bit centos, and
https://tickets.puppetlabs.com/browse/PA-2386 has been opened to make the test
not rely on actual SCL packages in the future.