### PR TITLE
(maint) Remove sles-12 and deb_targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -32,8 +32,8 @@ platform_repos:
     repo_location: repos/el/7/**/aarch64
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
-deb_targets: 'trusty-amd64 xenial-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-12-x86_64'
+deb_targets: ''
+rpm_targets: 'el-6-x86_64 el-7-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"


### PR DESCRIPTION
This commit removes `trusty-amd64 xenial-amd64` from
deb_targets and `sles-12-x86_64` from rpm_targets
Since we are not building deb/sles-12 packages.