### PR TITLE
(maint) Switch Travis to Ubuntu 20.04 builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,14 @@ matrix:
         - DOCKER_COMPOSE_VERSION=1.25.5
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
       script:
-        - |
-          set -ex
-          sudo rm /usr/local/bin/docker-compose
-          curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-          cd docker
-          make lint
-          make build
-          make test
-          set +x
+        - set -e
+        - cd docker
+        - make lint
+        - make build
+        - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-dist: bionic
+dist: focal
 sudo: false
 services:
-  # bionic uses 18.06 but need 19.03+ so upgrade later in relevant cell
   - docker
 git:
   depth: 250
@@ -26,7 +25,7 @@ matrix:
       env: "CHECK=commits"
     - stage: puppet-agent container tests
       language: ruby
-      rvm: 2.5.5
+      rvm: 2.6.6
       env:
         - DOCKER_COMPOSE_VERSION=1.25.5
         # necessary to prevent overwhelming TravisCI build output limits
@@ -34,9 +33,6 @@ matrix:
       script:
         - |
           set -ex
-          sudo apt update -y && sudo apt install -y docker.io
-          sudo systemctl unmask docker.service
-          sudo systemctl start docker
           sudo rm /usr/local/bin/docker-compose
           curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
           chmod +x docker-compose

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
   CONTAINER_BUILD_PATH: .
   CONTAINER_NAME2: puppet-agent-alpine
   LINT_IGNORES:
-  BUILD_OPTIONS: --memory 3g
+  BUILD_OPTIONS: --memory 3g --build-arg alpine_version=3.9 --build-arg ubuntu_version=18.04
 
 workspace:
   clean: resources

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -35,7 +35,7 @@ endif
 build: prep
 	docker pull alpine:$(alpine_version)
 	docker pull ubuntu:$(ubuntu_version)
-	docker build ${DOCKER_BUILD_FLAGS} --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
+	docker build ${DOCKER_BUILD_FLAGS} --build-arg ubuntu_version=$(ubuntu_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
 	docker build ${DOCKER_BUILD_FLAGS} --build-arg alpine_version=$(alpine_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
 ifeq ($(IS_LATEST),true)


### PR DESCRIPTION
 - Focal fossa time!
 - No need to upgrade Docker for buildkit as image has 19.03 already,
   so this should remove ~30s of setup time
 - Switch to Ruby 2.6.6 for specs, which is known good and installed
 - docker-compose in the 19.03 release included here is 1.23.1, so
   continue to upgrade it on Travis to 1.25.5
 - Separate out Travis operations so that logs have timings for lint, build and test