### PR TITLE
(PA-3405) Fix puppet resource output matching

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -68,7 +68,7 @@ component "puppet" do |pkg, settings, platform|
       [<<-HERE.undent
         mkdir -p  #{rpm_statedir} && chown root #{rpm_statedir} && chmod 0700 #{rpm_statedir} || :
         if [ -x #{puppet_bin} ] ; then
-          #{puppet_bin} resource service puppet | awk -F "'" '/ensure =>/ { print $2 }' > #{service_statefile} || :
+          #{puppet_bin} resource service puppet | awk -F "'" '/ensure[[:space:]]+=>/ { print $2 }' > #{service_statefile} || :
         fi
         HERE
       ]


### PR DESCRIPTION
PUP-3721[1] included an additional parameter in the `puppet resource`
command output which had the side effect of changing the indentation of
the output. As such, attempting to match `ensure =>` no longer works.

This causes agent upgrades on RPM-based SysV platforms and AIX to no
longer start the puppet service after the upgrade finishes.

Make the regex more permissive in order to account for any number of
spaces between `ensure` and `=>`.

[1] https://github.com/puppetlabs/puppet/commit/7a92874522d6540157168fd025174bba3b816c64