### PR TITLE
(PA-2752) Temporarily confine python3.4 on Jessie

### DIFF
--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -5,7 +5,8 @@ platform "debian-8-amd64" do |plat|
   plat.codename "jessie"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  # FIXME: revert the following line once PA-2752 gets fixed upstream
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends python3.4=3.4.2-1 python3.4-minimal=3.4.2-1 libpython3.4-stdlib=3.4.2-1 libpython3.4-minimal=3.4.2-1 build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
 end

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -5,7 +5,8 @@ platform "debian-8-i386" do |plat|
   plat.codename "jessie"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  # FIXME: revert the following line once PA-2752 gets fixed upstream
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends python3.4=3.4.2-1 python3.4-minimal=3.4.2-1 libpython3.4-stdlib=3.4.2-1 libpython3.4-minimal=3.4.2-1 build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-i386"
 end


### PR DESCRIPTION
A bug was introduced in the `python3.4` Jessie package, which is being tracked here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931044

This causes packaging jobs to fail on Debian 8 (Jessie), since package `devscripts` which is installed on this platform depends on `python3.4`.

Until this gets fixed, we need to confine `python3.4` and its dependencies to the previous version (3.4.2-1).
