### PR TITLE
(maint) pin pl-toolchain version - 5.5.x (cherry-pick)

### DIFF
--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -8,7 +8,6 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
     pkg.build_requires "cmake"
   elsif platform.is_windows?
     pkg.build_requires "cmake"
-    pkg.build_requires "pl-toolchain-#{platform.architecture}"
   elsif platform.name =~ /sles-15/
     # These platforms use their default OS toolchain and have package
     # dependencies configured in the platform provisioning step.

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -16,7 +16,6 @@ component "leatherman" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/6.1/ppc/pl-gettext-0.19.8-2.aix6.1.ppc.rpm"
   elsif platform.is_windows?
     pkg.build_requires "cmake"
-    pkg.build_requires "pl-toolchain-#{platform.architecture}"
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.name =~ /sles-15|el-8|debian-10/ || platform.is_fedora?
     # These platforms use their default OS toolchain and have package

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -17,6 +17,7 @@ platform "windows-2012r2-x64" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y pl-toolchain-x64 -version 2015.12.01.1 -debug --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -17,6 +17,7 @@ platform "windows-2012r2-x86" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y pl-toolchain-x86 -version 2015.12.01.1 -debug --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long

--- a/configs/platforms/windowsfips-2012r2-x64.rb
+++ b/configs/platforms/windowsfips-2012r2-x64.rb
@@ -19,6 +19,7 @@ platform "windowsfips-2012r2-x64" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y pl-toolchain-x64 -version 2015.12.01.1 -debug --no-progress"
 
   #FIXME we need Fips Compliant Wix, currently not in choco repositories
   #plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"


### PR DESCRIPTION
following artifactory update to 6.18.1, the version advertized as
latest changed to previous one for pl-toolchain package and now we
need to specifically request the latest version at least until issue
is checked/fixed on artifactory side