### PR TITLE
(maint) remove ubuntu 14.04 from deb_targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -117,7 +117,7 @@ platform_repos:
     repo_location: repos/solaris/11/**/*.sparc.p5p
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
-deb_targets: 'trusty-amd64 xenial-amd64 bionic-amd64'
+deb_targets: 'xenial-amd64 bionic-amd64'
 rpm_targets: 'el-6-x86_64 el-7-x86_64 sles-11-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"


### PR DESCRIPTION
deb_targets should only contain the deb platforms
that are supported as a master.