### PR TITLE
(maint) Use Docker 19.03 in Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,23 @@ matrix:
       rvm: 2.6.6
       env:
         - DOCKER_COMPOSE_VERSION=1.28.6
+        - DOCKER_BUILDX_VERSION=0.5.1
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
       before_install:
-        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-        - sudo apt-get update
-        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce docker-ce-cli containerd.io
         - sudo rm /usr/local/bin/docker-compose
         - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
+        - mkdir -vp ~/.docker/cli-plugins
+        - curl --location https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+        - chmod +x ~/.docker/cli-plugins/docker-buildx
+        - docker buildx create --name travis_builder --use
       script:
         - set -e
         - cd docker
         - make lint
         - make build
         - make test
+      after_script:
+        - docker buildx rm travis_builder

--- a/docker/puppet-agent-alpine/Dockerfile
+++ b/docker/puppet-agent-alpine/Dockerfile
@@ -12,9 +12,9 @@ ENV PATH=$PATH:$JAVA_HOME/jre/bin:$JAVA_HOME/bin \
 
 # hadolint ignore=DL3018,DL3028
 RUN apk add --no-cache cmake boost-dev make gcc g++ curl git curl-dev ruby ruby-dev yaml-cpp-dev jq openjdk8 augeas ruby-augeas ruby-etc ruby-json ruby-multi_json libressl-dev virt-what && \
-    gem install --no-rdoc --no-ri deep_merge semantic_puppet puppet-resource_api locale httpclient fast_gettext concurrent-ruby
-
-RUN mkdir /workspace && \
+    gem install --no-rdoc --no-ri deep_merge semantic_puppet puppet-resource_api locale httpclient fast_gettext concurrent-ruby  && \
+    \
+    mkdir /workspace && \
     sed -i -e 's/sys\/poll/poll/' /usr/include/boost/asio/detail/socket_types.hpp
 
 ######################################################
@@ -122,9 +122,9 @@ WORKDIR /workspace/puppet
 COPY configs/components/puppet.json /workspace
 RUN git clone https://github.com/puppetlabs/puppet . && \
     git checkout "$(jq -r .ref /workspace/puppet.json)" && \
-    ./install.rb --bindir=/opt/puppetlabs/puppet/bin --configdir=/etc/puppetlabs/puppet --sitelibdir=/usr/lib/ruby/vendor_ruby --codedir=/etc/puppetlabs/code --vardir=/opt/puppetlabs/puppet/cache --logdir=/var/log/puppetlabs/puppet --rundir=/var/run/puppetlabs --quick
-
-RUN mkdir -p /opt/puppetlabs/bin && \
+    ./install.rb --bindir=/opt/puppetlabs/puppet/bin --configdir=/etc/puppetlabs/puppet --sitelibdir=/usr/lib/ruby/vendor_ruby --codedir=/etc/puppetlabs/code --vardir=/opt/puppetlabs/puppet/cache --logdir=/var/log/puppetlabs/puppet --rundir=/var/run/puppetlabs --quick && \
+    \
+    mkdir -p /opt/puppetlabs/bin && \
     ln -s /opt/puppetlabs/puppet/bin/facter /opt/puppetlabs/bin/facter && \
     ln -s /opt/puppetlabs/puppet/bin/puppet /opt/puppetlabs/bin/puppet && \
     ln -s /opt/puppetlabs/puppet/bin/hiera /opt/puppetlabs/bin/hiera


### PR DESCRIPTION
- Instead of incurring the upgrade cost to Travis 20.10, use the
   existing 19.03 version.

   In practice, upgrading Docker in Travis turned out to be unreliable.

   To enable buildx requires installing the plugin from the github
   releases page. Using the experimental cli flag was supposed to enable
   the plugin for 19.03, but didn't seem to work in the Travis env.

 - Also adds missing generation of named buildx builder to 6.x branch