### PR TITLE
(maint) pin cmake to 3.11.4

### DIFF
--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -1,3 +1,7 @@
 platform "el-8-x86_64" do |plat|
   plat.inherit_from_default
+  plat.clear_provisioning
+
+  packages = %w(gcc-c++ rsync cmake-3.11.4 make rpm-libs rpm-build)
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
 end


### PR DESCRIPTION
Due to `cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd`