### PR TITLE
(maint) Update minimum packaging version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place)
 end
 
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15.17')
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.43')
 gem 'artifactory'
 gem 'rake'
 gem 'json'


### PR DESCRIPTION
This commit updates the minimum packaging dependency to 0.99.43. This includes
support for windowsfips. Lately, bundler has begun installing old versions of
packaging in CI, so this update ensures that we use up-to-date packaging.