### PR TITLE
(maint) add sourcing the helpers script to the repos run-smoke-test.sh

### DIFF
--- a/ext/smoke/repos/run-smoke-test.sh
+++ b/ext/smoke/repos/run-smoke-test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+source "$(dirname $0)/../helpers.sh"
 
 # Redirect stdout ( > ) into a named pipe ( >() ) running "tee"
 exec > >(tee -i "$(dirname $0)/../puppet-agent-${5}-smoke-test-repos-output.txt")


### PR DESCRIPTION
The script was updated to use helpers, but the sourcing of those helpers was missed.