### PR TITLE
(maint) Remove boost installation from build setup

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -19,9 +19,10 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-  packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
-
-  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  # If you need to add packages to install pre-build, add them to 'packages'
+  # and uncomment the provision_with line below
+  # packages = []
+  # plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
   plat.vmpooler_template 'osx-1012-x86_64'
   plat.output_dir File.join('apple', '10.12', 'puppet6', 'x86_64')

--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -20,9 +20,10 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
 
-  packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
-
-  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  # If you need to add packages to install pre-build, add them to 'packages'
+  # and uncomment the provision_with line below
+  # packages = []
+  # plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
   plat.vmpooler_template 'osx-1012-x86_64'
   plat.output_dir File.join('apple', '10.13', 'puppet6', 'x86_64')

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -1,23 +1,27 @@
 platform 'osx-10.14-x86_64' do |plat|
-    plat.servicetype 'launchd'
-    plat.servicedir '/Library/LaunchDaemons'
-    plat.codename "mojave"
-    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-    plat.provision_with 'export HOMEBREW_VERBOSE=true'
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/'
-    packages = ['https://raw.githubusercontent.com/Homebrew/homebrew-core/10c7c4d90919120ce4839f687c29f68cfc2fca92/Formula/boost.rb']
-    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-    plat.vmpooler_template 'osx-1012-x86_64'
-    plat.output_dir File.join('apple', '10.14', 'puppet6', 'x86_64')
-  end
+  plat.servicetype 'launchd'
+  plat.servicedir '/Library/LaunchDaemons'
+  plat.codename "mojave"
+  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+  plat.provision_with 'export HOMEBREW_VERBOSE=true'
+  plat.provision_with 'sudo dscl . -create /Users/test'
+  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+  plat.provision_with 'sudo dscl . -passwd /Users/test password'
+  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+  plat.provision_with 'mkdir -p /etc/homebrew'
+  plat.provision_with 'cd /etc/homebrew'
+  plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+  plat.provision_with 'sudo chown -R test:admin /Users/test/'
+
+  # If you need to add packages to install pre-build, add them to 'packages'
+  # and uncomment the provision_with line below
+  # packages = []
+  # plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+
+  plat.vmpooler_template 'osx-1012-x86_64'
+  plat.output_dir File.join('apple', '10.14', 'puppet6', 'x86_64')
+end


### PR DESCRIPTION
agent packages > 6.0.x are built with a precontstructed boost in
puppet-runtime, rather than including libraries from a package
installed from brew

A recent mergeup from 5.5.x re-introduced the old boost package
installation, so this commit removes it.

cherry-pick of 2ab4eba7eb139f78d7cb5279add064a52177dd10 from master