### PR TITLE
(maint) Merge up 6.4.x to master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Docker test and publish
+
+on:
+  push:
+    branches:
+      - 6.4.x
+      - master
+
+jobs:
+  build-and-publish:
+    env:
+      PUPPERWARE_ANALYTICS_STREAM: production
+      IS_LATEST: true
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - run: gem install bundler
+      - name: Set custom latest version
+        if: endsWith(github.ref, '/6.4.x')
+        run: echo "::set-env name=LATEST_VERSION::6.4"
+      - name: Build container
+        working-directory: docker
+        run: make lint build test
+      - name: Publish container
+        working-directory: docker
+        run: |
+          docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+          make publish

--- a/acceptance/tests/selinux.rb
+++ b/acceptance/tests/selinux.rb
@@ -1,0 +1,15 @@
+test_name 'PA-3067: Manage selinux' do
+
+  tag 'audit:low',
+      'audit:acceptance'
+
+  confine :to, :platform => /el-|fedora-|debian-|ubuntu-/
+  confine :except, :platform => /ubuntu-.*-ppc64el|ubuntu-14|fedora-28|el-6/
+
+  require 'puppet/acceptance/common_utils'
+
+  agents.each do |agent|
+    step "test require 'selinux'"
+      on agent, "#{ruby_command(agent)} -e 'require \"selinux\"'"
+  end
+end

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -7,5 +7,5 @@ platform "el-8-x86_64" do |plat|
 
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
-  plat.vmpooler_template "redhat-8-x86_64"
+  plat.vmpooler_template "centos-8-x86_64"
 end

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,10 +5,9 @@ build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 --ignore DL3028
 hadolint_container := hadolint/hadolint:latest
-pwd := $(shell pwd)
-export BUNDLE_PATH = $(pwd)/.bundle/gems
-export BUNDLE_BIN = $(pwd)/.bundle/bin
-export GEMFILE = $(pwd)/Gemfile
+export BUNDLE_PATH = $(PWD)/.bundle/gems
+export BUNDLE_BIN = $(PWD)/.bundle/bin
+export GEMFILE = $(PWD)/Gemfile
 
 version = $(shell echo $(git_describe) | sed 's/-.*//')
 dockerfile := Dockerfile
@@ -33,7 +32,7 @@ endif
 build: prep
 	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
-	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(pwd)/..
+	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent-ubuntu:$(LATEST_VERSION)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(LATEST_VERSION)

--- a/docker/distelli-manifest.yml
+++ b/docker/distelli-manifest.yml
@@ -1,9 +1,0 @@
-pe-and-platform/puppet-agent:
-  PreBuild:
-    - make lint
-  Build:
-    - make build
-    - make test
-  AfterBuildSuccess:
-    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
-    - make publish

