### PR TITLE
(maint) Disable cpp warnings on macOS

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -12,11 +12,7 @@ component "cpp-hocon" do |pkg, settings, platform|
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    if platform.name =~ /osx-10.14/ #apple's clang 10 complains about delete-non-virtual-destructor
-      special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-delete-non-virtual-dtor'"
-    else
-      special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
-    end
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -28,11 +28,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     platform_flags = '-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-bbigtoc"'
   elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
-    if platform.name =~ /osx-10.14/#apple's clang 10 complains about expansion-to-defined
-      platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-expansion-to-defined'"
-    else
-      platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
-    end
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
   elsif platform.is_cross_compiled_linux?

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -130,11 +130,7 @@ component "facter" do |pkg, settings, platform|
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    if platform.name =~ /osx-10.14/ #apple's clang 10 complains about expansion-to-defined and delete-non-virtual-destructor
-      special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-delete-non-virtual-dtor -Wno-expansion-to-defined'"
-    else
-      special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
-    end
+    special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -46,11 +46,7 @@ component "leatherman" do |pkg, settings, platform|
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    if platform.name =~ /osx-10.14/
-      special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-expansion-to-defined' -DLEATHERMAN_MOCK_CURL=FALSE"
-    else
-      special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DLEATHERMAN_MOCK_CURL=FALSE"
-    end
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -31,11 +31,7 @@ component "pxp-agent" do |pkg, settings, platform|
   elsif platform.is_macos?
     cmake = "/usr/local/bin/cmake"
     toolchain = ""
-    if platform.name =~ /osx-10.14/ #apple's clang 10 complains about expansion-to-defined and delete-non-virtual-destructor
-      special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-expansion-to-defined -Wno-delete-non-virtual-dtor'"
-    else
-      special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
-    end
+    special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = "-DBOOST_STATIC=OFF"
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"


### PR DESCRIPTION
This is more future proof than disabling specific warnings based on OS version.