### PR TITLE
(maint) Merge master to main

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -2,6 +2,8 @@ require 'puppet/acceptance/common_utils.rb'
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::CommandUtils
 
+confine :except, :platform => 'sles-12-ppc64le'
+
 def package_installer(agent)
   # for some reason, beaker does not have a configured package installer
   # for AIX, and for solaris-10 we install dependencies from opencsw. so we

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -87,6 +87,18 @@ End If
       Value="[CMDLINE_INSTALLDIR]"
       Execute="firstSequence" />
 
+    <!-- PUPPET_SERVER -->
+    <CustomAction
+      Id="SaveCmdLinePuppetServer"
+      Property="CMDLINE_PUPPET_SERVER"
+      Value="[PUPPET_SERVER]"
+      Execute="firstSequence" />
+    <CustomAction
+      Id="SetFromCmdLinePuppetServer"
+      Property="PUPPET_MASTER_SERVER"
+      Value="[CMDLINE_PUPPET_SERVER]"
+      Execute="firstSequence" />
+
     <!-- PUPPET_MASTER_SERVER -->
     <CustomAction
       Id="SetFromIniPuppetMasterServer"

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -19,8 +19,12 @@
         INI_PUPPET_MASTER_SERVER
       </Custom>
       <Custom Action='SaveCmdLinePuppetMasterServer' Before='AppSearch' />
+      <Custom Action='SaveCmdLinePuppetServer' Before='AppSearch' />
       <Custom Action='SetFromCmdLinePuppetMasterServer' After='FileCost'>
         CMDLINE_PUPPET_MASTER_SERVER
+      </Custom>
+      <Custom Action='SetFromCmdLinePuppetServer' After='FileCost'>
+        CMDLINE_PUPPET_SERVER
       </Custom>
       <Custom Action='SetDefaultPuppetMasterServer' Before='CostFinalize'>
         PUPPET_MASTER_SERVER=""

--- a/resources/windows/wix/ui/PuppetInstallDirDlg.wxs
+++ b/resources/windows/wix/ui/PuppetInstallDirDlg.wxs
@@ -29,7 +29,7 @@
         <Control Id="ChangeFolder" Type="PushButton" X="20" Y="100" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
 
         <Control Id="PuppetMasterServerText" Type="Text" X="20" Y="135" Width="290" Height="13" NoPrefix="yes"
-          Text="Fully qualified domain name of the Puppet master:" />
+          Text="Fully qualified domain name of the Puppet server:" />
         <Control Id="PuppetMasterServerEdit" Type="Edit" X="20" Y="150" Width="320" Height="18"
                  Text="[PUPPET_MASTER_SERVER]"
                  Property="PUPPET_MASTER_SERVER" />


### PR DESCRIPTION
Merge remote-tracking branch 'upstream/master' into main

* upstream/master:
  (PA-3440) add new property PUPPET_SERVER it should behave like alias to existing PUPPET_MASTER_SERVER
  (maint) skip `validate_vendored_ruby` test on sles-12-ppc64el
  (maint) test facter directories
  (maint) Update puppet to 3a701d147c2b7130962527922a842893d31a104d
  (maint) Bump zfs_core and cron_core modules version
  (maint) Bump facter version to the newest released one.

Conflicts:
	acceptance/tests/ensure_puppet-agent_paths.rb
	configs/components/facter-ng.rb

ensure_puppet-agent_paths test conflict was due to indentation changes in
cb16fb805 in main. This commit preserves the indentation and addition of
`facts.d` test from master, while preserving the publicdir test and removal of
rest_authconfig.

facter-ng component doesn't exist in main