### PR TITLE
(maint) Fix Travis docker build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,12 @@ matrix:
         - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
+        - docker buildx create --name travis_builder --use
       script:
         - set -e
         - cd docker
         - make lint
         - make build
         - make test
+      after_script:
+        - docker buildx rm travis_builder

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -35,9 +35,9 @@ endif
 build: prep
 	docker pull alpine:$(alpine_version)
 	docker pull ubuntu:$(ubuntu_version)
-	docker build ${DOCKER_BUILD_FLAGS} --build-arg ubuntu_version=$(ubuntu_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
+	docker buildx build --load ${DOCKER_BUILD_FLAGS} --build-arg ubuntu_version=$(ubuntu_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-ubuntu/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) puppet-agent-ubuntu
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(version)
-	docker build ${DOCKER_BUILD_FLAGS} --build-arg alpine_version=$(alpine_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
+	docker buildx build --load ${DOCKER_BUILD_FLAGS} --build-arg alpine_version=$(alpine_version) --build-arg vcs_ref=$(vcs_ref) --build-arg build_date=$(build_date) --build-arg version=$(version) --file puppet-agent-alpine/$(dockerfile) --tag $(NAMESPACE)/puppet-agent-alpine:$(version) $(PWD)/..
 ifeq ($(IS_LATEST),true)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent-ubuntu:$(LATEST_VERSION)
 	@docker tag $(NAMESPACE)/puppet-agent-ubuntu:$(version) $(NAMESPACE)/puppet-agent:$(LATEST_VERSION)


### PR DESCRIPTION
 - Upgrading to Travis 20.10 from 19.03 doesn't seem to have fully
   resolved the docker buildkit precondition issues. Implement the
   workaround suggestion from https://github.com/moby/moby/issues/41864

   This switches to the docker buildx build cli from docker build cli