### PR TITLE
(maint) Fixed Facter 3 and 4 comparisson tool

### DIFF
--- a/acceptance/lib/puppet/acceptance/fact_dif.rb
+++ b/acceptance/lib/puppet/acceptance/fact_dif.rb
@@ -28,7 +28,7 @@ class FactDif
         path.pop
       end
     else
-      compare(path, sh.to_s)
+      compare(path, sh)
     end
   end
 


### PR DESCRIPTION
There was a small issue with the comparison class, in some cases it added converted the value to string even if it was not needed. A PR on Facter that fixed the output was merged earlier caused failing builds on agent.