### PR TITLE
(PA-2677) Add Fedora 30 (amd64) to puppet-agent

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -33,12 +33,12 @@ component "cpp-hocon" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -47,13 +47,13 @@ component "cpp-pcp-client" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   elsif platform.is_cisco_wrlinux?
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -20,7 +20,7 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires 'puppet-runtime' # Provides openssl, ruby, augeas, curl
   pkg.build_requires 'leatherman'
-  pkg.build_requires 'runtime' unless platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  pkg.build_requires 'runtime' unless platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
   pkg.build_requires 'cpp-hocon'
   pkg.build_requires 'libwhereami'
 
@@ -47,7 +47,7 @@ component "facter" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-yaml-cpp-0.5.1-1.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "pl-yaml-cpp-#{platform.architecture}"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.
   else
@@ -156,13 +156,13 @@ component "facter" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags = "-DCMAKE_INSTALL_PREFIX=#{settings[:facter_root]} \
                      -DRUBY_LIB_INSTALL=#{settings[:facter_root]}/lib "
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
-    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -233,7 +233,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   # Disable tests for platforms that use the default OS toolchain
-  unless platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  unless platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     pkg.check do
       tests
     end

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -22,7 +22,7 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "pl-toolchain-#{platform.architecture}"
     pkg.build_requires "pl-boost-#{platform.architecture}"
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.
   else
@@ -32,7 +32,7 @@ component "leatherman" do |pkg, settings, platform|
   end
 
   pkg.build_requires "puppet-runtime" # Provides curl and ruby
-  pkg.build_requires "runtime" unless platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  pkg.build_requires "runtime" unless platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
 
@@ -76,12 +76,12 @@ component "leatherman" do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='-O1' " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='-O1' " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -29,12 +29,12 @@ component "libwhereami" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -12,7 +12,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.
   elsif !platform.is_solaris?
@@ -110,7 +110,7 @@ component "puppet" do |pkg, settings, platform|
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
-    elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+    elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
       msgfmt = "msgfmt"
     else
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -57,13 +57,13 @@ component "pxp-agent" do |pkg, settings, platform|
     special_flags = " -DCMAKE_INSTALL_PREFIX=#{settings[:pxp_root]} "
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
-    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-29|debian-10/
+    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
   elsif platform.is_cisco_wrlinux?
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -24,7 +24,7 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
     # We only need zlib because curl is dynamically linking against zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
-  elsif platform.name =~ /sles-15|fedora-29|el-8|debian-10/ || platform.is_macos?
+  elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/ || platform.is_macos?
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.
   else

--- a/configs/platforms/fedora-30-x86_64.rb
+++ b/configs/platforms/fedora-30-x86_64.rb
@@ -1,0 +1,13 @@
+platform "fedora-30-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  plat.dist "fc30"
+
+
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc gcc-c++ make rpmdevtools rpm-libs cmake"
+
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+
+  plat.vmpooler_template "fedora-30-x86_64"
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -111,7 +111,7 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime" unless platform.name =~ /sles-15|fedora-29|el-8|debian-10/
+  proj.component "runtime" unless platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
 
   # Windows doesn't need these wrappers, only unix platforms
   unless platform.is_windows?


### PR DESCRIPTION
This commit contains the following changes:

- Add Fedora 30 to configs/platforms
- Build puppet-agent on Fedora 30 without pl-build-tools dependencies

Depends on:
- https://github.com/puppetlabs/pxp-agent/pull/750
- https://github.com/puppetlabs/puppet/pull/7543
- https://github.com/puppetlabs/puppet-runtime/pull/181