### PR TITLE
(PA-2362) Update fedora 29 to use GCC 8

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -33,8 +33,7 @@ component "cpp-hocon" do |pkg, settings, platform|
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = "-DCMAKE_CXX_FLAGS='-Wno-error=address -Wno-error=nonnull-compare'" if platform.name =~ /fedora-29/
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -48,7 +48,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29/
   elsif platform.is_cisco_wrlinux?
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -156,7 +156,7 @@ component "facter" do |pkg, settings, platform|
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
-    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8/
+    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -74,8 +74,7 @@ component "leatherman" do |pkg, settings, platform|
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = "-DCMAKE_CXX_FLAGS='-Wno-error=deprecated-declarations'" if platform.name =~ /fedora-29/
-    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='-O1' " if platform.name =~ /el-8/
+    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='-O1' " if platform.name =~ /el-8|fedora-29/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -33,7 +33,7 @@ component "libwhereami" do |pkg, settings, platform|
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -54,7 +54,7 @@ component "pxp-agent" do |pkg, settings, platform|
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
-    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8/
+    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29/
   elsif platform.is_cisco_wrlinux?
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end

--- a/configs/platforms/fedora-29-x86_64.rb
+++ b/configs/platforms/fedora-29-x86_64.rb
@@ -4,25 +4,10 @@ platform "fedora-29-x86_64" do |plat|
   plat.servicetype "systemd"
   plat.dist "fc29"
 
-  # Becasue GCC 8.2 outputs far more warnings than previous GCC versions,
-  # we need to use an older version to be able to build leatherman.
-  # To use GCC 7 we need to fetch it from Fedora 27 packages.
-  # leatherman ticket that adresses the issue: https://tickets.puppetlabs.com/browse/LTH-161
-  fedora_27_packages = [
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/c/cpp-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/l/libgomp-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/g/gcc-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/l/libstdc++-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/l/libstdc++-devel-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/l/libquadmath-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/l/libquadmath-devel-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora/releases/27/Everything/x86_64/os/Packages/g/gcc-c++-7.2.1-2.fc27.x86_64.rpm",
-    "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_fedora-cache/updates/27/x86_64/Packages/r/redhat-rpm-config-77-1.fc27.noarch.rpm"
-  ]
 
-  fedora_27_packages.each { |package| plat.provision_with "dnf install -y #{package}" }
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc gcc-c++ make rpmdevtools rpm-libs cmake"
 
-  plat.provision_with "/usr/bin/dnf install -y --allowerasing --exclude=gcc --exclude=gcc-c++ autoconf automake rsync make cmake patch rpm-build"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y --allowerasing --exclude=gcc --exclude=gcc-c++"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+
   plat.vmpooler_template "fedora-29-x86_64"
 end


### PR DESCRIPTION
This change cleans up the build on fedora 29 to use gcc 8