### PR TITLE
(maint) Group gem dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ steps:
     $gempath = Join-Path -Path (Get-Location) -ChildPath 'docker/.bundle/gems'
     bundle config --local gemfile $gemfile
     bundle config --local path $gempath
-    bundle install
+    bundle install --with test
   displayName: Fetch Dependencies
   name: fetch_deps
 

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,8 +1,11 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem 'rspec'
-gem 'rspec_junit_formatter'
 gem 'pupperware',
   :git => 'https://github.com/puppetlabs/pupperware.git',
   :ref => 'master',
   :glob => 'gem/*.gemspec'
+
+group :test do
+  gem 'rspec'
+  gem 'rspec_junit_formatter'
+end

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -41,7 +41,7 @@ ifeq ($(IS_LATEST),true)
 endif
 
 test: prep
-	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE --with test
 	@bundle update
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/puppet-agent-ubuntu:$(version) \
 		bundle exec --gemfile $$GEMFILE rspec spec


### PR DESCRIPTION
Allows us to speed up calls to bundler by specifying groups to operate on.