### PR TITLE
(maint) Allow use of FQDNs in smoke test scripts

### DIFF
--- a/ext/smoke/README.md
+++ b/ext/smoke/README.md
@@ -11,9 +11,7 @@ the release process.
 #### Manually smoke test platform components installed from packages
 
 To run these smoke tests, check out 2 redhat-7-x86_64 VMs.
-Then run the `packages/run-smoke-test.sh` script as follows, where
-VM names should not include the domain, as that will be appended in the
-script:
+Then run the `packages/run-smoke-test.sh` script as follows:
 
 ```
 ./packages/run-smoke-test.sh <VM> <VM> <agent_version> <server_version> <puppetdb_version>

--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -201,3 +201,14 @@ function install_puppetdb_from_package() {
   echo ""
   echo ""
 }
+
+# Given a hostname or FQDN ($1), append a domain ($2, defaults to
+# '.delivery.puppetlabs.net') to form an FQDN if necessary
+function hostname_with_domain() {
+  host=$1
+  domain=${2:-.delivery.puppetlabs.net}
+  if [[ ! $host == *.* ]]; then
+    host="$host$domain"
+  fi
+  echo $host
+}

--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 set -e
+source "$(dirname $0)/../helpers.sh"
 
 USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <server-version> <puppetdb-version>"
-domain=".delivery.puppetlabs.net"
 
 master_vm="$1"
 agent_vm="$2"
@@ -17,17 +17,16 @@ if [[ -z "${master_vm}" || -z "${agent_vm}" || -z "${agent_version}" || \
   exit 1
 fi
 
-# Append domains after validation.
-master_vm="$1$domain"
-agent_vm="$2$domain"
+master_vm=$(hostname_with_domain $master_vm)
+agent_vm=$(hostname_with_domain $agent_vm)
 
-echo "#### Setting up master..."
+echo "#### Setting up master [$master_vm]"
 $(dirname $0)/steps/setup-master.sh ${master_vm} ${agent_version} ${server_version} ${puppetdb_version}
 
-echo "#### Setting up agent..."
+echo "#### Setting up agent [$agent_vm]"
 $(dirname $0)/../steps/setup-agent.sh ${master_vm} ${agent_vm} ${agent_version} "package"
 
-echo "#### Running validation..."
+echo "#### Running validation"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}
 
 echo "All done!"

--- a/ext/smoke/repos/run-smoke-test.sh
+++ b/ext/smoke/repos/run-smoke-test.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+source "$(dirname $0)/../helpers.sh"
+
 USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-vm1> <agent-vm2> <agent-version> <server-version> <puppetdb-version>"
 domain=".delivery.puppetlabs.net"
 
@@ -21,20 +23,19 @@ if [[ -z "${master_vm1}" || -z "${master_vm2}" || -z "${agent_vm1}" || \
   exit 1
 fi
 
-# Append domains after validation.
-master_vm1="$1$domain"
-master_vm2="$2$domain"
-agent_vm1="$3$domain"
-agent_vm2="$4$domain"
+master_vm1=$(hostname_with_domain $master_vm1)
+master_vm2=$(hostname_with_domain $master_vm2)
+agent_vm1=$(hostname_with_domain $agent_vm1)
+agent_vm2=$(hostname_with_domain $agent_vm2)
 
 echo "##### Setting up masters..."
 $(dirname $0)/steps/setup-masters.sh ${master_vm1} ${master_vm2} ${agent_version} ${server_version} ${puppetdb_version}
 
 # One agent starts with master 1, one agent starts with master 2
-echo "##### Master 1 (PuppetDB Module) + Agent 1"
+echo "##### Master 1 (PuppetDB Module) [$master_vm1] + Agent 1 [$agent_vm1]"
 $(dirname $0)/../steps/setup-agent.sh          ${master_vm1} ${agent_vm1} ${agent_version} "repo"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm1} ${agent_vm1}
-echo "##### Master 2 (PuppetDB Package) + Agent 2"
+echo "##### Master 2 (PuppetDB Package) [$master_vm2] + Agent 2 [$agent_vm2]"
 $(dirname $0)/../steps/setup-agent.sh          ${master_vm2} ${agent_vm2} ${agent_version} "repo"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm2} ${agent_vm2}
 


### PR DESCRIPTION
The smoke test scripts originally required a hostname only, and
incorrectly appended a domain when given an FQDN. This adjusts them to
only append a domain if needed.