### PR TITLE
(maint) Update nssm to 2.25.0

### DIFF
--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/nssm.git","ref":"4951a7870b68c6f90f35745fecc1c0a42dc00401"}
+{"url":"git://github.com/puppetlabs/nssm.git","ref":"refs/tags/2.25.0"}


### PR DESCRIPTION
2.25.0 was tagged at 4951a7870b68c6f90f35745fecc1c0a42dc00401: https://github.com/puppetlabs/nssm/compare/2.24.2...2.25.0