### PR TITLE
(maint) Merge b2e59a5 to 6 0 x

### DIFF
--- a/configs/platforms/osx-10.12-x86_64.rb
+++ b/configs/platforms/osx-10.12-x86_64.rb
@@ -18,7 +18,7 @@ platform "osx-10.12-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-  packages = ['boost']
+  packages = ['boost@1.60']
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
   plat.vmpooler_template 'osx-1012-x86_64'

--- a/configs/platforms/osx-10.13-x86_64.rb
+++ b/configs/platforms/osx-10.13-x86_64.rb
@@ -19,7 +19,7 @@ platform "osx-10.13-x86_64" do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-  packages = ['boost']
+  packages = ['boost@1.60']
 
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
   plat.vmpooler_template 'osx-1013-x86_64'

--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -16,10 +16,8 @@ platform 'osx-10.14-x86_64' do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
-
-  packages = ['boost']
+  packages = ['boost@1.60']
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-
   plat.vmpooler_template 'osx-1014-x86_64'
   plat.output_dir File.join('apple', '10.14', 'puppet6', 'x86_64')
 end


### PR DESCRIPTION
    * commit 'b2e59a5ac9ab2bd46b437ffaf6b82276b297e7be':
      (PA-2893) pin boost to 1.60 on osx
      (maint) Update puppet-runtime to 201909040

     Conflicts:
            configs/platforms/osx-10.14-x86_64.rb
