### PR TITLE
(maint) Pin homebrew boost

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -4,8 +4,6 @@ component "leatherman" do |pkg, settings, platform|
   make = platform[:make]
 
   if platform.is_macos?
-    pkg.build_requires "cmake"
-    pkg.build_requires "boost"
     pkg.build_requires "gettext"
   elsif platform.name =~ /solaris-10/
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-boost-1.58.0-7.#{platform.architecture}.pkg.gz"

--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -18,7 +18,7 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /var/empty/Library/'
 
-  packages = %w(cmake)
+  packages = ['cmake', 'https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 


### PR DESCRIPTION
Homebrew has changed their boost to have a hard dependency on ICU,
which breaks our build. This pins to the last boost relaesed before
that change.