### PR TITLE
(maint) skip `validate_vendored_ruby` test on sles-12-ppc64el

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -2,6 +2,8 @@ require 'puppet/acceptance/common_utils.rb'
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::CommandUtils
 
+confine :except, :platform => 'sles-12-ppc64le'
+
 def package_installer(agent)
   # for some reason, beaker does not have a configured package installer
   # for AIX, and for solaris-10 we install dependencies from opencsw. so we


### PR DESCRIPTION
we are missing `sqlite3-devel` package from our sles-12-ppc64el repo mirror
skip the test until mirroring is fixed