### PR TITLE
(maint) update for bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ git:
   depth: 150
 language: ruby
 bundler_args: --without development
+before_install:
+  - gem install bundler -v '< 2' --no-document;
 before_script:
   - 'git config --global user.email "you@example.com"'
   - 'git config --global user.name "Your Name"'


### PR DESCRIPTION
This also uses the `--no-document` option as `--no-rdoc` and
`--no-ri` were removed in bundler 2.