### PR TITLE
(maint) build el-6 on redhat instead of centos

### DIFF
--- a/configs/platforms/el-6-i386.rb
+++ b/configs/platforms/el-6-i386.rb
@@ -6,5 +6,5 @@ platform "el-6-i386" do |plat|
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-6-i386"
+  plat.vmpooler_template "redhat-6-i386"
 end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -6,5 +6,5 @@ platform "el-6-x86_64" do |plat|
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
   plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.install_build_dependencies_with "yum install --assumeyes"
-  plat.vmpooler_template "centos-6-x86_64"
+  plat.vmpooler_template "redhat-6-x86_64"
 end


### PR DESCRIPTION
Because CentOS 6 went end of life[1], the upstream repos are no longer available, the PR sets the build VMs to RedHat 6  instead of CentOS 6

1. https://phoenixnap.com/kb/centos-6-eol
