### PR TITLE
(maint) update facter-ng to 66866b320444ab530d58d91d46ef6ddf5fd3fd1c

### DIFF
--- a/configs/components/facter-ng.json
+++ b/configs/components/facter-ng.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter-ng.git","ref":"68068b2de426100885401db3cee7054b08d83ec6"}
+{"url":"git://github.com/puppetlabs/facter.git","ref":"66866b320444ab530d58d91d46ef6ddf5fd3fd1c"}


### PR DESCRIPTION
This is needed because the existing ref does not exist on facter 4.x(is on facter-ng) and the promote check fails.