### PR TITLE
(PA-2768) Extend manpath instead of overriding it

### DIFF
--- a/resources/files/puppet-agent.sh
+++ b/resources/files/puppet-agent.sh
@@ -6,8 +6,6 @@ elif ! echo ${PATH} | grep -q /opt/puppetlabs/bin ; then
   export PATH=${PATH}:/opt/puppetlabs/bin
 fi
 
-if [ -z ${MANPATH-} ] ; then
-  export MANPATH=/opt/puppetlabs/puppet/share/man
-elif ! echo ${MANPATH} | grep -q /opt/puppetlabs/puppet/share/man ; then
-  export MANPATH=${MANPATH}:/opt/puppetlabs/puppet/share/man
+if ! echo ${MANPATH-} | grep -q /opt/puppetlabs/puppet/share/man ; then
+  export MANPATH=${MANPATH-}:/opt/puppetlabs/puppet/share/man
 fi


### PR DESCRIPTION
Whoever implemented `MANPATH` apparently didn't do it like `PATH`.

By default, `MANPATH` is not set and man relies on paths specified in `/etc/man_db.conf`. When setting `MANPATH` to a single path, the default paths are overridden with this variable.

To make it work we need to prepend a colon to the exported variable, so that the search path gets extended instead of being replaced.

This is a regression introduced by https://github.com/puppetlabs/puppet-agent/pull/1728.
Thanks @KervyN for noticing and supplying a working version.