### PR TITLE
(maint) remove facter-ng.json

### DIFF
--- a/configs/components/facter-ng.json
+++ b/configs/components/facter-ng.json
@@ -1,1 +1,0 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"564b9d0561015ee240eaf8c56dcded297195e2a3"}


### PR DESCRIPTION
On main we do not use the facter-ng component.
This probably got merged-up by jenkins