### PR TITLE
(PA-3349) Switch to `main` runtime for puppet-agent#main

### DIFF
--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -32,10 +32,7 @@ component "runtime" do |pkg, settings, platform|
   # The runtime script uses readlink, which is in an odd place on Solaris systems:
   pkg.environment "PATH", "$(PATH):/opt/csw/gnu" if platform.is_solaris?
 
-  if platform.is_aix?
-    pkg.install_file File.join(libdir, "libstdc++.a"), "/opt/puppetlabs/puppet/lib/libstdc++.a"
-    pkg.install_file File.join(libdir, "libgcc_s.a"), "/opt/puppetlabs/puppet/lib/libgcc_s.a"
-  elsif platform.is_macos?
+  if platform.is_aix? || platform.is_macos?
     # Nothing to see here
   elsif platform.is_windows?
     lib_type = platform.architecture == "x64" ? "seh" : "sjlj"

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -5,7 +5,7 @@ project "puppet-agent" do |proj|
   # - Modifications to global settings like flags and target directories should be made in puppet-runtime.
   # - Settings included in this file should apply only to local components in this repository.
   runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
-  agent_branch = 'master'
+  agent_branch = 'main'
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']


### PR DESCRIPTION
Now that we merged all Ruby 2.7 blockers we can finally switch to the `main` runtime for puppet-agent#main.

This should be the same as the other agent runtimes, with Ruby bumped to 2.7.1 and the remaining win32 gems (service, process, dir, security) removed.