### PR TITLE
(PA-2701) Fix DHCP restart on puppet-agent upgrade

### DIFF
--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -30,14 +30,4 @@
   <!-- Above directly copies Vanagons default filter.xslt.erb as Vanagon does not provide a
        way to perform additional transforms against heat harvested file list -->
 
-  <!-- (PA-768) Modify puppetres.dll component as permanent -->
-  <xsl:template match="wix:Component[wix:File[@Source='$(var.AppSourcePath)\puppet\bin\puppetres.dll']]">
-    <!-- Copy original component with all attributes, marking "Permanent" -->
-    <xsl:copy>
-      <xsl:apply-templates select="@*" />
-      <xsl:attribute name="Permanent">yes</xsl:attribute>
-      <xsl:apply-templates select="node()" />
-    </xsl:copy>
-  </xsl:template>
-
 </xsl:stylesheet>

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -62,7 +62,7 @@
           <RegistryValue
             Type="string"
             Name="EventMessageFile"
-            Value="[INSTALLDIR]puppet\bin\puppetres.dll"/>
+            Value="%SystemRoot%\System32\EventCreate.exe"/>
           <RegistryValue
             Type="integer"
             Name="TypesSupported"


### PR DESCRIPTION
Changed the Windows Registry: Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\EventLog\Application\Puppet\EventMessageFile from [INSTALLDIR]puppet\bin\puppetres.dll to %SystemRoot%\System32\EventCreate.exe

This will create custom events and will not use puppetres.dll, as puppet/lib/puppet/util/windows/eventlog.rb does the same thing regarding events.

Now the EventCreate.exe will get locked and loaded into svchost.exe and will not
interfere with puppet-agent upgrade.

Note this fix will fix future puppet-agent versions, but to install the
fixed version when you have the bug, you have to use a workaround and
install puppet-agent with the msi_move_locked_files flag set to true.