### PR TITLE
cherry-pick "(maint) Update build_defaults.yaml rpm_targets for el-8"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -111,7 +111,7 @@ platform_repos:
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 deb_targets: 'trusty-amd64 xenial-amd64 bionic-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-11-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"


### PR DESCRIPTION
This was merged to the master branch after stop-ship/release branching for 6.4.0, and is needed in the 6.4.x branch, too.