### PR TITLE
(PA-2668) Add LD_LIBRARY_PATH to environment cleanup in AIX wrapper

### DIFF
--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -3,6 +3,7 @@
 unset LIBPATH
 unset LDR_PRELOAD
 unset LDR_PRELOAD64
+unset LD_LIBRARY_PATH
 
 COMMAND=`basename "${0}"`
 


### PR DESCRIPTION
Prior to this commit, we cleared LD_LIBRARY_PATH on Linux based
agents, but not AIX.  This meant that customers with that set
globally on their system were subject to library loading errors.

With this commit, we clear the LD_LIBRARY_PATH just as we do on
Linux agents.