### PR TITLE
(maint) remove build-tools repository from el-5

### DIFF
--- a/configs/platforms/el-5-i386.rb
+++ b/configs/platforms/el-5-i386.rb
@@ -4,7 +4,7 @@ platform "el-5-i386" do |plat|
   plat.servicetype "sysv"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch' > /etc/yum.repos.d/build-tools.repo"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck "
   plat.vmpooler_template "centos-5-i386"
 end

--- a/configs/platforms/el-5-x86_64.rb
+++ b/configs/platforms/el-5-x86_64.rb
@@ -4,7 +4,7 @@ platform "el-5-x86_64" do |plat|
   plat.servicetype "sysv"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
   plat.vmpooler_template "centos-5-x86_64"
 end


### PR DESCRIPTION
The build-tools repository was added in 2014: https://github.com/puppetlabs/puppet-agent/commit/b6153b66ebd550192b57122da71ef14726dad864, the reason is unknown but looking through the history it seems that it has been replaced by pl-build-tools and was not removed from the build process.
This PR removes build-tools as it is no longer used for the build process and the endpoint was removed causing the build to fail:
```
23:04:31 Executing 'yum install -y --nogpgcheck  pl-gettext e2fsprogs-devel pl-cmake util-linux pl-gcc ' on 'root@[REDACTED]'
23:04:31 Warning: Permanently added '[REDACTED],[REDACTED]' (RSA) to the list of known hosts.
23:04:31 Loaded plugins: fastestmirror, security
23:04:31 Loading mirror speeds from cached hostfile
23:04:32 http://enterprise.delivery.puppetlabs.net/build-tools/el/5/i386/repodata/repomd.xml: [Errno 14] HTTP Error 404: Not Found
23:04:32 Trying other mirror.
23:04:32 Error: Cannot retrieve repository metadata (repomd.xml) for repository: build-tools. Please verify its path and try again
23:04:32 An error was encountered evaluating block. Retrying..
23:04:32 Executing 'yum install -y --nogpgcheck  pl-gettext e2fsprogs-devel pl-cmake util-linux pl-gcc ' on 'root@[REDACTED]'
23:04:32 Warning: Permanently added '[REDACTED],10.32.122.182' (RSA) to the list of known hosts.
23:04:32 Loaded plugins: fastestmirror, security
23:04:32 Loading mirror speeds from cached hostfile
23:04:32 http://enterprise.delivery.puppetlabs.net/build-tools/el/5/i386/repodata/repomd.xml: [Errno 14] HTTP Error 404: Not Found
23:04:32 Trying other mirror.
23:04:32 Error: Cannot retrieve repository metadata (repomd.xml) for repository: build-tools. Please verify its path and try again
23:04:32 An error was encountered evaluating block. Retrying..
23:04:32 Block failed maximum number of 2 tries
```