### PR TITLE
(maint) Bump java to 1.7.1 on sles 11

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -71,9 +71,9 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires 'java-1_7_0-openjdk-devel'
     java_home = "/usr/lib64/jvm/java-1.7.0-openjdk"
   when /sles-11/
-    pkg.build_requires 'java-1_7_0-ibm-devel'
-    java_home = "/usr/lib64/jvm/java-1.7.0-ibm-1.7.0"
-    java_includedir = "-DJAVA_JVM_LIBRARY=/usr/lib64/jvm/java-1.7.0-ibm-1.7.0/include"
+    pkg.build_requires 'java-1_7_1-ibm-devel'
+    java_home = "/usr/lib64/jvm/java-1.7.1-ibm-1.7.1"
+    java_includedir = "-DJAVA_JVM_LIBRARY=/usr/lib64/jvm/java-1.7.1-ibm-1.7.1/include"
   else
     skip_jruby = 'ON'
   end


### PR DESCRIPTION
Bumped java to 1.7.1 since 1.7.0 is not available for sles11-sp4
ad_hoc build: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/Adhoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/531/