### PR TITLE
(PA-2028) fix windows services definition for puppet and pxp-agent

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -53,7 +53,7 @@ component "puppet" do |pkg, settings, platform|
     when "windows"
       # Note - this definition indicates that the file should be filtered out from the Wix
       # harvest. A corresponding service definition file is also required in resources/windows/wix
-      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\sys\\ruby\\bin\\ruby.exe", init_system: servicetype
+      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\ruby.exe"
     else
       fail "need to know where to put service files"
     end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -140,7 +140,7 @@ component "pxp-agent" do |pkg, settings, platform|
     when "windows"
       # Note - this definition indicates that the file should be filtered out from the Wix
       # harvest. A corresponding service definition file is also required in resources/windows/wix
-      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\service\\nssm.exe", init_system: servicetype
+      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm-pxp-agent.exe", init_system: servicetype
     else
       fail "need to know where to put #{pkg.get_name} service files"
     end


### PR DESCRIPTION
while solving original commit rebase conflicts, the 1.10.x windows
service definition was selected which is no longer working on 6.x

this commit should fix the windows service definition