### PR TITLE
(PA-3363) Bump sshkeys_core to 2.1.0 and zfs_core to 1.1.0

### DIFF
--- a/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/1.0.3"}
+{"url":"https://github.com/puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/2.1.0"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.0.5"}
+{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.1.0"}


### PR DESCRIPTION
passing ad-hoc: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/859/