### PR TITLE
(maint) Remove solarisstudio

### DIFF
--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -3,6 +3,7 @@ platform "solaris-11-i386" do |plat|
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
   plat.vmpooler_template "solaris-11-x86_64"
+  plat.provision_with("/usr/bin/pkg unset-publisher solarisstudio")
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "puppet5")

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -4,6 +4,7 @@ platform "solaris-11-sparc" do |plat|
   plat.servicetype "smf"
   plat.cross_compiled true
   plat.vmpooler_template "solaris-11-x86_64"
+  plat.provision_with("/usr/bin/pkg unset-publisher solarisstudio")
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "puppet5")


### PR DESCRIPTION
This PR removes solarisstudio publisher from Solaris 11 VMs. This publisher is not used in the agent pipeline