### PR TITLE
(PA-3452) Update cert sign command for smoke script

### DIFF
--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -77,10 +77,10 @@ set -e
 echo "### DEBUG: Sleeping for 5 seconds to give some time for the agent cert to appear on the master ..."
 sleep 5
 # TODO check collection for puppet7
-if [[ "${collection}" = "puppet6" ]]; then
-  on_master "puppetserver ca sign --all"
-else
+if [[ "${collection}" = "puppet5" ]]; then
   on_master "puppet cert sign --all"
+else
+  on_master "puppetserver ca sign --all"
 fi
 echo ""
 echo ""


### PR DESCRIPTION
Puppet collections 6 and higher should use the `puppetserver` command to sign certs.