### PR TITLE
(maint) ignore hadolint DL3028

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@ git_describe = $(shell git describe)
 vcs_ref := $(shell git rev-parse HEAD)
 build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
-hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001
+hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 --ignore DL3028
 hadolint_container := hadolint/hadolint:latest
 
 ifeq ($(IS_NIGHTLY),true)


### PR DESCRIPTION
This PR ignores the hadolint error code DL3028 that was added 4 days ago.

DL3028(https://github.com/hadolint/hadolint/wiki/DL3028) is similar to DL3008(https://github.com/hadolint/hadolint/wiki/DL3008) that is already in our ignore list