### PR TITLE
(maint) Bump zfs_core and cron_core modules version

### DIFF
--- a/configs/components/module-puppetlabs-cron_core.json
+++ b/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.4"}
+{"url":"https://github.com/puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.5"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.1.0"}
+{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.2.0"}


### PR DESCRIPTION
The `puppetlabs-zfs_core` module version `1.2.0` and `puppetlabs-cron_core` module version `1.0.5` got released and this commit bumps their version accordingly in puppet agent.