### PR TITLE
(PA-2629) Add dependecy on `find` for puppet-agent

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -40,6 +40,8 @@ component 'puppet-runtime' do |pkg, settings, platform|
     pkg.requires 'libyaml-cpp0_6'
   end
 
+  pkg.requires 'findutils' if platform.is_linux?
+
   pkg.install_only true
 
   if platform.is_cross_compiled_linux? || platform.is_solaris? || platform.is_aix?


### PR DESCRIPTION
Find utility is used by the `module tool`. Since some
Fedora minimal distributions could come without `find`
we add this as an dependecy to the `puppet-runtime`