### PR TITLE
Adds .idea to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ acceptance/log/*
 acceptance/tmp/*
 acceptance/merged_options.rb
 acceptance/.beaker/*
+.idea


### PR DESCRIPTION
The .idea folder is created when using an IDE (eg. Ruby Mine) for local caching and settings. It needs to be added to .gitignore so that developers using an IDE do not accidentally commit it.