### PR TITLE
(maint) ignore fact diffs on el-5

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -2,6 +2,8 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
   require 'puppet/acceptance/common_utils'
   require 'puppet/acceptance/fact_dif'
 
+  confine :except, :platform => /el-5/
+
   EXCLUDE_LIST = %w[os\.selinux\.enabled networking\.mtu fips_enabled mtu_lo mtu_ens192 selinux is_virtual
       load_averages\.1m load_averages\.5m load_averages\.15m mountpoints\./dev\.available_bytes
       system_uptime\.seconds system_uptime\.days system_uptime\.hours uptime_seconds uptime_days uptime_hours


### PR DESCRIPTION
As a follow-up to https://github.com/puppetlabs/puppet-agent/pull/1966 This PR ignores the fact diff test for el-5