### PR TITLE
(maint) Merge up 6.x to main

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -314,5 +314,12 @@ Style/RegexpLiteral:
 Style/ModuleFunction:
   Enabled: false
 
+# Excluding 'configs/platforms/*' so rubocop ignores the platforms that just 
+# inherit from default. 
+Style/SymbolProc:
+  Enabled: true
+  Exclude: 
+    - 'configs/platforms/*'
+
 Lint/Debugger:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def location_for(place)
   end
 end
 
-gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.20')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.21')
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.43')
 gem 'artifactory'
 gem 'rake'

--- a/configs/platforms/fedora-34-x86_64.rb
+++ b/configs/platforms/fedora-34-x86_64.rb
@@ -1,0 +1,13 @@
+platform "fedora-34-x86_64" do |plat|
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+    plat.dist "fc34"
+
+
+    plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake rsync gcc gcc-c++ make rpmdevtools cmake"
+
+    plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
+
+    plat.vmpooler_template "fedora-34-x86_64"
+  end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -15,6 +15,7 @@ foss_platforms:
   - fedora-30-x86_64
   - fedora-31-x86_64
   - fedora-32-x86_64
+  - fedora-34-x86_64
   - osx-10.14-x86_64
   - osx-10.15-x86_64
   - osx-11-x86_64
@@ -62,6 +63,8 @@ platform_repos:
     repo_location: repos/fedora/31/**/x86_64
   - name: fedora-32-x86_64
     repo_location: repos/fedora/32/**/x86_64
+  - name: fedora-34-x86_64
+    repo_location: repos/fedora/34/**/x86_64
   - name: debian-9-i386
     repo_location: repos/apt/stretch
   - name: debian-9-amd64


### PR DESCRIPTION


* 6.x:
  (PA-3604) Add Fedora 34 x86_64 platform definition
  (maint) Update leatherman to 9b13c5c9cf712e7bc6bb892df08b1acce69a4af6
  (VANAGON-85) add output_dir to mac OS
  (maint) Update puppet to 8d21da1425750d1ae7b399e67c7d7a4e2da33d31
  (maint) Update puppet to 8fc33e8b55ec4d178364d837d18336f7d7331e27
  (VANAGON-85) add inherit_from_default to OS X 11
  (VANAGON-85) Move platform definitions into core vanagon. Inherit definitions from a default platform.
  (PA-3605) Add Fedora 34 x86_64 to build_defaults.yaml

VANAGON-85 changes will be handled in a separate PR.

