### PR TITLE
(PCP-890) Use wrapper script when starting pxp-agent for AIX

### DIFF
--- a/configs/components/wrapper-script.rb
+++ b/configs/components/wrapper-script.rb
@@ -15,7 +15,7 @@ component "wrapper-script" do |pkg, settings, platform|
     pkg.install_file "sysv-wrapper.sh", wrapper, mode: '0755'
   end
 
-  ["facter", "hiera", "puppet"].each do |exe|
+  ["facter", "hiera", "puppet", "pxp-agent"].each do |exe|
     pkg.link wrapper, "#{settings[:link_bindir]}/#{exe}"
   end
 end

--- a/resources/aix/pxp-agent.service
+++ b/resources/aix/pxp-agent.service
@@ -1,1 +1,1 @@
-'/opt/puppetlabs/puppet/bin/pxp-agent' -a '--foreground' -s pxp-agent -u root
+/opt/puppetlabs/bin/pxp-agent -a '--foreground' -s pxp-agent -u root


### PR DESCRIPTION
This was something we forgot to do as part of PA-437. Note that we'll
also need the wrapper script for Solaris and OSX; their service scripts
will be updated accordingly in the pxp-agent repo.

Signed-off-by: Enis Inan <enis.inan@puppet.com>