### PR TITLE
(VANAGON-85) fix solaris 11 location

### DIFF
--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -1,3 +1,4 @@
 platform "solaris-11-i386" do |plat|
   plat.inherit_from_default
+  plat.output_dir File.join("solaris", "11", "puppet6")
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -1,3 +1,4 @@
 platform "solaris-11-sparc" do |plat|
   plat.inherit_from_default
+  plat.output_dir File.join("solaris", "11", "puppet6")
 end


### PR DESCRIPTION
Solaris packages should not be shipped in folders
per architecture, they are all in the same location.


```diff
--- from_file
+++ failing 1e31c88b6b8478749420c1944f355057d54c4717
@@ -1,4 +1,4 @@
-passing  84b6df9aacf984149f36a0372d6bac6728be4206
+failing 1e31c88b6b8478749420c1944f355057d54c4717
 
 aix
 apple
@@ -135,7 +135,7 @@
 ./el/8/puppet6/x86_64:
 
 ./fedora:
-30  31  32
+30  31  32  34
 
 ./fedora/30:
 puppet6
@@ -160,6 +160,14 @@
 x86_64
 
 ./fedora/32/puppet6/x86_64:
+
+./fedora/34:
+puppet6
+
+./fedora/34/puppet6:
+x86_64
+
+./fedora/34/puppet6/x86_64:
 
 ./redhatfips:
 7
@@ -215,6 +223,11 @@
 puppet6
 
 ./solaris/11/puppet6:
+i386  sparc
+
+./solaris/11/puppet6/i386:
+
+./solaris/11/puppet6/sparc:
 
 ./windows:
 
```