### PR TITLE
(maint) Allow for keeping headers with DEV_BUILD

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The location of Vanagon in the Gemfile can be overridden with the environment va
 * `file:///workspace/vanagon` - Absolute file path
 * `file://../vanagon` - File path relative to the project directory
 
+#### DEV\_BUILD
+By default, headers and other files that aren't needed in the final puppet-agent package will be removed as part of the [cleanup component](configs/components/cleanup.rb). If you'd like to keep these files in the finished package, set the `DEV_BUILD` environment variable to some non-empty value. Note that this will increase the size of the package considerably.
+
 Building puppet-agent or the facter gem
 ---
 

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -131,8 +131,13 @@ project "puppet-agent" do |proj|
   proj.component "module-puppetlabs-zone_core"
 
   # Including headers can make the package unacceptably large; This component
-  # removes files that aren't required:
+  # removes files that aren't required.
+  # Set the $DEV_BUILD environment variable to leave headers in place.
   proj.component "cleanup"
+
+  unless ENV['DEV_BUILD'].to_s.empty?
+    proj.settings[:dev_build] = true
+  end
 
   proj.directory proj.install_root
   proj.directory proj.prefix


### PR DESCRIPTION
In the final steps of puppet-agent builds, the 'cleanup' component
removes many files that are unnecessary in finished packages, including
headers for libraries like boost.

This change introduces a new environment variable, $DEV_BUILD, that,
when set, will make vanagon skip the cleanup so that all files
(including headers) are retained in the final package. This is useful
for C++ some development workflows.

(This just hooks up an environment variable to control the existing `:dev_build` setting)