### PR TITLE
(PA-2774) Add sanity check for manpages

### DIFF
--- a/acceptance/tests/test_manpage_clobber.rb
+++ b/acceptance/tests/test_manpage_clobber.rb
@@ -1,0 +1,29 @@
+test_name 'PA-2768: Extend manpath instead of overriding it' do
+
+  tag 'audit:low',
+    'audit:acceptance'
+
+  # shellpath scripts are only installed on linux, however macos knows how to find
+  # man directories relative to the existing path
+  confine :except, :platform => ['windows', 'aix', 'solaris']
+
+  agents.each do |agent|
+    man_command = nil
+
+    step "test for man command" do
+      on agent, "command -v man", :acceptable_exit_codes => [0, 1] do
+        man_command = stdout.chomp
+      end
+    end
+
+    skip_test "man command not found on #{agent.hostname} (#{agent.platform})" unless man_command
+
+    step "test if we have puppet manpages" do
+      on agent, "#{man_command} puppet"
+    end
+
+    step "test if we have unix manpages" do
+      on agent, "#{man_command} ls"
+    end
+  end
+end


### PR DESCRIPTION
Since puppet-agent messes with MANPATH, this checks for path clobbering
by querying a system manpage along with the puppet manpage to ensure we
did not override the system man path.