### PR TITLE
(maint) readd redhatfips-7

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -37,6 +37,7 @@ foss_platforms:
 pe_platforms:
   - aix-6.1-power
   - aix-7.1-power
+  - redhatfips-7-x86_64
   - solaris-10-i386
   - solaris-10-sparc
   - solaris-11-i386
@@ -66,6 +67,8 @@ platform_repos:
     repo_location: repos/el/7/**/aarch64
   - name: el-8-x86_64
     repo_location: repos/el/8/**/x86_64
+  - name: redhatfips-7-x86_64
+    repo_location: repos/redhatfips/7/**/x86_64
   - name: sles-11-i386
     repo_location: repos/sles/11/**/i386
   - name: sles-11-x86_64


### PR DESCRIPTION
this was accidentally removed in the merge-up from 1.10.x to 5.5.x: https://github.com/puppetlabs/puppet-agent/pull/1666/files
This PR readds this platform to build_defaults