### PR TITLE
(packaging) Bump facter to d405b8c0

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"61951f9a54f6a7145a46b7796c83c2527b9c8dc1"}
+{"url":"git://github.com/puppetlabs/facter.git","ref":"d405b8c0e4c88095ba5a0ff4a3c5ffa72ed99f14"}


### PR DESCRIPTION
Previous version did not have lib/facter/version.rb bumped.

This bumps facter to 4.0.46. 4.0.45 was never released.