### PR TITLE
(maint) remove RHEL 8 AARCH from Facter diff tests

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -2,7 +2,7 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
   require 'puppet/acceptance/common_utils'
   require 'puppet/acceptance/fact_dif'
 
-  confine :except, :platform => 'el-5-x86_64'
+  confine :except, :platform => /el-5-x86_64|el-8-aarch64/
 
   EXCLUDE_LIST = %w[ fips_enabled facterversion identity\.gid identity\.privileged identity\.uid
                     load_averages\.15m load_averages\.1m load_averages\.5m memory\.swap\.available_bytes


### PR DESCRIPTION
Remove checking diffs between Facter 3 and Facter 4 until Facter 4 is released.