### PR TITLE
(PA-3253) Aligns with last_run_summary.yaml file puppet changes

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -28,6 +28,7 @@ def config_options(agent)
     codedir = "#{puppetlabs_data}/code"
     confdir = "#{puppetlabs_data}/puppet/etc"
     vardir = "#{puppetlabs_data}/puppet/cache"
+    publicdir = "#{puppetlabs_data}/puppet/public"
     logdir = "#{puppetlabs_data}/puppet/var/log"
     rundir = "#{puppetlabs_data}/puppet/var/run"
     sep = ";"
@@ -37,6 +38,7 @@ def config_options(agent)
     codedir = '/etc/puppetlabs/code'
     confdir = '/etc/puppetlabs/puppet'
     vardir = '/opt/puppetlabs/puppet/cache'
+    publicdir = '/opt/puppetlabs/puppet/public'
     logdir = '/var/log/puppetlabs/puppet'
     rundir = '/var/run/puppetlabs'
     sep = ":"
@@ -80,6 +82,9 @@ def config_options(agent)
     {:name => :logdir,          :expected => logdir,                      :installed => :dir},
     {:name => :rundir,          :expected => rundir,                      :installed => :dir},
     {:name => :pidfile,         :expected => "#{rundir}/agent.pid"},
+
+    # publicdir
+    {:name => :publicdir,       :expected => publicdir,                   :installed => :dir},
   ]
 end
 

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -140,17 +140,20 @@ component "puppet" do |pkg, settings, platform|
 
   if platform.is_windows?
     vardir = File.join(settings[:sysconfdir], 'puppet', 'cache')
+    publicdir = File.join(settings[:sysconfdir], 'puppet', 'public')
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
     logdir = File.join(settings[:sysconfdir], 'puppet', 'var', 'log')
     piddir = File.join(settings[:sysconfdir], 'puppet', 'var', 'run')
     prereqs = "--check-prereqs"
   else
     vardir = File.join(settings[:prefix], 'cache')
+    publicdir = File.join(settings[:prefix], 'public')
     configdir = settings[:puppet_configdir]
     logdir = settings[:logdir]
     piddir = settings[:piddir]
     prereqs = "--no-check-prereqs"
   end
+
   pkg.install do
     [
       "#{settings[:host_ruby]} install.rb \
@@ -161,6 +164,7 @@ component "puppet" do |pkg, settings, platform|
         --sitelibdir=#{settings[:ruby_vendordir]} \
         --codedir=#{settings[:puppet_codedir]} \
         --vardir=#{vardir} \
+        --publicdir=#{publicdir} \
         --rundir=#{piddir} \
         --logdir=#{logdir} \
         --localedir=#{settings[:datadir]}/locale \
@@ -220,6 +224,7 @@ component "puppet" do |pkg, settings, platform|
   pkg.configfile File.join(configdir, 'auth.conf')
 
   pkg.directory vardir, mode: '0750'
+  pkg.directory publicdir, mode: '0755'
   pkg.directory configdir
   pkg.directory File.join(settings[:datadir], "locale")
   pkg.directory settings[:puppet_codedir]

--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -27,6 +27,7 @@
           <Directory Id="PuppetAppData" Name="puppet">
             <Directory Id="PuppetConfDir" Name="etc"/>
             <Directory Id="PuppetVarDir" Name="var"/>
+            <Directory Id="PuppetPublicDir" Name="public"/>
           </Directory>
           <Directory Id="FacterAppData" Name="facter">
             <Directory Id="FactsDotD" Name="facts.d"/>
@@ -243,6 +244,16 @@
         Guid="B95A17F3-CF5E-4EC7-859E-F10C0965645F"
         Directory="PuppetVarDir">
         <CreateFolder />
+      </Component>
+      <Component
+        Id="PuppetPublicDir"
+        Permanent="yes"
+        Guid="B1A31F2F-D759-4444-B4E6-8EF9A353B47A"
+        Directory="PuppetPublicDir">
+        <CreateFolder>
+          <!-- allow everyone read & execute -->
+          <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;0x1200a9;;;WD)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)" />
+        </CreateFolder>
       </Component>
       <Component
         Id="FacterAppDir"


### PR DESCRIPTION
In [PUP-10627](https://github.com/puppetlabs/puppet/pull/8277) the `last_run_summary.yaml` file location (to `/opt/puppetlabs/puppet/public` on Linux and `C:\ProgramData\PuppetLabs\puppet\public` on Microsoft Windows) and permissions (to `0755`) changed and this commit aligns the puppet component to those changes. It also sets accordingly the new cli config parameter called `publicdir`.


TODO before merging this:
- [x] Merge [PUP-10627](https://github.com/puppetlabs/puppet/pull/8277) first
- [x] Remove the maint commit (Jenkins needs it for running tests with the puppet changes and CI checks will keep failing until it is removed)
