### PR TITLE
(PA-3756) codesign entry-points on mac OS

### DIFF
--- a/acceptance/tests/ensure_macos_executables_are_signed.rb
+++ b/acceptance/tests/ensure_macos_executables_are_signed.rb
@@ -1,0 +1,22 @@
+test_name 'Ensure puppet executables are codesigned on mac OS' do
+  confine :to, :platform => /osx/
+  tag 'audit:high'
+
+  agents.each do |agent|
+    [
+      '/opt/puppetlabs/bin/puppet',
+      '/opt/puppetlabs/puppet/bin/puppet',
+      '/opt/puppetlabs/puppet/bin/pxp-agent',
+      '/opt/puppetlabs/puppet/bin/wrapper.sh'
+    ].each do |path|
+      step "test #{path}" do
+        on(agent, "codesign -vv #{path}") do |result|
+          output = result.output
+
+          assert_match(/valid on disk/, output)
+          assert_match(/satisfies its Designated Requirement/, output)
+        end
+      end
+    end
+  end
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -21,6 +21,15 @@ project "puppet-agent" do |proj|
   # at present, we need to conflict with pe-r10k < 2.5.0.0
   proj.conflicts "pe-r10k", "2.5.0.0"
 
+  if platform.is_macos?
+    proj.extra_file_to_sign File.join(proj.bindir, 'puppet')
+    proj.extra_file_to_sign File.join(proj.bindir, 'pxp-agent')
+    proj.extra_file_to_sign File.join(proj.bindir, 'wrapper.sh')
+    proj.signing_hostname 'osx-signer.delivery.puppetlabs.net'
+    proj.signing_username 'jenkins'
+    proj.signing_command '"security -q unlock-keychain -p \$$OSX_SIGNING_KEYCHAIN_PW \$$OSX_SIGNING_KEYCHAIN; codesign --timestamp --keychain \$$OSX_SIGNING_KEYCHAIN -vfs \"\$$OSX_CODESIGNING_CERT\""'
+  end
+
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Puppet Inc")


### PR DESCRIPTION
builds available for main branch on under `9933b8fa7b66de8f99fe7dafc71e4cb8f1878e75` ref
depends on: https://github.com/puppetlabs/vanagon/pull/700

```
Ensure puppet executables are codesigned on mac OS

  * test /opt/puppetlabs/bin/puppet

    host (host) 09:08:20$ codesign -vv /opt/puppetlabs/bin/puppet
      /opt/puppetlabs/bin/puppet: valid on disk
      /opt/puppetlabs/bin/puppet: satisfies its Designated Requirement

    host (host) executed in 3.15 seconds

  * test /opt/puppetlabs/puppet/bin/puppet

    host (host) 09:08:23$ codesign -vv /opt/puppetlabs/puppet/bin/puppet
      /opt/puppetlabs/puppet/bin/puppet: valid on disk
      /opt/puppetlabs/puppet/bin/puppet: satisfies its Designated Requirement

    host (host) executed in 1.01 seconds

  * test /opt/puppetlabs/puppet/bin/pxp-agent

    host (host) 09:08:25$ codesign -vv /opt/puppetlabs/puppet/bin/pxp-agent
      /opt/puppetlabs/puppet/bin/pxp-agent: valid on disk
      /opt/puppetlabs/puppet/bin/pxp-agent: satisfies its Designated Requirement

    host (host) executed in 1.40 seconds

  * test /opt/puppetlabs/puppet/bin/pxp-agent

    host (host) 09:08:26$ codesign -vv /opt/puppetlabs/puppet/bin/wrapper.sh
      /opt/puppetlabs/puppet/bin/wrapper.sh: valid on disk
      /opt/puppetlabs/puppet/bin/wrapper.sh: satisfies its Designated Requirement

    host (host) executed in 1.40 seconds
```