### PR TITLE
(maint) install `libarchive` on el-8

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -1,8 +1,3 @@
 platform "el-8-aarch64" do |plat|
   plat.inherit_from_default
-
-  plat.clear_provisioning
-
-  packages = %w(gcc-c++ rsync cmake-3.11.4 make rpm-libs rpm-build)
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
 end

--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -3,7 +3,7 @@ platform "el-8-ppc64le" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake-3.11.4 make rpm-libs rpm-build)
+  packages = %w(gcc gcc-c++ autoconf automake createrepo rsync cmake make rpm-libs rpm-build libarchive)
 
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "

--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -1,7 +1,3 @@
 platform "el-8-x86_64" do |plat|
   plat.inherit_from_default
-  plat.clear_provisioning
-
-  packages = %w(gcc-c++ rsync cmake-3.11.4 make rpm-libs rpm-build)
-  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
 end


### PR DESCRIPTION
https://github.com/puppetlabs/puppet-agent/pull/2108 locked cmake to 3.11.4 to overcome an issue with libarchive 3.3.2.
The issue was fixed in libarchive 3.3.1 bugs.centos.org/view.php?id=18212

depends on https://github.com/puppetlabs/vanagon/pull/697