### PR TITLE
(maint) Enable linux docker buildkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+dist: bionic
 sudo: false
 services:
+  # bionic uses 18.06 but need 19.03+ so upgrade later in relevant cell
   - docker
 git:
   depth: 150
@@ -27,9 +29,14 @@ matrix:
       rvm: 2.5.5
       env:
         - DOCKER_COMPOSE_VERSION=1.24.0
+        # necessary to prevent overwhelming TravisCI build output limits
+        - DOCKER_BUILD_FLAGS="--progress plain"
       script:
         - |
           set -ex
+          sudo apt update -y && sudo apt install -y docker.io
+          sudo systemctl unmask docker.service
+          sudo systemctl start docker
           sudo rm /usr/local/bin/docker-compose
           curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
           chmod +x docker-compose

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,7 @@ hadolint_container := hadolint/hadolint:latest
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
+export DOCKER_BUILDKIT = 1
 
 version = $(shell echo $(git_describe) | sed 's/-.*//')
 dockerfile := Dockerfile
@@ -30,9 +31,9 @@ else
 endif
 
 build: prep
-	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
+	docker build ${DOCKER_BUILD_FLAGS} --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
-	docker build --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
+	docker build ${DOCKER_BUILD_FLAGS} --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent-ubuntu:$(LATEST_VERSION)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(LATEST_VERSION)


### PR DESCRIPTION
Turns on Buildkit to improve Docker build performance

Builds on #1889 

This turns out to be trickier than I originally anticipated, so I'm moving this effort to a separate PR.


From what I can tell, removing `gcr.io` from `daemon.json` and restarting Docker doesn't resolve the problem (as described in https://github.com/moby/buildkit/issues/606#issuecomment-453959632)

I solved this once before in https://github.com/puppetlabs/docker-pe-postgres/pull/18 ... there is a 30s penalty to upgrading Docker.


Another solution in Travis is to use the container that runs buildkit - i.e. https://travis-ci.community/t/docker-builds-are-broken-if-buildkit-is-used-docker-buildkit-1/2994/4

Some more ideas are here -- https://blog.alexellis.io/building-containers-without-docker/