### PR TITLE
(PA-3401) Provide MSI property to configure serverport setting

### DIFF
--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -129,6 +129,34 @@
           Key="masterport"
           Directory="PuppetConfDir" />
       </Component>
+      <Component
+        Id="PuppetServerPortSetting"
+        Guid="D9CBF5C4-06DE-11EB-ADC1-0242AC120002"
+        Transitive = "yes"
+        Directory="PuppetConfDir" >
+        <CreateFolder />
+        <Condition><![CDATA[(SERVER_PORT <> ".") AND (SERVER_PORT <> "")]]></Condition>
+        <IniFile
+          Id="PuppetConfServerPort" Name="puppet.conf"
+          Action="addLine"
+          Section="main"
+          Key="serverport" Value="[SERVER_PORT]"
+          Directory="PuppetConfDir" />
+      </Component>
+      <Component
+        Id="PuppetServerPortSettingClean"
+        Guid="296650AC-06DF-11EB-ADC1-0242AC120002"
+        Transitive = "yes"
+        Directory="PuppetConfDir" >
+        <CreateFolder />
+        <Condition><![CDATA[(SERVER_PORT = ".") OR (SERVER_PORT = "")]]></Condition>
+        <IniFile
+          Id="PuppetConfServerPort" Name="puppet.conf"
+          Action="removeLine"
+          Section="main"
+          Key="serverport"
+          Directory="PuppetConfDir" />
+      </Component>
       <!-- This is a permanent directory, do not remove on uninstall -->
       <Component
         Id="PuppetConfUnconditionalSettings"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -43,6 +43,7 @@ If (fso.FileExists(iniPath)) Then
   Set iniFile = Nothing
   SetPropertyFromIni "server", "INI_PUPPET_MASTER_SERVER", iniFileText
   SetPropertyFromIni "masterport", "INI_PUPPET_MASTER_PORT", iniFileText
+  SetPropertyFromIni "serverport", "INI_PUPPET_SERVER_PORT", iniFileText
   SetPropertyFromIni "environment", "INI_PUPPET_AGENT_ENVIRONMENT", iniFileText
   SetPropertyFromIni "certname", "INI_PUPPET_AGENT_CERTNAME", iniFileText
   SetPropertyFromIni "ca_server", "INI_PUPPET_CA_SERVER", iniFileText
@@ -116,6 +117,16 @@ End If
        Id="SetFromCmdLinePuppetMasterPort"
        Property="MASTER_PORT"
        Value="[PUPPET_MASTER_PORT]"
+       Execute="firstSequence" />
+     <CustomAction
+      Id="SetFromIniPuppetServerPort"
+      Property="SERVER_PORT"
+      Value="[INI_PUPPET_SERVER_PORT]"
+      Execute="firstSequence" />
+    <CustomAction
+       Id="SetFromCmdLinePuppetServerPort"
+       Property="SERVER_PORT"
+       Value="[PUPPET_SERVER_PORT]"
        Execute="firstSequence" />
 
     <!-- PUPPET_AGENT_ENVIRONMENT -->

--- a/resources/windows/wix/properties.wxs.erb
+++ b/resources/windows/wix/properties.wxs.erb
@@ -4,6 +4,7 @@
 
     <ComponentGroup Id="FragmentProperties" />
     <Property Id="MASTER_PORT" Value="." />
+    <Property Id="SERVER_PORT" Value="." />
 
     <!-- Add/Remove Programs icon and help link -->
     <Property

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -67,6 +67,12 @@
       <Custom Action='SetFromIniPuppetMasterPort' Before='FileCost'>
         INI_PUPPET_MASTER_PORT AND NOT PUPPET_MASTER_PORT
       </Custom>
+      <Custom Action='SetFromCmdLinePuppetServerPort' After='FileCost'>
+        PUPPET_SERVER_PORT
+      </Custom>
+      <Custom Action='SetFromIniPuppetServerPort' Before='FileCost'>
+        INI_PUPPET_SERVER_PORT AND NOT PUPPET_SERVER_PORT
+      </Custom>
     </InstallUISequence>
 
     <InstallExecuteSequence>
@@ -124,11 +130,17 @@
       <Custom Action='SetDomainToNtAuthority' After='SetDomainToLocalComputer'>
         (PUPPET_AGENT_ACCOUNT_USER ~= "LocalService") OR (PUPPET_AGENT_ACCOUNT_USER ~= "NetworkService")
       </Custom>
-       <Custom Action='SetFromCmdLinePuppetMasterPort' After='FileCost'>
+      <Custom Action='SetFromCmdLinePuppetMasterPort' After='FileCost'>
         PUPPET_MASTER_PORT
       </Custom>
       <Custom Action='SetFromIniPuppetMasterPort' Before='FileCost'>
         INI_PUPPET_MASTER_PORT AND NOT PUPPET_MASTER_PORT
+      </Custom>
+      <Custom Action='SetFromCmdLinePuppetServerPort' After='FileCost'>
+        PUPPET_SERVER_PORT
+      </Custom>
+      <Custom Action='SetFromIniPuppetServerPort' Before='FileCost'>
+        INI_PUPPET_SERVER_PORT AND NOT PUPPET_SERVER_PORT
       </Custom>
 
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->


### PR DESCRIPTION
Add `PUPPET_SERVER_PORT` installer property to be used to
configure puppet `serverport` setting