### PR TITLE
(maint) Don't take Azure containers latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,8 @@ steps:
     testRunTitle: Puppet Agent Alpine Test Results
 - powershell: |
     . ./docker/ci/build.ps1
-    Clear-ContainerBuilds
+    # builds alias puppet-agent to puppet-agent-ubuntu which requires forced removal
+    Clear-ContainerBuilds -Name puppet-agent-ubuntu -Force
+    Clear-ContainerBuilds -Name puppet-agent-alpine
   displayName: Container Cleanup
   condition: always()

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -40,13 +40,11 @@ function Build-Container(
     '--build-arg', "build_date=$build_date",
     '--build-arg', "version=$Version",
     '--file', "puppet-agent-$Base/$subdir/Dockerfile",
-    '--tag', "$Namespace/puppet-agent-${Base}:$Version",
-    '--tag', "$Namespace/puppet-agent-${Base}:latest"
+    '--tag', "$Namespace/puppet-agent-${Base}:$Version"
   )
   if ($Base -eq 'ubuntu')
   {
     $docker_args += @(
-      '--tag', "$Namespace/puppet-agent:latest",
       '--tag', "$Namespace/puppet-agent:$Version"
     )
   }

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -85,9 +85,51 @@ function Invoke-ContainerTest($Name, $Namespace = 'puppet', $Version = (Get-Cont
   Pop-Location
 }
 
-# removes any temporary containers / images used during builds
-function Clear-ContainerBuilds
+# removes temporary layers / containers / images used during builds
+# removes $Namespace/$Name images > 14 days old by default
+function Clear-ContainerBuilds(
+  $Namespace = 'puppet',
+  $Name,
+  $OlderThan = [DateTime]::Now.Subtract([TimeSpan]::FromDays(14)),
+  [Switch]
+  $Force = $false
+)
 {
+  Write-Output 'Pruning Containers'
   docker container prune --force
+
+  # this provides example data which ConvertFrom-String infers parsing structure with
+  $template = @'
+{Version*:1.2.3} {ID:5b84704c1d01} {[DateTime]Created:2019-02-07 18:24:51} +0000 GMT
+{Version*:latest} {ID:0123456789ab} {[DateTime]Created:2019-01-29 00:05:33} +0000 GMT
+'@
+  $output = docker images --filter=reference="$Namespace/${Name}" --format "{{.Tag}} {{.ID}} {{.CreatedAt}}"
+  Write-Output @"
+
+Found $Namespace/${Name} images:
+$($output | Out-String)
+
+"@
+
+  if ($output -eq $null) { return }
+
+  Write-Output "Filtering removal candidates..."
+  # docker image prune supports filter until= but not repository like 'puppetlabs/foo'
+  # must use label= style filtering which is a bit more inconvenient
+  # that output is also not user-friendly!
+  # engine doesn't maintain "last used" or "last pulled" metadata, which would be more useful
+  # https://github.com/moby/moby/issues/4237
+  $output |
+    ConvertFrom-String -TemplateContent $template |
+    ? { $_.Created -lt $OlderThan } |
+    # ensure 'latest' are listed first
+    Sort-Object -Property Version -Descending |
+    % {
+      Write-Output "Removing Old $Namespace/${Name} Image $($_.Version) ($($_.ID)) Created On $($_.Created)"
+      $forcecli = if ($Force) { '-f' } else { '' }
+      docker image rm $_.ID $forcecli
+    }
+
+  Write-Output "`nPruning Dangling Images"
   docker image prune --filter "dangling=true" --force
 }


### PR DESCRIPTION
 - The 'latest' moniker is not used anywhere in Azure builds or tests
   and could cause undesirable container usage when running the tests
   from the 'pupperware' repo, so remove that part of the process
 - Cleanup old containers / images

Output from cleanup

```
runing Containers
Total reclaimed space: 0B

Found puppet/puppet-agent-ubuntu images:
6.0.5 4719ef1b51ef 2019-02-09 01:50:51 +0000 GMT
6.2.0 ac5fc328a823 2019-02-06 19:05:49 +0000 GMT
latest ac5fc328a823 2019-02-06 19:05:49 +0000 GMT
6.1.0 74a2752e20f3 2019-01-11 22:35:38 +0000 GMT
6.0.4 e0303b20fa47 2019-01-11 22:28:12 +0000 GMT


Filtering removal candidates...
Removing Old puppet/puppet-agent-ubuntu Image 6.1.0 (74a2752e20f3) Created On 01/11/2019 22:35:38
Untagged: puppet/puppet-agent-ubuntu:6.1.0
Untagged: puppet/puppet-agent:6.1.0
Deleted: sha256:74a2752e20f3e4f7c4c97464fb70cb54c31a9d1e903a8db506fe3017bddfbc39
Deleted: sha256:e3f8d330e424bcae6f7cedbaca38d8b46b052f0726d513ac4d263c834e4c960b
Deleted: sha256:cf166317f9c9253febecef6baf1e98a2cdb52b5e4f0ff330a99f2aa0ec6051d6
Deleted: sha256:9fc6624831e30f773acdc8f7469973c1657388c415a8506a9e6e5b250a390072
Deleted: sha256:8a411462e0c426c67b880de2759279a680189a3b011dc42eb70229721b7f7101
Deleted: sha256:e8ed0a0af2047750a33aa80278029e0431a27104c5f87e36ab7febd503b408fc
Deleted: sha256:ea96091e8addd72ab2b02ba066b6778f0408fb5f8dfdc9565c3bd514d30de0cb
Deleted: sha256:4e9f077f7c4bbd1b034f7c3673d2b5d0a475468c0215017ac6b3e00f3adbbbe8
Deleted: sha256:c6cee829b71c62cbf833482c4ee583a07d750653e6303eda58d06a096ddc5fa0
Deleted: sha256:8dd45e6d7d826309848611ef8946dbbdde09a0fa070555297815f23553a3933a
Deleted: sha256:71cb83cb5020254c219b8be719723716effee0a5f518822fa67019f38775061c
Deleted: sha256:b23f06b5283e7889c2f0b7bf7cc475db2397d9509c346a788e9d7152e0f052e0
Deleted: sha256:9a488f629b0eee66efee8c38b1370fc293e8b56e0162405c5470043f8dd7b782
Removing Old puppet/puppet-agent-ubuntu Image 6.0.4 (e0303b20fa47) Created On 01/11/2019 22:28:12
Untagged: puppet/puppet-agent-ubuntu:6.0.4
Untagged: puppet/puppet-agent:6.0.4
Deleted: sha256:e0303b20fa47ad8f4d031573437b2a30863c0c5ed6023575801b226ae9961d5b
Deleted: sha256:6afd1ac04b8547385050a1f64132081e3dc4c36b8798a7b2231f6a0124b417da
Deleted: sha256:57bc52ae192ff4717220a3a09565ad05e417defdb6197958b34444eeec58b86a
Deleted: sha256:f68fadde65a56549bf6a84c510e03599ce0bbac6b36b4d197752d67b63c120fc
Deleted: sha256:5b075cda919a8831f74cca2649e884078a9056c6b48a3842d2507a4e194d0989
Deleted: sha256:99e4d372200880fb9280d1d30ab98d6cbc395c7a2d0cd731efd47142e164f8b4
Deleted: sha256:1593004c35a706bf2971431cc800736ce63d28944344512bedcba05d9ad665ac
Deleted: sha256:480af897197f5b9f26443ba6ae84935a74ac405a95392b9e4337f110f2581535
Deleted: sha256:c4c0aebeeaa60c5e10a79ba72dd3f3221d00c77d26fa1c1ac537eba9744f64da
Deleted: sha256:47efaa03f835648469708555dd25ba1ecdd09ec10adb4d6277da312b24594e9f
Deleted: sha256:a9b1a5967bd1c62c0a221365435f38103fdd03ba9cbfc2145def9c6243f4180b
Deleted: sha256:6a8c9c9ea6971274445bacfdff0b18c115c82e382425105218ab15eb5e1a2492
Deleted: sha256:6f60b4acb22659a7c2b028550e67918ca84bcead2e98ffc0d991cb34b5a596e2
Deleted: sha256:2853b77bbda73907177f0b795310e7d3c11b84636251567e550c5af8b862808f
Deleted: sha256:8f1a4e0cc52da6a288a7ee310fc484b95691531ac7ce325b3f4d8be64f9a9cf5
Deleted: sha256:186cceedb4c0a9e0a527659d9aa58c30b07d952c17fccc830ddbf852a90d2787
Deleted: sha256:146eb71eeb10d282174b21a57fdda0a4e6678d6cbf87849ad7243835948cc1eb
Deleted: sha256:a42aababeff73208e6383ca3097f15576802378cd2d390f39a28b33b410efae0
Deleted: sha256:318f95e8e16f7f24d2de00ce701552ad11bd78593f6a10b5833477022d6d6d2a
Deleted: sha256:152e5d6b3e789e8b0491b3b9e1d15241bce6821bd1632f9176add8e3888cede3
Deleted: sha256:33525bc6205f3744be6baf04d8abbaa0d2d9a9f7ac8b5fbb56f08152b6d0d0ad
Deleted: sha256:aaae4f657e10d12664eb9fa7303061eb81f7dadd9addf5ff7166ca62d2f5331b

Pruning Dangling Images
Deleted Images:
untagged: ubuntu@sha256:b967b9f2a5625231a22db642609e61b7b1a5481128f51fe771e91bb92e0a35d0
deleted: sha256:b0ef3016420a4052400d0a36f5144ebdee5d358ef6942afee072517b5a94168c
deleted: sha256:7c42fc68785f05435c7d0a15ab5eba645dd51431ff85ba8c81aac71b6d7fa676
deleted: sha256:9ae10a8fb5d0419283b7d8ede59c6cb17df79c1bc0f0367ad5d5fd5f9040b9b7
deleted: sha256:8c7764429ac5850455be6b16dcbf2f3e916522ea400c90133b498701debfe3a2
deleted: sha256:8241afc74c6f5ca20c3bd7f3ddb3e5621d637ee85aaf40de440bf465b2a9984f
deleted: sha256:8c9a8f0c82de71180be33ee3c9df41ec4f92211450ea21fdd49bca6e2c58a82a
deleted: sha256:441a25e6c53c128d1d511e3fc24b713bc03a7d5bdcc1e15ad00e7534e28c850b
deleted: sha256:e8be3eff93fdb6e175f48f39eee4ba7d5b1716bc6f6747a0a5eb5b6670de81f2
deleted: sha256:39e27d4c7030d147aba3a5619e902be8efea7659a1a110f9ec0472b86a484ca8
deleted: sha256:934316bb492f1aed9df13b73dad5392cfa864caea13331465b6c67230b5fa39b
deleted: sha256:42311d50a13045dae6cbdf76aebaecab701014575c50ba0af79a5582396c0875
deleted: sha256:0a7102eeeabf668b6abf671e030553fa5f23c1e3913fb3bb240e73b7c1481563
deleted: sha256:c7b8af47b6630c0a3e1c3f8b0a77dba4be01507854f086aa78e1857275e366d4
deleted: sha256:db19ea83a94b7eb6b5f1e2b4681b0d43988daa961e66cbb59f2a359b6e55b32e
deleted: sha256:57dc815105599d4cc756acfa3088b60878d44cebf577ef110809b8c075a11669

Total reclaimed space: 296.7MB
Pruning Containers
Total reclaimed space: 0B

Found puppet/puppet-agent-alpine images:
latest e01d25e87981 2019-02-07 16:56:50 +0000 GMT


Filtering removal candidates...

Pruning Dangling Images
Total reclaimed space: 0B
```