### PR TITLE
(maint) pull docker images before build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,6 +5,8 @@ build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint
 hadolint_container := hadolint/hadolint:latest
+alpine_version := 3.9
+ubuntu_version := 18.04
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
@@ -31,9 +33,11 @@ else
 endif
 
 build: prep
-	docker build ${DOCKER_BUILD_FLAGS} --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
+	docker pull alpine:$(alpine_version)
+	docker pull ubuntu:$(ubuntu_version)
+	docker build ${DOCKER_BUILD_FLAGS} --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
-	docker build ${DOCKER_BUILD_FLAGS} --pull --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
+	docker build ${DOCKER_BUILD_FLAGS} --build-arg alpine_version=$(alpine_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent-ubuntu:$(LATEST_VERSION)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(LATEST_VERSION)

--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -1,8 +1,9 @@
 ######################################################
 # build tooling
 ######################################################
+ARG alpine_version=3.9
 
-FROM alpine:3.9 as build
+FROM alpine:${alpine_version} as build
 
 # note: JAVA_HOME cannot be defined in the same ENV block it's used in
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk

--- a/docker/puppet-agent-ubuntu/Dockerfile
+++ b/docker/puppet-agent-ubuntu/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:18.04
+ARG ubuntu_version=18.04
+
+FROM ubuntu:${ubuntu_version}
 
 ARG version="6.0.0"
 ARG vcs_ref


### PR DESCRIPTION
This PR ensures that the base docker images are available before building the Puppet Agent containers.

On travis `--pull` build argument seems to be causing the following transient error:
```
#3 [internal] load metadata for docker.io/library/alpine:3.9
#3 ERROR: docker.io/library/alpine:3.9 not found
#9 [internal] load build context
#9 transferring context: 10.45kB done
#9 DONE 0.0s
#4 [build 1/3] FROM docker.io/library/alpine:3.9
#4 resolve docker.io/library/alpine:3.9 0.0s done
#4 ERROR: docker.io/library/alpine:3.9 not found
```  