### PR TITLE
(maint) Use agent-runtime-6.4.x instead of master

### DIFF
--- a/configs/projects/facter-gem.rb
+++ b/configs/projects/facter-gem.rb
@@ -6,7 +6,7 @@ project "facter-gem" do |proj|
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']
-  settings[:puppet_runtime_basename] = "agent-runtime-master-#{runtime_details['version']}.#{platform.name}"
+  settings[:puppet_runtime_basename] = "agent-runtime-6.4.x-#{runtime_details['version']}.#{platform.name}"
 
   platform = proj.get_platform
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag

--- a/configs/projects/facter-source-gem.rb
+++ b/configs/projects/facter-source-gem.rb
@@ -6,7 +6,7 @@ project "facter-source-gem" do |proj|
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']
-  settings[:puppet_runtime_basename] = "agent-runtime-master-#{runtime_details['version']}.#{platform.name}"
+  settings[:puppet_runtime_basename] = "agent-runtime-6.4.x-#{runtime_details['version']}.#{platform.name}"
 
   platform = proj.get_platform
   # identify if we are at a tag. Git sets the release to '0' when we are on a tag

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -8,7 +8,7 @@ project "puppet-agent" do |proj|
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']
-  settings[:puppet_runtime_basename] = "agent-runtime-master-#{runtime_details['version']}.#{platform.name}"
+  settings[:puppet_runtime_basename] = "agent-runtime-6.4.x-#{runtime_details['version']}.#{platform.name}"
 
   settings_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.settings.yaml")
   sha1sum_uri = "#{settings_uri}.sha1"


### PR DESCRIPTION
PR that introduce 6.4.x runtime: https://github.com/puppetlabs/ci-job-configs/pull/5693