### PR TITLE
(MAINT) Remove puppet_docker_tools

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+TEST-rspec.xml

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -10,5 +10,5 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.2')
+gem 'rspec'
 gem 'rspec_junit_formatter'

--- a/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-alpine/spec/dockerfile_spec.rb
@@ -1,5 +1,3 @@
-require 'puppet_docker_tools/spec_helper'
-
 describe 'puppet-agent' do
   before(:all) do
     @image = ENV['PUPPET_TEST_DOCKER_IMAGE']

--- a/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
+++ b/docker/puppet-agent-ubuntu/spec/dockerfile_spec.rb
@@ -1,5 +1,3 @@
-require 'puppet_docker_tools/spec_helper'
-
 describe 'puppet-agent' do
   before(:all) do
     @image = ENV['PUPPET_TEST_DOCKER_IMAGE']


### PR DESCRIPTION
This is the last project still referencing this gem, which we're
replacing in favor of the Docker CLI.