### PR TITLE
(PA-2752) Revert python3.4 version lock on Jessie

### DIFF
--- a/configs/platforms/debian-8-amd64.rb
+++ b/configs/platforms/debian-8-amd64.rb
@@ -5,8 +5,7 @@ platform "debian-8-amd64" do |plat|
   plat.codename "jessie"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  # FIXME: revert the following line once PA-2752 gets fixed upstream
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends python3.4=3.4.2-1 python3.4-minimal=3.4.2-1 libpython3.4-stdlib=3.4.2-1 libpython3.4-minimal=3.4.2-1 build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-x86_64"
 end

--- a/configs/platforms/debian-8-i386.rb
+++ b/configs/platforms/debian-8-i386.rb
@@ -5,8 +5,7 @@ platform "debian-8-i386" do |plat|
   plat.codename "jessie"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-#{plat.get_codename}.deb"
-  # FIXME: revert the following line once PA-2752 gets fixed upstream
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends python3.4=3.4.2-1 python3.4-minimal=3.4.2-1 libpython3.4-stdlib=3.4.2-1 libpython3.4-minimal=3.4.2-1 build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "debian-8-i386"
 end


### PR DESCRIPTION
This reverts commit 708091fbf48f78850700fceb5d10df212d967c1b.

Debian has [fixed](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931097#10) the python3.4 installation bug, and published a new working version: 3.4.2-1+deb8u4. We can safely revert this workaround.