### PR TITLE
(PA-3667) PUPPET_SERVER .msi property

### DIFF
--- a/resources/windows/wix/properties.wxs.erb
+++ b/resources/windows/wix/properties.wxs.erb
@@ -94,6 +94,23 @@
         Type="raw"
         Win64="no" />
     </Property>
+    <Property Id="PUPPET_SERVER">
+      <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
+      <RegistrySearch
+        Id="RecallBadPuppetServer"
+        Root="HKLM"
+        Key="[REMEMBERED_PUPPET_ROOT_KEY]"
+        Name="RememberedPuppetServer"
+        Type="raw"
+        Win64="no" />
+      <RegistrySearch
+        Id="RecallPuppetServer"
+        Root="HKLM"
+        Key="[REMEMBERED_PUPPETINSTALLER_ROOT_KEY]"
+        Name="RememberedPuppetServer"
+        Type="raw"
+        Win64="no" />
+    </Property>
     <Property Id="PUPPET_AGENT_ENVIRONMENT">
       <!-- Recall the property in repair, upgrade, and uninstall scenarios -->
       <RegistrySearch

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -31,6 +31,10 @@
             Type="string"
             Value="[PUPPET_MASTER_SERVER]" />
           <RegistryValue
+            Name="RememberedPuppetServer"
+            Type="string"
+            Value="[PUPPET_SERVER]" />
+          <RegistryValue
             Name="RememberedPuppetAgentEnvironment"
             Type="string"
             Value="[PUPPET_AGENT_ENVIRONMENT]" />

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -92,8 +92,12 @@
         INI_PUPPET_MASTER_SERVER
       </Custom>
       <Custom Action='SaveCmdLinePuppetMasterServer' Before='AppSearch' />
+      <Custom Action='SaveCmdLinePuppetServer' Before='AppSearch' />
       <Custom Action='SetFromCmdLinePuppetMasterServer' After='FileCost'>
         CMDLINE_PUPPET_MASTER_SERVER
+      </Custom>
+      <Custom Action='SetFromCmdLinePuppetServer' After='FileCost'>
+        CMDLINE_PUPPET_SERVER
       </Custom>
       <Custom Action='SetDefaultPuppetMasterServer' Before='CostFinalize'>
         PUPPET_MASTER_SERVER=""


### PR DESCRIPTION
Previously using PUPPET_SERVER .msi property would
not correctly set puppet server.
Now it is correctly linked.
PUPPET_MASTER_SERVER also works.