### PR TITLE
(PA-2769) Fix PATH set by wrapper scripts

### DIFF
--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -8,7 +8,8 @@ unset LD_LIBRARY_PATH
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
   # Add /opt/puppetlabs/bin to a possibly empty $PATH
-  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  export PATH
 fi
 
 COMMAND=`basename "${0}"`

--- a/resources/files/osx-wrapper.sh
+++ b/resources/files/osx-wrapper.sh
@@ -6,7 +6,8 @@ unset DYLD_INSERT_LIBRARIES
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
   # Add /opt/puppetlabs/bin to a possibly empty $PATH
-  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  export PATH
 fi
 
 COMMAND=`basename "${0}"`

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -14,7 +14,8 @@ unset LD_PRELOAD
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then
   # Add /opt/puppetlabs/bin to a possibly empty $PATH
-  export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"
+  export PATH
 fi
 
 COMMAND=`basename "${0}"`


### PR DESCRIPTION
The bourne shell on Solaris 10 is not familiar
with the current export syntax:
`export PATH="${PATH:+${PATH}:}/opt/puppetlabs/bin"`

Updated the wrapper scripts to set the PATH and then export.