### PR TITLE
(maint) force posix boost random provider [cherry-pick] -> master

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -46,6 +46,7 @@ component "leatherman" do |pkg, settings, platform|
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
+    special_flags = "-DCMAKE_CXX_FLAGS='-DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX'"
   elsif platform.is_solaris?
     if platform.architecture == 'sparc'
       ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"


### PR DESCRIPTION
in cross compiled environment, boost could configure randomizer based on kernel sources on host that can be newer that the kernel running on target leading to errors at run-time:
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::uuids::entropy_error> >'
  what():  getrandom
Aborted
```
See https://github.com/boostorg/uuid/issues/91