### PR TITLE
(PA-3351) fix registry handling in nssm custom action (5.5.x)

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -228,10 +228,10 @@ End If
     <%-end-%>
 
     <%-if @platform.architecture == "x86"-%>
-    <Property Id="WixQuietExecCmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }&quot;"/>
+    <Property Id="WixQuietExecCmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;if (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components') { Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop -ErrorAction Stop } } } }&quot;"/>
     <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
     <%-else-%>
-    <Property Id="WixQuietExec64CmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop } } }&quot;"/>
+    <Property Id="WixQuietExec64CmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;if (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components') { Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Remove-ItemProperty -Path $_.PSPath -Name $prop -ErrorAction Stop } } } }&quot;"/>
     <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>
     <%-end-%>
 

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -148,7 +148,9 @@
       </Custom>
       <%-end-%>
 
-      <Custom Action='RemoveLegacyNssmRegistryKey' Before='RemoveExistingProducts' />
+      <Custom Action='RemoveLegacyNssmRegistryKey' Before='RemoveExistingProducts' >
+        NOT SKIP_NSSM_REGISTRY_CLEANUP
+      </Custom>
 
     </InstallExecuteSequence>
 


### PR DESCRIPTION
Before this fix, if the registry key `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components`
is not existing, installer will fail on Windows
(this is the case on few Google Cloud Windows Server images)

After this fix, nssm custom action:
- tries to remove nssm component from registry only if the `...\Components` key exists
- fails if nssm component is found in registry and cannot be removed (can happen if
  UAC is enabled and current user is not Administrator).