### PR TITLE
(maint) Use letherman master for PA master

### DIFF
--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /workspace
 RUN sed -i -e 's/sys\/poll/poll/' /usr/include/boost/asio/detail/socket_types.hpp
 
 COPY configs/components/leatherman.json /workspace
-RUN git clone -b 1.5.x https://github.com/puppetlabs/leatherman && \
+RUN git clone -b master https://github.com/puppetlabs/leatherman && \
     mkdir -p /workspace/leatherman/build
 WORKDIR /workspace/leatherman/build
 RUN git checkout "$(jq .ref /workspace/leatherman.json | tr -d \")" && \


### PR DESCRIPTION
1.5.x branch of leatherman was incorrectly promoted to Puppet Agent master.
This branch was part of the 6.0.x release. Since we're no longer providing builds for this release the branch was deleted causing the PR tests to fail.
