### PR TITLE
(CPR-709) Send package smoke test params to Artifactory

### DIFF
--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -37,4 +37,5 @@ echo "puppetdb: ${puppetdb_version}" >> ${versions_file}
 curl -T ${versions_file} "https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/puppet-agent-version-compatibility/${versions_file}"
 rm ${versions_file}
 
+echo
 echo "All done!"

--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -30,4 +30,11 @@ $(dirname $0)/../steps/setup-agent.sh ${master_vm} ${agent_vm} ${agent_version} 
 echo "#### Running validation"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}
 
+echo "#### Sending parameters to Artifactory for use by repo smoke test"
+versions_file=${agent_version}.yaml
+echo "puppetserver: ${server_version}" > ${versions_file}
+echo "puppetdb: ${puppetdb_version}" >> ${versions_file}
+curl -T ${versions_file} "https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/puppet-agent-version-compatibility/${versions_file}"
+rm ${versions_file}
+
 echo "All done!"


### PR DESCRIPTION
This commit updates the package smoke test script to send the version
parameters used to Artifactory. This will allow us to fetch the same parameters
for use in the repo smoke test that's run after the release.