### PR TITLE
(PA-3388) add native platform redhat-8-aarch64

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -1,0 +1,11 @@
+platform "el-8-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(gcc-c++ rsync cmake make rpm-libs rpm-build)
+
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-8-arm64"
+end


### PR DESCRIPTION
Depends on:
   - [x] puppet-runtime - https://github.com/puppetlabs/puppet-runtime/pull/373
   - [ ] beaker-puppet (including release of) - https://github.com/voxpupuli/beaker-puppet/pull/145 
   - [x] packaging (including release of) - https://github.com/puppetlabs/packaging/pull/1068 
   - [x] facter aws detection - https://github.com/puppetlabs/facter/pull/2095
   - [x] facter DHCP server detection - https://github.com/puppetlabs/facter/pull/2097
