### PR TITLE
(maint) Ignore facterng acceptance test on rhel5

### DIFF
--- a/acceptance/tests/ensure_puppet_facts_can_use_facter_ng.rb
+++ b/acceptance/tests/ensure_puppet_facts_can_use_facter_ng.rb
@@ -2,6 +2,8 @@ test_name 'Ensure puppet facts can use facter-ng' do
 
   require 'puppet/acceptance/common_utils'
 
+  confine :except, :platform => /el-5/
+
   teardown do
     on agent, puppet('config set facterng false')
   end


### PR DESCRIPTION
The `ensure_puppet_facts_can_use_facter_ng.rb` test fails because of a Facter 4 debug message on `rhel5`. We will be able to reenable the test once we release a new version of Facter.