### PR TITLE
(PA-3263) fix nssm lock - master

### DIFF
--- a/configs/components/nssm.rb
+++ b/configs/components/nssm.rb
@@ -11,5 +11,5 @@ component "nssm" do |pkg, settings, platform|
     ]
   end
 
-  pkg.install_file "out/nssm.exe", "#{settings[:bindir]}/nssm.exe"
+  pkg.install_file "out/nssm.exe", "#{settings[:bindir]}/nssm-pxp-agent.exe"
 end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -138,7 +138,7 @@ component "pxp-agent" do |pkg, settings, platform|
   when "windows"
     # Note - this definition indicates that the file should be filtered out from the Wix
     # harvest. A corresponding service definition file is also required in resources/windows/wix
-    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm.exe"
+    pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm-pxp-agent.exe"
   else
     fail "need to know where to put #{pkg.get_name} service files"
   end

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -227,6 +227,14 @@ End If
       Return="ignore" />
     <%-end-%>
 
+    <%-if @platform.architecture == "x86"-%>
+    <Property Id="WixQuietExecCmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }; Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*puppet\bin\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }&quot;"/>
+    <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+    <%-else-%>
+    <Property Id="WixQuietExec64CmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }; Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*puppet\bin\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }&quot;"/>
+    <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>
+    <%-end-%>
+
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->
     <CustomAction
       Id="ResetDataPermissions"

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -147,6 +147,9 @@
         <![CDATA[VersionNT64 >= 100 AND <%= settings[:win64] %> = no AND NOT (&<%= settings[:product_id] %>Runtime = 2)]]>
       </Custom>
       <%-end-%>
+
+      <Custom Action='RemoveLegacyNssmRegistryKey' Before='RemoveExistingProducts' />
+
     </InstallExecuteSequence>
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -7,9 +7,9 @@
                  Guid="52B1CD57-95A2-4CA4-AB8E-9DDD6DE8FC66"
                  Directory="<%= get_service("pxp-agent").bindir_id %>" >
         <CreateFolder />
-        <File Id="NSSM"
+        <File Id="NSSM_PXP_Agent"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm-pxp-agent.exe" />
 
         <ServiceInstall Id="PXPServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"


### PR DESCRIPTION
Before this fix, if the puppet-agent upgrade on Windows was performed
while nssm.exe was loaded by EventLog service, many services, including
critical ones lihe dhcp/dns clients were restarted, leading to unreachable
machines.

With this commit we deliver dedicated nssm executable for pxp-agent
(nssm-pxp-agent.exe) and we remove windows registry references to old
nssm.exe in a WiX custom action.