### PR TITLE
(PA-2561) Remove Cumulus Platform from build_defaults.yaml only

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,6 @@
 project: 'puppet-agent'
 # foss_platforms will be shipped to the nightly repos
 foss_platforms:
-  - cumulus-2.2-amd64
   - debian-7-amd64
   - debian-7-i386
   - debian-8-amd64
@@ -48,8 +47,6 @@ platform_repos:
     repo_location: repos/aix/6.1/**/ppc
   - name: aix-7.1-power
     repo_location: repos/aix/7.1/**/ppc
-  - name: cumulus-amd64
-    repo_location: repos/apt/cumulus
   - name: eos-4-i386
     repo_location: repos/eos/4/**/i386
   - name: el-5-i386


### PR DESCRIPTION
This change removes the Cumulus platform from ext/build_defaults.yaml.
Cumulus is not removed from acceptance/tests/validate_vendored_ruby.rb or
configs/platforms/cumulus-2.2-amd64.rb.