### PR TITLE
(PA-3435) update platform to build AIX7.1 runtime on 5.5.x

### DIFF
--- a/configs/platforms/aix-7.1-ppc.rb
+++ b/configs/platforms/aix-7.1-ppc.rb
@@ -1,9 +1,4 @@
 platform "aix-7.1-ppc" do |plat|
-  # patch AIX platform to set the rpm filename to 7.1 instead of 6.1
-  plat._platform.define_singleton_method(:rpm_defines) do
-    %(--define '_topdir $(tempdir)/rpmbuild' --define '_rpmfilename %%{ARCH}/%%{NAME}-%%{VERSION}-%%{RELEASE}.aix7.1.%%{ARCH}.rpm')
-  end
-
   plat.servicetype "aix"
 
   plat.make "gmake"
@@ -11,7 +6,7 @@ platform "aix-7.1-ppc" do |plat|
   plat.rpmbuild "/usr/bin/rpm"
   plat.patch "/opt/freeware/bin/patch"
 
-  # Basic vanagon operations require mktemp, rsync, coreutils, tar and sed so leave this in there
+  # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
   # We use --force with rpm because the pl-gettext and pl-autoconf
@@ -21,5 +16,5 @@ platform "aix-7.1-ppc" do |plat|
   # for pl-autoconf) we'll need to force the installation
   #                                         Sean P. McD.
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
-  plat.vmpooler_template "aix-6.1-power"
+  plat.vmpooler_template "aix-7.1-power"
 end


### PR DESCRIPTION
This is intermediary step of AIX6.1 removal on 5.5.x

