### PR TITLE
(PA-3248) clean ruby env

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,14 @@ namespace :package do
   end
 end
 
+desc 'run static analysis with rubocop'
+task(:rubocop) do
+  require 'rubocop'
+  cli = RuboCop::CLI.new
+  exit_code = cli.run(%w(--display-cop-names --format simple))
+  raise "RuboCop detected offenses" if exit_code != 0
+end
+
 desc "verify that commit messages match CONTRIBUTING.md requirements"
 task(:commits) do
   commits = ENV['TRAVIS_COMMIT_RANGE']

--- a/resources/files/aix-wrapper.sh
+++ b/resources/files/aix-wrapper.sh
@@ -4,6 +4,14 @@ unset LIBPATH
 unset LDR_PRELOAD
 unset LDR_PRELOAD64
 unset LD_LIBRARY_PATH
+unset GEM_HOME
+unset GEM_PATH
+unset DLN_LIBRARY_PATH
+unset RUBYLIB
+unset RUBYLIB_PREFIX
+unset RUBYOPT
+unset RUBYPATH
+unset RUBYSHELL
 
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then

--- a/resources/files/osx-wrapper.sh
+++ b/resources/files/osx-wrapper.sh
@@ -2,6 +2,14 @@
 
 unset DYLD_LIBRARY_PATH
 unset DYLD_INSERT_LIBRARIES
+unset GEM_HOME
+unset GEM_PATH
+unset DLN_LIBRARY_PATH
+unset RUBYLIB
+unset RUBYLIB_PREFIX
+unset RUBYOPT
+unset RUBYPATH
+unset RUBYSHELL
 
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then

--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -10,6 +10,14 @@ end"
 LD_LIBRARY_PATH=`/opt/puppetlabs/puppet/bin/ruby -e "$STRIP_LDLYP_COMMAND"`
 export LD_LIBRARY_PATH
 unset LD_PRELOAD
+unset GEM_HOME
+unset GEM_PATH
+unset DLN_LIBRARY_PATH
+unset RUBYLIB
+unset RUBYLIB_PREFIX
+unset RUBYOPT
+unset RUBYPATH
+unset RUBYSHELL
 
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then


### PR DESCRIPTION
As puppet-agent is delivered with his own ruby, ignore external ruby
envirment variables