### PR TITLE
(maint) Pin cmake on el-8-aarch64

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -3,7 +3,7 @@ platform "el-8-aarch64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc-c++ rsync cmake make rpm-libs rpm-build)
+  packages = %w(gcc-c++ rsync cmake-3.11.4 make rpm-libs rpm-build)
 
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "


### PR DESCRIPTION
Same fix as [PR#2103](https://github.com/puppetlabs/puppet-agent/pull/2103) but for el-8-aarch64

RedHat recently updated their repos and the cmake version pulled is newer (3.18.2). This uses a libarchive method that is not available on 3.3.2 which is the one that comes with the box.

cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

This can either be fixed by updating the libarchive package to 3.3.3, or by pinning cmake to the previous working version (3.11.4). Pin cmake for now.