### PR TITLE
(PA-2691) Redirect stderr to stdout in MSI action

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -337,7 +337,7 @@ Function ExecuteCommand (Command)
   ' https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/d5fk67ky%28v%3dvs.84%29
   ' intWindows Style - 0 - Hides the window and activates another window.
   ' bWaitOnReturn - True - waits for program termination
-  Dim exitCode : exitCode = wshShell.Run(Command & " 2>&1 > """ & tempFilePath & """", 0, True)
+  Dim exitCode : exitCode = wshShell.Run(Command & " > """ & tempFilePath & """ 2>&1", 0, True)
 
   Dim outFile : Set outFile = fso.OpenTextFile(tempFilePath)
   Do While Not outFile.AtEndOfStream


### PR DESCRIPTION
Previously, stderr was redirected to stdout after the file redirection, which is the incorrect order.

This commit redirects stderr after the file redirection.

@glennsarti, I applied your fix from the JIRA ticket. From an UNIX standpoint the order looks fine to me, however I fail to parse the additional redirect after 2>&1 in your initial suggestion:

```
Dim exitCode : exitCode = wshShell.Run(Command & " > """ & tempFilePath & """ 2>&1 > ", 0, True)
```

I removed it, can you confirm this looks right?