### PR TITLE
(maint) Omit legacy auth.conf from puppet-agent packages

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -53,7 +53,6 @@ def config_options(agent)
 
     # confdir
     {:name => :confdir,         :expected => confdir,                     :installed => :dir},
-    {:name => :rest_authconfig, :expected => "#{confdir}/auth.conf"},
     {:name => :autosign,        :expected => "#{confdir}/autosign.conf"},
     {:name => :binder_config,   :expected => ""},
     {:name => :csr_attributes,  :expected => "#{confdir}/csr_attributes.yaml"},

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -223,7 +223,6 @@ component "puppet" do |pkg, settings, platform|
   end
 
   pkg.configfile File.join(configdir, 'puppet.conf')
-  pkg.configfile File.join(configdir, 'auth.conf')
 
   pkg.directory vardir, mode: '0750'
   pkg.directory publicdir, mode: '0755'


### PR DESCRIPTION
Omit the default legacy auth.conf in puppet-agent packages for new installs.
During an upgrade, the old file will be left as-is and ignored.