### PR TITLE
Several fixes to smoke test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ acceptance/log/*
 acceptance/tmp/*
 acceptance/merged_options.rb
 acceptance/.beaker/*
+ext/smoke/*output.txt

--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -212,3 +212,13 @@ function hostname_with_domain() {
   fi
   echo $host
 }
+
+# Guesses the puppet collection based on a version of puppet-agent ($1)
+function guess_puppet_collection_for() {
+  if [[ $1 =~ ^[0-9] ]]; then
+    echo "puppet${1:0:1}"
+  else
+    echo "ERROR: Couldn't determine a puppet collection based on the puppet-agent version '${1}'"
+    exit 1
+  fi
+}

--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -3,7 +3,7 @@
 set -e
 source "$(dirname $0)/../helpers.sh"
 
-USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <server-version> <puppetdb-version>"
+USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <server-version> <puppetdb-version> [<collection>]"
 
 master_vm="$1"
 agent_vm="$2"
@@ -19,12 +19,13 @@ fi
 
 master_vm=$(hostname_with_domain $master_vm)
 agent_vm=$(hostname_with_domain $agent_vm)
+collection="${6:-$(guess_puppet_collection_for $agent_version)}"
 
 echo "#### Setting up master [$master_vm]"
-$(dirname $0)/steps/setup-master.sh ${master_vm} ${agent_version} ${server_version} ${puppetdb_version}
+$(dirname $0)/steps/setup-master.sh ${master_vm} ${agent_version} ${server_version} ${puppetdb_version} ${collection}
 
 echo "#### Setting up agent [$agent_vm]"
-$(dirname $0)/../steps/setup-agent.sh ${master_vm} ${agent_vm} ${agent_version} "package"
+$(dirname $0)/../steps/setup-agent.sh ${master_vm} ${agent_vm} ${agent_version} "package" ${collection}
 
 echo "#### Running validation"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}

--- a/ext/smoke/packages/steps/setup-master.sh
+++ b/ext/smoke/packages/steps/setup-master.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 source "$(dirname $0)/../../helpers.sh"
 

--- a/ext/smoke/packages/steps/setup-master.sh
+++ b/ext/smoke/packages/steps/setup-master.sh
@@ -11,7 +11,7 @@ master_vm="$1"
 agent_version="$2"
 server_version="$3"
 puppetdb_version="$4"
-collection="${5:-puppet5}"
+collection="${5:-$(guess_puppet_collection_for $agent_version)}"
 
 if [[ -z "${master_vm}" || -z "${agent_version}" || -z "${server_version}" || -z "${puppetdb_version}}" ]]; then
   echo "${USAGE}"

--- a/ext/smoke/repos/run-smoke-test.sh
+++ b/ext/smoke/repos/run-smoke-test.sh
@@ -5,7 +5,6 @@ set -e
 source "$(dirname $0)/../helpers.sh"
 
 USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-vm1> <agent-vm2> <agent-version> <server-version> <puppetdb-version> [<collection>]"
-domain=".delivery.puppetlabs.net"
 
 master_vm1="$1"
 master_vm2="$2"

--- a/ext/smoke/repos/run-smoke-test.sh
+++ b/ext/smoke/repos/run-smoke-test.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 set -e
-set -x
 
 source "$(dirname $0)/../helpers.sh"
 
-USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-vm1> <agent-vm2> <agent-version> <server-version> <puppetdb-version>"
+USAGE="USAGE: $0 <master-vm1> <master-vm2> <agent-vm1> <agent-vm2> <agent-version> <server-version> <puppetdb-version> [<collection>]"
 domain=".delivery.puppetlabs.net"
 
 master_vm1="$1"
@@ -27,16 +26,17 @@ master_vm1=$(hostname_with_domain $master_vm1)
 master_vm2=$(hostname_with_domain $master_vm2)
 agent_vm1=$(hostname_with_domain $agent_vm1)
 agent_vm2=$(hostname_with_domain $agent_vm2)
+collection="${8:-$(guess_puppet_collection_for $agent_version)}"
 
 echo "##### Setting up masters..."
 $(dirname $0)/steps/setup-masters.sh ${master_vm1} ${master_vm2} ${agent_version} ${server_version} ${puppetdb_version}
 
 # One agent starts with master 1, one agent starts with master 2
 echo "##### Master 1 (PuppetDB Module) [$master_vm1] + Agent 1 [$agent_vm1]"
-$(dirname $0)/../steps/setup-agent.sh          ${master_vm1} ${agent_vm1} ${agent_version} "repo"
+$(dirname $0)/../steps/setup-agent.sh          ${master_vm1} ${agent_vm1} ${agent_version} "repo" ${collection}
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm1} ${agent_vm1}
 echo "##### Master 2 (PuppetDB Package) [$master_vm2] + Agent 2 [$agent_vm2]"
-$(dirname $0)/../steps/setup-agent.sh          ${master_vm2} ${agent_vm2} ${agent_version} "repo"
+$(dirname $0)/../steps/setup-agent.sh          ${master_vm2} ${agent_vm2} ${agent_version} "repo" ${collection}
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm2} ${agent_vm2}
 
 echo "All done!"

--- a/ext/smoke/repos/steps/setup-masters.sh
+++ b/ext/smoke/repos/steps/setup-masters.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -x
 
 source "$(dirname $0)/../../helpers.sh"
 
@@ -12,7 +11,7 @@ master_vm2="$2"
 agent_version="$3"
 server_version="$4"
 puppetdb_version="$5"
-collection="${6:-puppet5}"
+collection="${6:-$(guess_puppet_collection_for $agent_version)}"
 
 if [[ -z "${master_vm1}" || -z "${master_vm2}" || -z "${agent_version}" || -z "${server_version}" || -z "${puppetdb_version}}" ]]; then
   echo "${USAGE}"
@@ -41,9 +40,10 @@ function identify_master() {
 }
 
 echo "STEP: Install puppetserver and puppet-agent on both masters"
+
 for master_vm in ${master_vm1} ${master_vm2}; do
   which_master=`identify_master ${master_vm}`
-  on_master ${master_vm} "rpm -Uvh http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm --force"
+  on_master ${master_vm} "rpm -Uvh http://yum.puppetlabs.com/${collection}/${collection}-release-el-7.noarch.rpm --force"
 
   echo "STEP: Install puppet-agent on ${which_master}"
   on_master ${master_vm} "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"
@@ -90,7 +90,7 @@ done
 for master_vm in ${master_vm1} ${master_vm2}; do
   which_master=`identify_master ${master_vm}`
   SEMANTIC_VERSION_RE="[0-9]+\.[0-9]+\.[0-9]+"
-  REQUIRED_PACKAGES="puppet5-release-${SEMANTIC_VERSION_RE}-1.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-1\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-1\.el7\.noarch"
+  REQUIRED_PACKAGES="${collection}-release-${SEMANTIC_VERSION_RE}-1.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-1\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-1\.el7\.noarch"
 
   echo "STEP: Verify that the required puppet packages are installed on ${which_master}!"
   grep_results=`on_master "${master_vm}" "rpm -qa | grep puppet"`

--- a/ext/smoke/steps/run-validation-tests.sh
+++ b/ext/smoke/steps/run-validation-tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-# set -x
 
 function on_host() {
   host="$1"

--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -4,7 +4,7 @@ set -e
 
 source "$(dirname $0)/../helpers.sh"
 
-USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <type>"
+USAGE="USAGE: $0 <master-vm> <agent-vm> <agent-version> <type> [<collection>]"
 
 master_vm="$1"
 agent_vm="$2"
@@ -15,6 +15,8 @@ if [[ -z "${master_vm}" || -z "${agent_vm}" || -z "${agent_version}" || -z "${ty
   echo "${USAGE}"
   exit 1
 fi
+
+collection="${5:-$(guess_puppet_collection_for $agent_version})}"
 
 function on_master() {
   cmd="$1"
@@ -47,10 +49,10 @@ echo "STEP: Install the puppet-agent package"
 master_ip=`on_master "facter ipaddress" | tail -n 1`
 on_agent "echo ${master_ip} puppet >> /etc/hosts"
 if [[ "${type}" = "repo" ]]; then
-  on_agent "rpm -Uvh http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm --force"
+  on_agent "rpm -Uvh http://yum.puppetlabs.com/${collection}/${collection}-release-el-7.noarch.rpm --force"
   on_agent "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"
 elif [[ "${type}" = "package" ]]; then
-  on_agent "curl -f -O http://builds.puppetlabs.lan/puppet-agent/${agent_version}/artifacts/el/7/puppet5/x86_64/puppet-agent-${agent_version}-1.el7.x86_64.rpm"
+  on_agent "curl -f -O http://builds.puppetlabs.lan/puppet-agent/${agent_version}/artifacts/el/7/${collection}/x86_64/puppet-agent-${agent_version}-1.el7.x86_64.rpm"
   on_agent "rpm -ivh puppet-agent-${agent_version}-1.el7.x86_64.rpm"
 else
   echo "Unrecognized type '${type}' supplied"


### PR DESCRIPTION
These three commits update the scripts in `ext/smoke` to address a few bugs and papercuts encountered during the 6.3.0 release:

- Guesses the puppet collection based on the puppet-agent version when no collection is explicitly specified (this allows us to stop hard-coding the default collection and keep the same code for 5.5.x and later branches)
- Passes collection arguments through from runner to helper scripts when they do exist
- Uses the `puppetserver ca` command for cert interaction when dealing with puppet >= 6