### PR TITLE
(PA-2780) CFPropertyList in wrong folder for PA

### DIFF
--- a/configs/components/cfpropertylist.json
+++ b/configs/components/cfpropertylist.json
@@ -1,1 +1,0 @@
-{"url": "git://github.com/ckruse/CFPropertyList.git", "ref": "cfpropertylist-2.3.5"}

--- a/configs/components/cfpropertylist.rb
+++ b/configs/components/cfpropertylist.rb
@@ -1,9 +1,0 @@
-component "cfpropertylist" do |pkg, settings, platform|
-  pkg.load_from_json('configs/components/cfpropertylist.json')
-
-  pkg.build_requires "puppet-runtime" # Provides ruby
-
-  pkg.install do
-    ["cp -pr lib/* #{settings[:ruby_vendordir]}"]
-  end
-end

--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"http://builds.delivery.puppetlabs.net/puppet-runtime/201912170/artifacts/","version":"201912170"}
+{"location":"http://builds.delivery.puppetlabs.net/puppet-runtime/30ab4280fe96bab25f4b61087ae3963aac83f5c2/artifacts/","version":"201810110.309.g30ab428"}

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -119,9 +119,9 @@ project "puppet-agent" do |proj|
   end
 
   # Components only applicable on OSX
-  if platform.is_macos?
-    proj.component "cfpropertylist"
-  end
+  # if platform.is_macos?
+  #   proj.component "cfpropertylist"
+  # end
 
   # Including headers can make the package unacceptably large; This component
   # removes files that aren't required.


### PR DESCRIPTION
PR JUST TO TEST PUPPET-AGENT WITH different runtime

This commit removes CFProperty List component from puppet-agent as the
CFProperty List gem will be installed by puppet-runtime.