### PR TITLE
(PA-3244) Changes to allow boost build 1.73.0

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "refs/tags/0.2.0"}
+{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "58e796e7d2902c5bae216e5be03677b05f43d2bc"}

--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -49,6 +49,15 @@ component "cpp-hocon" do |pkg, settings, platform|
 
   # Until we build our own gettext packages, disable using locales.
   # gettext 0.17 is required to compile .mo files with msgctxt.
+  #
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
@@ -57,6 +66,7 @@ component "cpp-hocon" do |pkg, settings, platform|
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
         #{boost_static_flag} \
+        -DBoost_NO_BOOST_CMAKE=ON \
         ."]
   end
 

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -55,6 +55,14 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     platform_flags = "-DLEATHERMAN_USE_LOCALES=OFF"
   end
 
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     [
       "#{cmake} \
@@ -67,6 +75,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
           -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
           -DCMAKE_SYSTEM_PREFIX_PATH=#{settings[:prefix]} \
           #{boost_static_flag} \
+          -DBoost_NO_BOOST_CMAKE=ON \
           #{special_flags} \
           ."
     ]

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -169,6 +169,15 @@ component "facter" do |pkg, settings, platform|
   end
 
   # FACTER_RUBY Needs bindir
+  #
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
@@ -178,6 +187,7 @@ component "facter" do |pkg, settings, platform|
         -DCMAKE_INSTALL_RPATH=#{settings[:libdir]} \
         -DRUBY_LIB_INSTALL=#{settings[:ruby_vendordir]} \
         #{special_flags} \
+        -DBoost_NO_BOOST_CMAKE=ON \
         #{boost_static_flag} \
         #{yamlcpp_static_flag} \
         -DWITHOUT_CURL=#{skip_curl} \

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -92,6 +92,15 @@ component "leatherman" do |pkg, settings, platform|
     pkg.environment "PATH", "/opt/pl-build-tools/bin:$(PATH)"
   end
 
+
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
@@ -104,6 +113,7 @@ component "leatherman" do |pkg, settings, platform|
         -DLEATHERMAN_SHARED=TRUE \
         #{special_flags} \
         #{boost_static_flag} \
+        -DBoost_NO_BOOST_CMAKE=ON \
         ."]
   end
 

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -47,6 +47,15 @@ component "libwhereami" do |pkg, settings, platform|
 
   # Until we build our own gettext packages, disable using locales.
   # gettext 0.17 is required to compile .mo files with msgctxt.
+  #
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     ["#{cmake} \
         #{toolchain} \
@@ -54,6 +63,7 @@ component "libwhereami" do |pkg, settings, platform|
         -DCMAKE_PREFIX_PATH=#{settings[:prefix]} \
         -DCMAKE_INSTALL_PREFIX=#{settings[:prefix]} \
         #{special_flags} \
+        -DBoost_NO_BOOST_CMAKE=ON \
         #{boost_static_flag} \
         ."]
   end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -66,6 +66,14 @@ component "pxp-agent" do |pkg, settings, platform|
     special_flags += " -DLEATHERMAN_USE_LOCALES=OFF "
   end
 
+  # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost
+  # 1.73 for PA-3244. https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake
+  # describes the setting itself (and what we are disabling). It
+  # may make sense in the future to remove this cmake parameter and
+  # actually make the boost build work with boost's own cmake
+  # helpers. But for now disabling boost's cmake helpers allow us
+  # to upgrade boost with minimal changes.
+  #                                  - Sean P. McDonald 5/19/2020
   pkg.configure do
     [
       "#{cmake}\
@@ -78,6 +86,7 @@ component "pxp-agent" do |pkg, settings, platform|
           -DMODULES_INSTALL_PATH=#{File.join(settings[:install_root], 'pxp-agent', 'modules')} \
           #{special_flags} \
           #{boost_static_flag} \
+          -DBoost_NO_BOOST_CMAKE=ON \
           ."
     ]
   end


### PR DESCRIPTION
This commit updates build configuration to prepare for boost 1.73.0. Two
changes were made:

1. Added -DBoost_NO_BOOST_CMAKE=ON to all cmake builds. That setting
will force cmake to ignore new cmake functions from boost > 1.70 that break
builds. See
https://cmake.org/cmake/help/v3.0/module/FindBoost.html#boost-cmake for more
details.

2. cpp-hocon has been updated to the HEAD of master to pick up
https://github.com/puppetlabs/cpp-hocon/commit/caab275509826dc5fe5ab2632582abb8f83ea2b3