### PR TITLE
(PA-2986) Update GCC compiler/linker flags

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -31,10 +31,12 @@ component "cpp-hocon" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
   elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
+    pkg.environment "CPPFLAGS", settings[:cppflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -45,11 +45,13 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
   elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
+    pkg.environment "CPPFLAGS", settings[:cppflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
-    special_flags = " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
+    special_flags = " -DENABLE_CXX_WERROR=OFF"
   elsif platform.is_cisco_wrlinux?
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -157,11 +157,13 @@ component "facter" do |pkg, settings, platform|
                      -DRUBY_LIB_INSTALL=#{settings[:facter_root]}/lib "
   elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
+    pkg.environment "CPPFLAGS", settings[:cppflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
-    special_flags += " -DENABLE_CXX_WERROR=OFF " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
+    special_flags += " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -74,10 +74,14 @@ component "leatherman" do |pkg, settings, platform|
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
   elsif platform.name =~ /sles-15|fedora-(29|30)|el-8|debian-10/
     # These platforms use the default OS toolchain, rather than pl-build-tools
+    pkg.environment "CPPFLAGS", settings[:cppflags]
+    pkg.environment "LDFLAGS", settings[:ldflags]
     cmake = "cmake"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='-O1' " if platform.name =~ /el-8|fedora-(29|30)|debian-10/
+
+    # Workaround for hanging leatherman tests (-fno-strict-overflow)
+    special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -fno-strict-overflow' "
   else
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"


### PR DESCRIPTION
Harden Linux ELF binaries by compiling with PIE (Position Independent Executables) support, stack canary and full RELRO.

We only do this on platforms that use their default OS toolchain since pl-gcc versions are too old to support these flags.

Relevant flags are:

CPPFLAGS="-D_FORTIFY_SOURCE=2"
CFLAGS="-fstack-protector-strong -fno-plt"
LDFLAGS="-z,relro,-z,now"

The relevant settings are inherited from puppet-runtime, here we make sure we are putting them in the right places.

To be merged after a runtime with https://github.com/puppetlabs/puppet-runtime/pull/245 is promoted.