### PR TITLE
(PA-2670) Update puppet, facter, and hiera to include version in gemspec

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -239,7 +239,7 @@ component "facter" do |pkg, settings, platform|
     end
   end
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version_forced}.gemspec"
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/facter.bat", sum: "185b8645feecac4acadc55c64abb3755")
     pkg.add_source("file://resources/files/windows/facter_interactive.bat", sum: "20a1c0bc5368ffb24980f42432f1b372")

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -32,6 +32,6 @@ component "hiera" do |pkg, settings, platform|
     #{flags}"]
   end
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec" unless platform.is_windows?
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version_forced}.gemspec" unless platform.is_windows?
 
 end

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -198,7 +198,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.install_configfile("../indent_puppet.vim", "#{settings[:datadir]}/vim/puppet-vimfiles/indent/puppet.vim")
   pkg.install_configfile("../syntax_puppet.vim", "#{settings[:datadir]}/vim/puppet-vimfiles/syntax/puppet.vim")
 
-  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}.gemspec"
+  pkg.install_file ".gemspec", "#{settings[:gem_home]}/specifications/#{pkg.get_name}-#{pkg.get_version_forced}.gemspec"
 
   if platform.is_windows?
     # Install the appropriate .batch files to the INSTALLDIR/bin directory


### PR DESCRIPTION
Between ruby 2.1 and 2.4, gem stopped being able to properly process
gemspecs if they did not match the pattern <gem>-<version>.gemspec. This
code updates the installation of the puppet, facter, and hiera gems to
include the version calculated from the git sources.