### PR TITLE
(maint) ignore selinux test on ubuntu14, fedora28 and el6

### DIFF
--- a/acceptance/tests/selinux.rb
+++ b/acceptance/tests/selinux.rb
@@ -4,12 +4,12 @@ test_name 'PA-3067: Manage selinux' do
       'audit:acceptance'
 
   confine :to, :platform => /el-|fedora-|debian-|ubuntu-/
-  confine :except, :platform => /ubuntu-.*-ppc64el/
+  confine :except, :platform => /ubuntu-.*-ppc64el|ubuntu-14|fedora-28|el-6/
 
   require 'puppet/acceptance/common_utils'
 
   agents.each do |agent|
     step "test require 'selinux'"
-    on agent, "#{ruby_command(agent)} -e 'require \"selinux\"'"
+      on agent, "#{ruby_command(agent)} -e 'require \"selinux\"'"
   end
 end


### PR DESCRIPTION
This PR removes the SELinux test for running on the following platforms:
- ubuntu-14 - We do not provide Ruby SELinux on Ubuntu 14.04
- fedora 28 - Ticket: https://tickets.puppetlabs.com/browse/PA-3069
- el6 - require selinux workes on CentOS 6 and RedHat6 but fails on Amazon Linux 6. Ticket: https://tickets.puppetlabs.com/browse/PA-3068