### PR TITLE
(maint) Add el-8-x86_64 to platform_repos

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -64,6 +64,8 @@ platform_repos:
     repo_location: repos/el/7/**/ppc64le
   - name: el-7-aarch64
     repo_location: repos/el/7/**/aarch64
+  - name: el-8-x86_64
+    repo_location: repos/el/8/**/x86_64
   - name: sles-11-i386
     repo_location: repos/sles/11/**/i386
   - name: sles-11-x86_64


### PR DESCRIPTION
This commit adds el-8-x86_64 to the set of `platform_repos`, which is used by
the packaging repo to build puppet-agent tarballs.