### PR TITLE
(maint) don't fail tests if agent is not registered.

### DIFF
--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -44,7 +44,7 @@ echo ""
 echo "Clean out the agent's SSL directory so it forgets any old masters"
 
 if [[ "$collection" =~ "puppet5" ]]; then
-  on_master "puppet cert clean ${agent_vm}"
+  on_master "puppet cert clean ${agent_vm} || true"
 else
   # This produces an error when the cert can't be cleaned; we don't care
   on_master "puppetserver ca clean --certname ${agent_vm} || true"


### PR DESCRIPTION
`puppet cert clean  ${agent_vm}` is executed before the agent is setup. Because of this, the command exists with an error:
```
[root@r135q90bp2lvnym ~]# puppet cert clean ra35q90bp2lvnym.delivery.puppetlabs.net
Warning: 'puppet cert' is deprecated and will be removed in a future release.
   (location: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:370:in `run')
Error: Could not find a serial number for ra35q90bp2lvnym.delivery.puppetlabs.net
```

This PR ignores the error for `puppet cert clean  ${agent_vm}` that is executed before the agent setup