### PR TITLE
(PA-3404) remove %PUPPET_DIR%\bin from PATH

### DIFF
--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -9,8 +9,8 @@ SET PUPPET_DIR=%PL_BASEDIR%\puppet
 REM Set a fact so we can easily source the environment.bat file in the future.
 SET FACTER_env_windows_installdir=%PL_BASEDIR%
 
-REM Add puppet's bindirs to the PATH
-SET PATH=%PUPPET_DIR%\bin;%PL_BASEDIR%\bin;%PATH%
+REM Add puppet's bin to the PATH
+SET PATH=%PATH%;%PL_BASEDIR%\bin
 
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
 SET RUBYLIB=%PUPPET_DIR%\lib;%RUBYLIB%

--- a/resources/files/windows/facter.bat
+++ b/resources/files/windows/facter.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0environment.bat" %0 %*
 
-ruby -S -- facter %*
+"%PUPPET_DIR%\bin\ruby.exe" -S -- "%PUPPET_DIR%\bin\facter" %*

--- a/resources/files/windows/hiera.bat
+++ b/resources/files/windows/hiera.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0environment.bat" %0 %*
 
-ruby -S -- hiera %*
+"%PUPPET_DIR%\bin\ruby.exe" -S -- "%PUPPET_DIR%\bin\hiera" %*

--- a/resources/files/windows/puppet.bat
+++ b/resources/files/windows/puppet.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0environment.bat" %0 %*
 
-ruby -S -- puppet %*
+"%PUPPET_DIR%\bin\ruby.exe" -S -- "%PUPPET_DIR%\bin\puppet" %*

--- a/resources/files/windows/puppet_shell.bat
+++ b/resources/files/windows/puppet_shell.bat
@@ -2,5 +2,8 @@
 
 call "%~dp0environment.bat" %0 %*
 
+REM Prepend puppet's bindirs to the PATH
+SET PATH=%PUPPET_DIR%\bin;%PL_BASEDIR%\bin;%PATH%
+
 REM Display Ruby version
 ruby.exe -v

--- a/resources/files/windows/run_facter_interactive.bat
+++ b/resources/files/windows/run_facter_interactive.bat
@@ -2,4 +2,4 @@
 @echo off
 SETLOCAL
 call "%~dp0environment.bat" %0 %*
-@elevate.exe "%~dp0facter_interactive.bat"
+@"%PUPPET_DIR%\bin\elevate.exe" "%~dp0facter_interactive.bat"

--- a/resources/files/windows/run_puppet_interactive.bat
+++ b/resources/files/windows/run_puppet_interactive.bat
@@ -2,4 +2,4 @@
 @echo off
 SETLOCAL
 call "%~dp0environment.bat" %0 %*
-@elevate.exe "%~dp0puppet_interactive.bat"
+@"%PUPPET_DIR%\bin\elevate.exe" "%~dp0puppet_interactive.bat"


### PR DESCRIPTION
Before this commit, on Windows, puppet bin was
prepended to PATH, this was making puppet commands
to always use the ruby and gem provided in the
puppet-agent AIO.

With this change, puppet bin is appended at the
end of PATH, in the same manner we do for linux.