### PR TITLE
(PA-3364) Disable Puppet Agent installation on Windows 2008 and 2008R2

### DIFF
--- a/resources/windows/wix/condition.wxs.erb
+++ b/resources/windows/wix/condition.wxs.erb
@@ -9,13 +9,13 @@
 
     <%- if @platform.architecture == "x64" -%>
       <!-- http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html -->
-      <Condition Message="<%= settings[:product_name] %> is no longer supported on Windows Server 2003.">
-        <![CDATA[Installed OR (VersionNT64 >= 600)]]>
+      <Condition Message="<%= settings[:product_name] %> is no longer supported on this Windows version.">
+        <![CDATA[Installed OR (VersionNT64 >= 601)]]>
       </Condition>
     <%- else %>
       <!-- http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html -->
-      <Condition Message="<%= settings[:product_name] %> is no longer supported on Windows Server 2003.">
-        <![CDATA[Installed OR (VersionNT >= 600)]]>
+      <Condition Message="<%= settings[:product_name] %> is no longer supported on this Windows version.">
+        <![CDATA[Installed OR (VersionNT >= 601)]]>
       </Condition>
 
       <Condition Message="32 bit <%= settings[:product_name] %> is no longer supported on 64 bit Windows Operating Systems.">

--- a/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
+++ b/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
@@ -102,7 +102,7 @@ Patch dialog sequence:
       <Publish Dialog="WarningDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[Installed AND PATCH]]></Publish>
       <Publish Dialog="WarningDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"></Publish>
 
-      <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"><![CDATA[VersionNT >= 600]]></Publish>
+      <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"><![CDATA[VersionNT >= 601]]></Publish>
       <Publish Dialog="PuppetLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="PuppetInstallDirDlg">LicenseAccepted = "1"</Publish>
 
       <Publish Dialog="PuppetInstallDirDlg" Control="Back" Event="NewDialog" Value="PuppetLicenseAgreementDlg">1</Publish>


### PR DESCRIPTION
This PR blocks the installation of the Puppet Agent msi on Windows versions older than 2012.
The change is done only on the Platform 7 stream.