### PR TITLE
(maint) Update brew formula for boost

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -18,8 +18,8 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-
-  packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
+  #Temporary fix for installing boost without icu4c support
+  packages = ['https://raw.githubusercontent.com/mihaibuzgau/homebrew-core/50b53d7dd993bc7a91588740c5a200a56855d259/Formula/boost.rb']
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 

--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -18,8 +18,8 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-
-  packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
+  #Temporary fix for installing boost without icu4c support
+  packages = ['https://raw.githubusercontent.com/mihaibuzgau/homebrew-core/50b53d7dd993bc7a91588740c5a200a56855d259/Formula/boost.rb']
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -16,7 +16,8 @@ platform 'osx-10.14-x86_64' do |plat|
     plat.provision_with 'cd /etc/homebrew'
     plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
     plat.provision_with 'sudo chown -R test:admin /Users/test/'
-    packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
+    #Temporary fix for installing boost without icu4c support
+    packages = ['https://raw.githubusercontent.com/mihaibuzgau/homebrew-core/50b53d7dd993bc7a91588740c5a200a56855d259/Formula/boost.rb']
     plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
     plat.vmpooler_template 'osx-1012-x86_64'
     plat.output_dir File.join('apple', '10.14', 'puppet5', 'x86_64')


### PR DESCRIPTION
In this commit: https://github.com/Homebrew/homebrew-core/commit/4c9da082d3cc20664ca78615b3ca26c62467ed19 homebrew has made icu4c a mandatory dependency for boost. The build for Leatherman fails if boost is compiled with icu4c enabled. To fix this issue we've pointed to the previous version of boost homebrew formula here: https://github.com/puppetlabs/puppet-agent/commit/6272f2608b36c25665f1422f9bd84accdc88dff0
A couple of days ago, Homebrew has removed dependencies for old compiles (cxx14): https://github.com/Homebrew/homebrew-core/commit/80584e1ba06664c2610707dc71c308f82b13895a breaking our builds:
`17:11:52 Error: boost: "cxx14" is not a recognized standard`

This is a temporary fix to get the builds passing until we find a better solution for this. The following Jira item has been created to track this issue: https://tickets.puppetlabs.com/browse/PA-2426. 