### PR TITLE
(maint) Add repo_link_target for puppet7

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -91,5 +91,7 @@ apt_repo_name: 'puppet7'
 yum_repo_name: 'puppet7'
 repo_name: 'puppet7'
 nonfinal_repo_name: 'puppet7-nightly'
+repo_link_target: 'puppet'
+nonfinal_repo_link_target: 'puppet-nightly'
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
Now that we're publicly releasing puppet 7 we should probably add this to the main branch, and remove it from the 6.x stream.

This should have probably been done prior to shipping 7.0.0, but I don't fully know the implications of these params.

/cc @puppetlabs/release-engineering 