--- a/resources/windows/wix/localization/puppet_en-us.wxl
+++ b/resources/windows/wix/localization/puppet_en-us.wxl
@@ -260,6 +260,11 @@
     <String Id="WelcomeUpdateDlgDescriptionUpdate" Overridable="yes"><!-- _locID_text="WelcomeUpdateDlgDescriptionUpdate" _locComment="WelcomeUpdateDlgDescriptionUpdate" -->This will update [ProductName] to version [VersionUIString] and configure the system to fetch configurations every half hour given a valid master. This installer also includes tooling to run Puppet standalone, independent of a master.</String>
     <String Id="WelcomeDlgTitle" Overridable="yes"><!-- _locID_text="WelcomeDlgTitle" _locComment="WelcomeDlgTitle" -->{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
+    <String Id="WarningDlg_Title" Overridable="yes"><!-- _locID_text="WarningDlg_Title" _locComment="WarningDlg_Title" -->[ProductName] Warning</String>
+    <String Id="WarningDlgBitmap" Overridable="yes"><!-- _locID_text="WarningDlgBannerBitmap" _locComment="WarningDlgBannerBitmap" -->WixUI_Bmp_Dialog</String>
+    <String Id="WarningDlgDescription" Overridable="yes"><!-- _locID_text="WarningDlgDescription" _locComment="WarningDlgDescription" -->Deprecation warning: On January 14, 2020, support for Windows Server 2008 and 2008 R2 will end.</String>
+    <String Id="WarningDlgTitle" Overridable="yes"><!-- _locID_text="WarningDlgTitle" _locComment="WarningDlgTitle" -->{\WixUI_Font_Bigger}Operating System Compatibility Warning</String>
+
     <String Id="WelcomeEulaDlg_Title" Overridable="yes"><!-- _locID_text="WelcomeEulaDlg_Title" _locComment="WelcomeEulaDlg_Title" -->[ProductName] Setup</String>
     <String Id="WelcomeEulaDlgBitmap" Overridable="yes"><!-- _locID_text="WelcomeEulaDlgBitmap" _locComment="WelcomeEulaDlgBitmap" -->WixUI_Bmp_Dialog</String>
     <String Id="WelcomeEulaDlgLicenseAcceptedCheckBox" Overridable="yes"><!-- _locID_text="WelcomeEulaDlgLicenseAcceptedCheckBox" _locComment="WelcomeEulaDlgLicenseAcceptedCheckBox" -->I &amp;accept the terms in the License Agreement</String>

--- a/resources/windows/wix/ui/WarningDlg.wxs
+++ b/resources/windows/wix/ui/WarningDlg.wxs
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Microsoft Corporation.  All rights reserved.
+
+    The use and distribution terms for this software are covered by the
+    Common Public License 1.0 (http://opensource.org/licenses/cpl1.0.php)
+    which can be found in the file CPL.TXT at the root of this distribution.
+    By using this software in any fashion, you are agreeing to be bound by
+    the terms of this license.
+
+    You must not remove this notice, or any other, from this software.
+-->
+
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI>
+            <Dialog Id="WarningDlg" Width="370" Height="270" Title="!(loc.WarningDlg_Title)">
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+
+                <Control Id="Description" Type="Text" X="135" Y="80" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.WarningDlgDescription)" />
+                <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.WarningDlgTitle)" />
+                <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="!(loc.WarningDlgBitmap)" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
+++ b/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
@@ -60,8 +60,13 @@ Patch dialog sequence:
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
-      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg"><![CDATA[NOT Installed]]></Publish>
-      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[Installed AND PATCH]]></Publish>
+     <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg" Order="1"><![CDATA[NOT Installed]]></Publish>
+     <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="1"><![CDATA[Installed AND PATCH]]></Publish>
+     <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="WarningDlg" Order="2"><![CDATA[VersionNT <= 601]]></Publish>
+ 
+      <Publish Dialog="WarningDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg"><![CDATA[NOT Installed]]></Publish>
+      <Publish Dialog="WarningDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[Installed AND PATCH]]></Publish>
+      <Publish Dialog="WarningDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"></Publish>
 
       <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"></Publish>
       <Publish Dialog="PuppetLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="PuppetInstallDirDlg">LicenseAccepted = "1"</Publish>
@@ -89,8 +94,13 @@ Patch dialog sequence:
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
-      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg"><![CDATA[NOT VersionNT64 AND NOT Installed]]></Publish>
-      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[NOT VersionNT64 AND Installed AND PATCH]]></Publish>
+      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg" Order="1"><![CDATA[NOT VersionNT64 AND NOT Installed]]></Publish>
+      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="1"><![CDATA[NOT VersionNT64 AND Installed AND PATCH]]></Publish>
+      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="WarningDlg" Order="2"><![CDATA[VersionNT <= 601]]></Publish>
+
+      <Publish Dialog="WarningDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg"><![CDATA[NOT Installed]]></Publish>
+      <Publish Dialog="WarningDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[Installed AND PATCH]]></Publish>
+      <Publish Dialog="WarningDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"></Publish>
 
       <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"><![CDATA[VersionNT >= 600]]></Publish>
       <Publish Dialog="PuppetLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="PuppetInstallDirDlg">LicenseAccepted = "1"</Publish>


### PR DESCRIPTION
* upstream/6.4.x:
  (maint) Update puppet to 0cef45942416e8c1d53f669af136aa3dda521e20
  (maint) ignore selinux test on ubuntu14, fedora28 and el6
  (maint) Update puppet-runtime to 202001090
  (maint) Update puppet-runtime to 202001090
  (PA-3067) Add selinux test
  (packaging) Bump to version '5.5.19' [no-promote]
  (maint) remove distelli-manifest.yml
  (maint) Makefile simplification
  (maint) standardize makefile with master branch
  (maint) Add github action for docker build
  (PA-3018) Add warning for Win2008
  (maint) Update puppet-runtime to 202001070