### PR TITLE
Merge up 5.5.x to master

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -114,7 +114,7 @@ platform_repos:
     repo_location: repos/solaris/11/**/*.sparc.p5p
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
-deb_targets: 'trusty-amd64 xenial-amd64 bionic-amd64'
+deb_targets: 'xenial-amd64 bionic-amd64'
 rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 redhatfips-7-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"


### PR DESCRIPTION
```
* pl/5.5.x:
  (maint) Update pxp-agent to 02b21ab894e0ce826c46d5015a29cf342953c932
  (maint) Update puppet-runtime to 202005083
  (maint) Update puppet-runtime to 202005083
  (maint) Update puppet-runtime to 202005082
  (maint) Update puppet-runtime to 202005082
  (maint) Update puppet-runtime to 202005081
  (maint) Update puppet-runtime to 202005081
  (maint) Update puppet-runtime to 202005080
  (maint) Update puppet-runtime to 202005080
  (maint) Update puppet to d317a9acfb1e04dfec8b49a72dbee098ec232eda
  (maint) remove ubuntu 14.04 from deb_targets
  (maint) Update puppet to 7d0aee3338edf4fdca88a493a8025e9c98374c62

  Conflicts:
 	configs/components/puppet-runtime.json
 	configs/components/puppet.json
 	configs/components/pxp-agent.json
 	ext/build_defaults.yaml

 Conflics were solved by keeping components configuration from master and removing
 `trusty-amd64` from master version of `ext/build_defaults.yaml`
```