### PR TITLE
(maint) Merge 1.10.x to 5.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 git:
-  depth: 150
+  depth: 250
 language: ruby
 bundler_args: --without development
 before_install:


### PR DESCRIPTION
* pl/1.10.x:
  (maint) increase the travis clone depth
  (maint) Update puppet-runtime to 202004280
  (maint) Add ability to load upstream metadata

  Conflicts:
 	configs/projects/puppet-agent.rb

  Conflict was resolved by keeping `agent_branch = '5.5.x'` on 5.5.x branch
