### PR TITLE
(maint) Fix repo smoke tests

### DIFF
--- a/ext/smoke/repos/steps/setup-masters.sh
+++ b/ext/smoke/repos/steps/setup-masters.sh
@@ -89,8 +89,8 @@ done
 
 for master_vm in ${master_vm1} ${master_vm2}; do
   which_master=`identify_master ${master_vm}`
-  SEMANTIC_VERSION_RE="[0-9]+\.[0-9]+\.[0-9]+"
-  REQUIRED_PACKAGES="${collection}-release-${SEMANTIC_VERSION_RE}-1.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}-1\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}-1\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}-1\.el7\.noarch"
+  SEMANTIC_VERSION_RE="[0-9]+\.[0-9]+\.[0-9]+-[0-9]+"
+  REQUIRED_PACKAGES="${collection}-release-${SEMANTIC_VERSION_RE}\.el7\.noarch puppet-agent-${SEMANTIC_VERSION_RE}\.el7\.x86_64 puppetserver-${SEMANTIC_VERSION_RE}\.el7\.noarch puppetdb-${SEMANTIC_VERSION_RE}\.el7\.noarch puppetdb-termini-${SEMANTIC_VERSION_RE}\.el7\.noarch"
 
   echo "STEP: Verify that the required puppet packages are installed on ${which_master}!"
   grep_results=`on_master "${master_vm}" "rpm -qa | grep puppet"`


### PR DESCRIPTION
When looking for the expected packages, the release field was hardcoded
to '1' for all packages. While for most packages this will work, release
packages often have multiple releases over their lifetime, so the test
was failing to pick up the release package. This updates the regex to
include the release field and allow that to be `[0-9]+`.