### PR TITLE
(maint) Bump leatherman version to 1.4.13

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/leatherman.git","ref":"f83da4733a10217534328ac4492645cc1fed8cd0"}
+{"url":"git://github.com/puppetlabs/leatherman.git","ref":"refs/tags/1.4.13"}


### PR DESCRIPTION
The last leatherman tag was done on a `[no-promote]` commit and caused puppet-agent to not promote it (seen in `leatherman.json`). This commit bumps letherman to the latest tag.