### PR TITLE
(maint) Remove repo_link_target for puppet6

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -129,7 +129,5 @@ apt_repo_name: 'puppet6'
 yum_repo_name: 'puppet6'
 repo_name: 'puppet6'
 nonfinal_repo_name: 'puppet6-nightly'
-repo_link_target: 'puppet'
-nonfinal_repo_link_target: 'puppet-nightly'
 build_tar: FALSE
 build_gem: TRUE


### PR DESCRIPTION
See https://github.com/puppetlabs/puppet-agent/pull/2021.