### PR TITLE
(maint) Save smoke test params as json

### DIFF
--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -31,9 +31,11 @@ echo "#### Running validation"
 $(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}
 
 echo "#### Sending parameters to Artifactory for use by repo smoke test"
-versions_file=${agent_version}.yaml
-echo "puppetserver: ${server_version}" > ${versions_file}
-echo "puppetdb: ${puppetdb_version}" >> ${versions_file}
+versions_file=${agent_version}.json
+echo "{" > ${versions_file}
+echo "\"puppetserver\":\"${server_version}\"," >> ${versions_file}
+echo "\"puppetdb\":\"${puppetdb_version}\"" >> ${versions_file}
+echo "}" >> ${versions_file}
 curl -T ${versions_file} "https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/puppet-agent-version-compatibility/${versions_file}"
 rm ${versions_file}
 

--- a/ext/smoke/packages/run-smoke-test.sh
+++ b/ext/smoke/packages/run-smoke-test.sh
@@ -32,12 +32,13 @@ $(dirname $0)/../steps/run-validation-tests.sh ${master_vm} ${agent_vm}
 
 echo "#### Sending parameters to Artifactory for use by repo smoke test"
 versions_file=${agent_version}.json
-echo "{" > ${versions_file}
-echo "\"puppetserver\":\"${server_version}\"," >> ${versions_file}
-echo "\"puppetdb\":\"${puppetdb_version}\"" >> ${versions_file}
-echo "}" >> ${versions_file}
-curl -T ${versions_file} "https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/puppet-agent-version-compatibility/${versions_file}"
-rm ${versions_file}
+version_data="{
+                \"puppetserver\":\"$server_version\",
+                \"puppetdb\":\"$puppetdb_version\"
+              }"
+echo $version_data > $versions_file
+curl -T $versions_file "https://artifactory.delivery.puppetlabs.net/artifactory/scratchpad__local/puppet-agent-version-compatibility/${versions_file}"
+rm $versions_file
 
 echo
 echo "All done!"


### PR DESCRIPTION
This commit updates the repo smoke test script to send parameters to Artifactory
as json instead of yaml. This allows us to make use of bash tools, like jq, that
already exist on the Jenkins workers that will consume these params.