### PR TITLE
(maint) Use an alternative filename for the build metadata

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -13,7 +13,7 @@ project "puppet-agent" do |proj|
 
   settings_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.settings.yaml")
   sha1sum_uri = "#{settings_uri}.sha1"
-  metadata_uri = File.join(runtime_details['location'], "#{runtime_details['version']}.build_metadata.agent-runtime-#{agent_branch}.#{platform.name}.json")
+  metadata_uri = File.join(runtime_details['location'], "#{proj.settings[:puppet_runtime_basename]}.json")
   proj.inherit_yaml_settings(settings_uri, sha1sum_uri, metadata_uri: metadata_uri)
 
   # (PA-678) pe-r10k versions prior to 2.5.0.0 ship gettext gems.


### PR DESCRIPTION
This will make building with non-tagged runtimes (or locally built
artifacts) possible.

This was made possible by
https://github.com/puppetlabs/vanagon/pull/651.