### PR TITLE
(maint) Emit docker build command line

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,9 +31,9 @@ else
 endif
 
 build: prep
-	@docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
+	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
-	@docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(pwd)/..
+	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(pwd)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent-ubuntu:$(LATEST_VERSION)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(LATEST_VERSION)

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -47,6 +47,8 @@ function Build-Container(
   {
     $docker_args += @('--memory', '3g')
 
+    Write-Host "docker build --pull --file puppet-agent-alpine/windows-build/Dockerfile.build --tag $Namespace/puppet-agent-alpine:build ."
+
     # fake multistage builds for Windows since LCOW doesn't support yet
     docker build --pull `
       --file puppet-agent-alpine/windows-build/Dockerfile.build `
@@ -63,6 +65,8 @@ function Build-Container(
       /usr/lib/ruby/gems `
       /srv
   }
+
+  Write-Host "docker build $docker_args puppet-agent-$Base"
 
   docker build $docker_args puppet-agent-$Base
 


### PR DESCRIPTION
Verified Travis

> docker build --pull --build-arg vcs_ref=044948767d23656426c74e1a99506d94b63b3e7c --build-arg build_date=2019-10-27T07:02:52 --build-arg version=6.10.1 --file puppet-agent-ubuntu/Dockerfile --tag puppet/puppet-agent-ubuntu:6.10.1 puppet-agent-ubuntu

> docker build --pull --build-arg vcs_ref=044948767d23656426c74e1a99506d94b63b3e7c --build-arg build_date=2019-10-27T07:02:52 --build-arg version=6.10.1 --file puppet-agent-alpine/Dockerfile --tag puppet/puppet-agent-alpine:6.10.1 /home/travis/build/puppetlabs/puppet-agent/docker/..

~Azure builds behave differently on this repo, and don't emit the same info.~

Added extra commit for Azure to get:

> docker build --pull --build-arg vcs_ref=044948767d23656426c74e1a99506d94b63b3e7c --build-arg build_date=--build-arg version=6.10.1 --file puppet-agent-ubuntu//Dockerfile --tag puppet/puppet-agent-ubuntu:6.10.1 --tag puppet/puppet-agent:6.10.1 puppet-agent-ubuntu


This repo doesn't use the standard `Build-Container` helper. Until it does, this will have to suffice.