### PR TITLE
(packaging) Update resource_api to refs/tags/v1.7.0.

### DIFF
--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"241916209b92e9ef17bcba7f2d25fcf8b91d301e"}
+{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.7.0"}


### PR DESCRIPTION
Jenkins doesn't know how to do this automatically for resource_api.