### PR TITLE
(PA-2840) fix windowsfips build_details definition

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -43,7 +43,7 @@ pe_platforms:
   - solaris-10-sparc
   - solaris-11-i386
   - solaris-11-sparc
-  - windowsfips-2012r2-x64
+  - windowsfips-2012-x64
 platform_repos:
   - name: aix-6.1-power
     repo_location: repos/aix/6.1/**/ppc


### PR DESCRIPTION
This was already cherry-picked in master to speed up the process, since we need windowsfips just in master