### PR TITLE
(maint) Exclude some legacy blockdevice facts

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -19,7 +19,8 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
                     operatingsystemrelease os\.release\.full os\.distro\.description filesystems
                     sp_uptime system_profiler\.uptime os\.release\.minor
                     hypervisors\.zone\..* system_uptime\.uptime uptime hypervisors\.ldom\..* ldom_.*
-                    boardassettag dmi\.board\.asset_tag is_virtual kernelmajversion lsbmajdistrelease zones virtual]
+                    boardassettag dmi\.board\.asset_tag is_virtual kernelmajversion lsbmajdistrelease zones virtual
+                    blockdevice_.*_vendor blockdevice_.*_size]
 
   agents.each do |agent|
     teardown do


### PR DESCRIPTION
Exclude the blockdevice size and vendor facts from the facter 3/4
acceptance tests, until we release a new Facter version containing
https://github.com/puppetlabs/facter/pull/2238.