### PR TITLE
(maint) Enable acceptance test for Rhel5

### DIFF
--- a/acceptance/tests/ensure_puppet_facts_can_use_facter_ng.rb
+++ b/acceptance/tests/ensure_puppet_facts_can_use_facter_ng.rb
@@ -2,8 +2,6 @@ test_name 'Ensure puppet facts can use facter-ng' do
 
   require 'puppet/acceptance/common_utils'
 
-  confine :except, :platform => /el-5/
-
   teardown do
     on agent, puppet('config set facterng false')
   end


### PR DESCRIPTION
This test was skipped because of a bug in Facter. As the bug was fixed and a new version of Facter was released, this test can be enabled again.