### PR TITLE
(FACT-2738-fix) Add `sshecdsakey` fact to ignore list

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -17,7 +17,7 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
       boardassettag dmi\.board\.asset_tag boardassettag dmi\.board\.asset_tag lsbdistrelease lsbminordistrelease
       processor.* processors\.models\..* processors\.speed bios_release_date bios_vendor bios_version chassisassettag
       chassistype dmi\..* hypervisors\.zone\..* manufacturer productname virtual zones os\.distro\.description
-      kernelmajversion uuid sshed25519key]
+      kernelmajversion uuid sshed25519key sshecdsakey]
 
   agents.each do |agent|
     teardown do


### PR DESCRIPTION
Fact `sshecdsakey` is not implemented on AIX. Added it to ignore list.