### PR TITLE
(PA-2750) Ensure /opt/puppetlabs/bin is on the PATH

### DIFF
--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -5,6 +5,12 @@ unset LDR_PRELOAD
 unset LDR_PRELOAD64
 unset LD_LIBRARY_PATH
 
+# If $PATH does not match a regex for /opt/puppetlabs/bin
+if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
+  # Add /opt/puppetlabs/bin to a possibly empty $PATH
+  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+fi
+
 COMMAND=`basename "${0}"`
 
 exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"

--- a/resources/files/osx-wrapper.sh
+++ b/resources/files/osx-wrapper.sh
@@ -3,6 +3,12 @@
 unset DYLD_LIBRARY_PATH
 unset DYLD_INSERT_LIBRARIES
 
+# If $PATH does not match a regex for /opt/puppetlabs/bin
+if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
+  # Add /opt/puppetlabs/bin to a possibly empty $PATH
+  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+fi
+
 COMMAND=`basename "${0}"`
 
 exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -11,6 +11,12 @@ LD_LIBRARY_PATH=`/opt/puppetlabs/puppet/bin/ruby -e "$STRIP_LDLYP_COMMAND"`
 export LD_LIBRARY_PATH
 unset LD_PRELOAD
 
+# If $PATH does not match a regex for /opt/puppetlabs/bin
+if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
+  # Add /opt/puppetlabs/bin to a possibly empty $PATH
+  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+fi
+
 COMMAND=`basename "${0}"`
 
 exec /opt/puppetlabs/puppet/bin/${COMMAND} "$@"


### PR DESCRIPTION
Prior to this commit, Puppet subcommands that delegated to external
scripts or binaries, such as `puppet-query` or `puppet-infra`, would
show up as "not found" if `/opt/pupptlabs/bin` was not on the `PATH`.

This could commonly happen:

  - Immediately after installation of Puppet or PE as the shell needs
    to be re-started or re-freshed to pick up the effect of
    `/etc/profile.d/puppet-agent.sh`

  - When running `sudo puppet` in an environment where `/etc/sudoers`
    has the `env_reset` option enabled (it is enabled by default).

This commit updates the wrapper scripts to ensure `/opt/puppetlabs/bin`
is on the `PATH` in addition to unsetting various environment variables
that affect where the linker looks for shared libraries.