### PR TITLE
(FACT-2738) Write acceptance test that compares Facter 3 and Facter 4 output

### DIFF
--- a/acceptance/lib/puppet/acceptance/fact_dif.rb
+++ b/acceptance/lib/puppet/acceptance/fact_dif.rb
@@ -1,0 +1,45 @@
+require 'json'
+
+class FactDif
+  def initialize(old_output, new_output, exclude_list = [])
+    @c_facter = JSON.parse(old_output)['values']
+    @next_facter = JSON.parse(new_output)['values']
+    @exclude_list = exclude_list
+    @diff = {}
+  end
+
+  def difs
+    search_hash(@c_facter, [])
+
+    @diff
+  end
+
+  private
+
+  def search_hash(sh, path = [])
+    if sh.is_a?(Hash)
+      sh.each do |k, v|
+        search_hash(v, path.push(k))
+        path.pop
+      end
+    elsif sh.is_a?(Array)
+      sh.each_with_index do |v, index|
+        search_hash(v, path.push(index))
+        path.pop
+      end
+    else
+      compare(path, sh.to_s)
+    end
+  end
+
+  def compare(fact_path, old_value)
+    new_value = @next_facter.dig(*fact_path)
+    if old_value != new_value && !excluded?(fact_path.join('.'))
+      @diff[fact_path.join('.')] = { new_value: new_value.inspect, old_value: old_value.inspect }
+    end
+  end
+
+  def excluded?(fact_name)
+    @exclude_list.any? {|excluded_fact| fact_name =~ /#{excluded_fact}/}
+  end
+end

--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -1,0 +1,52 @@
+test_name 'Ensure Facter 3 and Facter 4 outputs match' do
+  require 'puppet/acceptance/common_utils'
+  require 'puppet/acceptance/fact_dif'
+
+  EXCLUDE_LIST = %w[os\.selinux\.enabled networking\.mtu fips_enabled mtu_lo mtu_ens192 selinux is_virtual
+      load_averages\.1m load_averages\.5m load_averages\.15m mountpoints\./dev\.available_bytes
+      system_uptime\.seconds system_uptime\.days system_uptime\.hours uptime_seconds uptime_days uptime_hours
+      identity\.privileged identity\.gid identity\.uid processors\.physicalcount processors\.count physicalprocessorcount
+      processorcount  memorysize_mb
+      memoryfree_mb swapsize_mb swapfree_mb clientnoop
+      memoryfree system_uptime\.uptime uptime facterversion lsbmajdistrelease blockdevices
+      filesystems hypervisors\.vmware\.version sshfp_ecdsa sshfp_rsa sshfp_ed25519 sshfp_dsa
+      blockdevice_.*_vendor blockdevice_.*_model blockdevice_.*_size mountpoints\..* partitions\..* operatingsystemrelease
+      os\.release\.full mtu_.* networking\.interfaces\..* scope6 disks\..* hypervisors\.lpar\.partition_number.*
+      interfaces.* memory\..*
+      processors\.speed serialnumber sshdsakey sshrsakey swapfree hypervisors\.xen\.privileged os\.release\.minor
+      boardassettag dmi\.board\.asset_tag boardassettag dmi\.board\.asset_tag lsbdistrelease lsbminordistrelease
+      processor.* processors\.models\..* processors\.speed bios_release_date bios_vendor bios_version chassisassettag
+      chassistype dmi\..* hypervisors\.zone\..* manufacturer productname virtual zones os\.distro\.description
+      kernelmajversion uuid sshed25519key]
+
+  agents.each do |agent|
+    teardown do
+      step 'disable facterng feature flag' do
+        on agent, puppet('config set facterng false')
+      end
+    end
+
+    step 'obtain output from puppet facts running with Facter 3.x' do
+      on agent, puppet('facts') do
+        @facter3_output = stdout
+      end
+    end
+
+    step 'enable facterng feature flag' do
+      on agent, puppet('config set facterng true')
+    end
+    
+    step 'obtain output from puppet facts running with Facter 4.x' do
+      on agent, puppet('facts') do
+        @facter4_output = stdout
+      end
+    end
+
+    step 'compare Facter 3 to Facter 4 outputs' do
+      fact_dif = FactDif.new(@facter3_output, @facter4_output, EXCLUDE_LIST)
+      unless fact_dif.difs.empty?
+        fail_test("Facter 3 and Facter 4 outputs have the fallowing differences:  #{fact_dif.difs}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Compare Facter 3 with Facter 4 output. We are able to exclude facts via the `EXCLUDE_LIST `. The excluded fact name can also be a regex because there are fact names that are built dynamically.