### PR TITLE
(PA-3489) Add log rotation for pxp-agent on Solaris

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -83,6 +83,11 @@ component "pxp-agent" do |pkg, settings, platform|
     pkg.install_service "#{service_conf}/osx/pxp-agent.plist", nil, 'com.puppetlabs.pxp-agent'
   when 'smf'
     pkg.install_service "#{service_conf}/solaris/smf/pxp-agent.xml", service_type: 'network'
+    logadm_script = <<-EOM
+    logadm -C30 -z0\
+      -w /var/log/puppetlabs/pxp-agent/pxp-agent.log
+    EOM
+    pkg.add_postinstall_action ['install'], [logadm_script]
   when 'aix'
     pkg.install_service 'resources/aix/pxp-agent.service', nil, 'pxp-agent'
   when 'windows'


### PR DESCRIPTION
On Solaris platforms logrotate does not come by default, but logadm
comes.

Command logadm -C30 -z0 -w /var/log/puppetlabs/pxp-agent/pxp-agent.log
means:
-C30 keps 30 copies of logs
-z0 compress all archived logs
-w /var/log/puppetlabs/pxp-agent/pxp-agent.log adds an entry into the
config file (that is, /etc/logadm.conf) that corresponds to
/var/log/puppetlabs/pxp-agent/pxp-agent.log

DRAFT