### PR TITLE
(PA-2994) Add macOS 10.15 platform definition

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,0 +1,23 @@
+platform 'osx-10.15-x86_64' do |plat|
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename "catalina"
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/'
+    packages = ['boost@1.60']
+    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+    plat.vmpooler_template 'osx-1015-x86_64'
+    plat.output_dir File.join('apple', '10.15', 'puppet5', 'x86_64')
+  end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -23,6 +23,7 @@ foss_platforms:
   - osx-10.12-x86_64
   - osx-10.13-x86_64
   - osx-10.14-x86_64
+  - osx-10.15-x86_64
   - sles-11-i386
   - sles-11-x86_64
   - sles-12-x86_64
@@ -116,6 +117,8 @@ platform_repos:
     repo_location: repos/apple/10.13/**/x86_64/*.dmg
   - name: osx-10.14
     repo_location: repos/apple/10.14/**/x86_64/*.dmg
+  - name: osx-10.15
+    repo_location: repos/apple/10.15/**/x86_64/*.dmg
   - name: solaris-10-i386
     repo_location: repos/solaris/10/**/*.i386.pkg.gz
   - name: solaris-10-sparc


### PR DESCRIPTION
Blocked on:
- [x] https://github.com/puppetlabs/puppet-runtime/pull/290
- [x] https://github.com/puppetlabs/beaker/pull/1612
- [x] release of beaker
- [x] release of beaker-hostgenerator
- [x] puppet-runtime builds in CI