### PR TITLE
(MAINT) Add Beaker vcloud hyperisor to Gemfile

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -18,6 +18,7 @@ gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] ||
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
+gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 1")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false


### PR DESCRIPTION
vcloud hyperisor is needed by the imaging pipelines so adding this to
the Gemfile.