### PR TITLE
(maint) Upgrade Docker container Alpine base from 3.8 to 3.9

### DIFF
--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -50,7 +50,7 @@ function Build-Container(
   }
   else # alpine
   {
-    $docker_args += '--memory 3g'
+    $docker_args += @('--memory', '3g')
 
     # fake multistage builds for Windows since LCOW doesn't support yet
     docker build --pull `

--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as build
+FROM alpine:3.9 as build
 
 RUN apk add --no-cache cmake boost-dev make curl git curl-dev ruby ruby-dev gcc g++ yaml-cpp-dev jq openjdk8
 
@@ -119,7 +119,7 @@ RUN mkdir -p /etc/puppetlabs/code/environment/production && \
     puppet module install puppetlabs-apk
 
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 ARG version=6.0.0
 ARG vcs_ref

--- a/docker/puppet-agent-alpine/windows-build/Dockerfile
+++ b/docker/puppet-agent-alpine/windows-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ARG version=6.0.0
 ARG vcs_ref

--- a/docker/puppet-agent-alpine/windows-build/Dockerfile.build
+++ b/docker/puppet-agent-alpine/windows-build/Dockerfile.build
@@ -1,8 +1,8 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk add --no-cache cmake boost-dev make curl git curl-dev ruby ruby-dev gcc g++ yaml-cpp-dev
 
-RUN mkdir /workspace 
+RUN mkdir /workspace
 WORKDIR /workspace
 RUN sed -i -e 's/sys\/poll/poll/' /usr/include/boost/asio/detail/socket_types.hpp
 


### PR DESCRIPTION
 - The Alpine based agent container was running atop 3.8, but can be
   updated to 3.9.

   Alpine 3.9 release notes:
   alpinelinux.org/posts/Alpine-3.9.0-released.html