### PR TITLE
(PA-2692) Handle unset vars in /etc/profile.d/puppet.sh

### DIFF
--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -1,9 +1,13 @@
 # Add /opt/puppetlabs/bin to the path for sh compatible users
 
-if ! echo $PATH | grep -q /opt/puppetlabs/bin ; then
-  export PATH=$PATH:/opt/puppetlabs/bin
+if [ -z ${PATH-} ] ; then
+  export PATH=/opt/puppetlabs/bin
+elif ! echo ${PATH} | grep -q /opt/puppetlabs/bin ; then
+  export PATH=${PATH}:/opt/puppetlabs/bin
 fi
 
-if ! echo $MANPATH | grep -q /opt/puppetlabs/puppet/share/man ; then
-  export MANPATH=$MANPATH:/opt/puppetlabs/puppet/share/man
+if [ -z ${MANPATH-} ] ; then
+  export MANPATH=/opt/puppetlabs/puppet/share/man
+elif ! echo ${MANPATH} | grep -q /opt/puppetlabs/puppet/share/man ; then
+  export MANPATH=${MANPATH}:/opt/puppetlabs/puppet/share/man
 fi


### PR DESCRIPTION
If 'set -u' is set in shell or bash then unset variables will exit non-zero. For scripts which need to use puppet and have this set we must ensure that puppet.sh can be sourced cleanly.
