### PR TITLE
(maint) Update exclude list in `puppet facts diff` acceptance test

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -4,23 +4,20 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
 
   confine :except, :platform => /el-5-x86_64|aix/
 
-  EXCLUDE_LIST = %w[ fips_enabled facterversion identity\.gid identity\.privileged identity\.uid
-                    load_averages\.15m load_averages\.1m load_averages\.5m memory\.swap\.available_bytes
-                    memory\.swap\.capacity memory\.swap\.total_bytes memory\.swap\.used_bytes memory\.swap\.available
-                    memory\.system\.available memory\.system\.available_bytes memory\.system\.capacity memory\.swap\.used
-                    memory\.system\.total_bytes memory\.system\.used memory\.system\.used_bytes memoryfree memoryfree_mb
-                    memorysize_mb mountpoints\..* mtu_.* networking\.interfaces\..*\.mtu networking\.mtu
-                    os\.selinux\.enabled partitions\..*\.filesystem partitions\..*\.size_bytes partitions\..*\.mount
-                    partitions\..*\.uuid physicalprocessorcount processorcount processors\.count
-                    processors\.physicalcount selinux swapfree_mb swapsize_mb system_uptime\.days system_uptime\.hours
-                    system_uptime\.seconds uptime_days uptime_hours uptime_seconds clientnoop swapfree
-                    disks\..*\.size_bytes hypervisors\.lpar\.partition_number mountpoints\..*\.capacity
-                    processors\.speed serialnumber hypervisors\.xen\.privileged os\.release.\minor
-                    operatingsystemrelease os\.release\.full os\.distro\.description filesystems
-                    sp_uptime system_profiler\.uptime os\.release\.minor
-                    hypervisors\.zone\..* system_uptime\.uptime uptime hypervisors\.ldom\..* ldom_.*
-                    boardassettag dmi\.board\.asset_tag is_virtual kernelmajversion lsbmajdistrelease zones virtual
-                    blockdevice_.*_vendor blockdevice_.*_size]
+  EXCLUDE_LIST = %w[ facterversion
+    load_averages\..*
+    processors\.speed
+    swapfree swapfree_mb
+    memoryfree memoryfree_mb
+    memory\.swap\.available_bytes memory\.swap\.used_bytes
+    memory\.swap\.available memory\.swap\.capacity memory\.swap\.used
+    memory\.system\.available_bytes memory\.system\.used_bytes
+    memory\.system\.available memory\.system\.capacity memory\.system\.used
+    mountpoints\..*\.available* mountpoints\..*\.capacity mountpoints\..*\.used*
+    sp_uptime system_profiler\.uptime
+    uptime uptime_days uptime_hours uptime_seconds
+    system_uptime\.uptime system_uptime\.days system_uptime\.hours system_uptime\.seconds
+  ]
 
   agents.each do |agent|
     teardown do


### PR DESCRIPTION
This commit updates the exclude list in `acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb` according to [PUP-10947](https://github.com/puppetlabs/puppet/pull/8538) changes and findings.

Needed fixed and released before merging this pull request:
- [ ] [FACT-2956](https://tickets.puppetlabs.com/browse/FACT-2956)
- [ ] [FACT-2963](https://tickets.puppetlabs.com/browse/FACT-2963)
- [ ] [FACT-2964](https://tickets.puppetlabs.com/browse/FACT-2964)
- [ ] [FACT-2965](https://tickets.puppetlabs.com/browse/FACT-2965)
- [ ] [FACT-2966](https://tickets.puppetlabs.com/browse/FACT-2966)
- [ ] [FACT-2967](https://tickets.puppetlabs.com/browse/FACT-2967)