### PR TITLE
(PA-2780) CFPropertyList in wrong folder for PA

### DIFF
--- a/configs/components/cfpropertylist.json
+++ b/configs/components/cfpropertylist.json
@@ -1,1 +1,0 @@
-{"url": "git://github.com/ckruse/CFPropertyList.git", "ref": "cfpropertylist-2.3.5"}

--- a/configs/components/cfpropertylist.rb
+++ b/configs/components/cfpropertylist.rb
@@ -1,9 +1,0 @@
-component "cfpropertylist" do |pkg, settings, platform|
-  pkg.load_from_json('configs/components/cfpropertylist.json')
-
-  pkg.build_requires "puppet-runtime" # Provides ruby
-
-  pkg.install do
-    ["cp -pr lib/* #{settings[:ruby_vendordir]}"]
-  end
-end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -118,11 +118,6 @@ project "puppet-agent" do |proj|
     proj.component "wrapper-script"
   end
 
-  # Components only applicable on OSX
-  if platform.is_macos?
-    proj.component "cfpropertylist"
-  end
-
   # Including headers can make the package unacceptably large; This component
   # removes files that aren't required.
   # Set the $DEV_BUILD environment variable to leave headers in place.


### PR DESCRIPTION
This commit removes CFProperty List component from puppet-agent as the
CFProperty List gem will be installed by puppet-runtime.