### PR TITLE
(maint) Fix facter accetance test on windows

### DIFF
--- a/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
+++ b/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
@@ -12,7 +12,13 @@ test_name 'Ensure puppet facts can use facter' do
 
     step "test puppet facts with facter has all the dependencies installed" do
       on agent, puppet('facts --debug'), :acceptable_exit_codes => [0] do
-        unresolved_fact = stdout.match(/(resolving fact .+\, but)/)
+        if agent['platform'] =~ /win/
+          # exclude augeas as it is not provided on Windows
+          unresolved_fact = stdout.match(/(resolving fact (?!augeas).+\, but)/)
+        else
+          unresolved_fact = stdout.match(/(resolving fact .+\, but)/)
+        end
+
         assert_nil(unresolved_fact, "missing dependency for facter from: #{unresolved_fact.inspect}")
       end
     end


### PR DESCRIPTION
Update facter accetance test to exclude augeas on windows as it is not provided on Windows. Implies the same change as #1939 but for the `next` branch.