### PR TITLE
(maint) Promote aix 7.1 to pe#main

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -25,15 +25,14 @@ foss_platforms:
   - windows-2012-x86
   - windows-2012-x64
 pe_platforms:
-  - aix-6.1-power
   - aix-7.1-power
   - redhatfips-7-x86_64
   - solaris-11-i386
   - solaris-11-sparc
   - windowsfips-2012-x64
 platform_repos:
-  - name: aix-6.1-power
-    repo_location: repos/aix/6.1/**/ppc
+  - name: aix-7.1-power
+    repo_location: repos/aix/7.1/**/ppc
   - name: el-6-i386
     repo_location: repos/el/6/**/i386
   - name: el-6-x86_64


### PR DESCRIPTION
We're now building on aix 7.1, so update the path, for example:

    repos/aix/7.1/puppet7/ppc/puppet-agent-7.0.0.51.g68a734e7-1.aix7.1.ppc.rpm