### PR TITLE
Revert "Merge pull request #1920 from gimmyxd/maint/bump_facter-ng"

### DIFF
--- a/configs/components/facter-ng.json
+++ b/configs/components/facter-ng.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"2566649d2f4a90e759e057a269ce20846b2f3c7e"}
+{"url":"git://github.com/puppetlabs/facter-ng.git","ref":"68068b2de426100885401db3cee7054b08d83ec6"}


### PR DESCRIPTION
This reverts commit acac8ca70a797004414b861f322998d44541afa7, reversing
changes made to 5995eb4eeb3f7701d13a660c1ad7950210b98197.

This is needed because Vanagon does not support two different components form the same repo.