### PR TITLE
(maint) Update gitignore for build_metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ output/*
 Gemfile.lock
 Gemfile.local
 *.log
-ext/build_metadata.json
+ext/build_metadata.*
 ext/packaging
 pkg/*
 *.swp


### PR DESCRIPTION
VANAGON-132 allows for platform- and project-specific build_metadata files; This
adjusts the .gitignore file to ignore any and all of them.