### PR TITLE
(PA-3829) Add macOS 11 arm64 platform

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -13,6 +13,7 @@ component "cpp-hocon" do |pkg, settings, platform|
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
+    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -70,6 +71,7 @@ component "cpp-hocon" do |pkg, settings, platform|
   # Tests will be skipped on AIX until they are expected to pass
   if platform.is_cross_compiled? || platform.is_aix?
     test = "/bin/true"
+    test = "/usr/bin/true" if platform.is_macos?
   else
     test = "#{make} test ARGS=-V"
   end

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -29,6 +29,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
+    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -120,6 +120,7 @@ component "facter" do |pkg, settings, platform|
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
+    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -12,6 +12,11 @@ component "hiera" do |pkg, settings, platform|
             --sitelibdir=#{settings[:ruby_vendordir]} \
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
+  if platform.is_cross_compiled? && platform.is_macos?
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+    pkg.build_requires "ruby@#{ruby_version_y}"
+  end
+
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -39,6 +39,7 @@ component "leatherman" do |pkg, settings, platform|
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
+    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -8,10 +8,19 @@
 # This component should also be present in the puppet-runtime project
 component "pl-ruby-patch" do |pkg, settings, platform|
   if platform.is_cross_compiled?
+    if platform.is_macos?
+      pkg.build_requires 'gnu-sed'
+      pkg.environment "PATH", "/usr/local/opt/gnu-sed/libexec/gnubin:$(PATH)"
+    end
+
     ruby_api_version = settings[:ruby_version].gsub(/\.\d*$/, '.0')
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+
     base_ruby = case platform.name
                 when /solaris-10/
                   "/opt/csw/lib/ruby/2.0.0"
+                when /osx/
+                  "/usr/local/opt/ruby@#{ruby_version_y}/lib/ruby/#{ruby_api_version}"
                 else
                   "/opt/pl-build-tools/lib/ruby/2.1.0"
                 end
@@ -21,8 +30,10 @@ component "pl-ruby-patch" do |pkg, settings, platform|
       # weird architecture naming conventions...
       target_triple = if platform.architecture =~ /ppc64el|ppc64le/
                         "powerpc64le-linux"
-                      elsif platform.name =~ /solaris-11-sparc/
+                      elsif platform.name == 'solaris-11-sparc'
                         "sparc-solaris-2.11"
+                      elsif platform.is_macos?
+                        "aarch64-darwin"
                       else
                         "#{platform.architecture}-linux"
                       end
@@ -36,7 +47,12 @@ component "pl-ruby-patch" do |pkg, settings, platform|
     end
 
     # make rubygems use our target rbconfig when installing gems
-    sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    if ruby_version_y == '2.7'
+      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    else
+      sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    end
+
     pkg.build do
       [
         %(#{platform[:sed]} -i "#{sed_command}" #{base_ruby}/rubygems/ext/ext_conf_builder.rb)

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -33,6 +33,7 @@ component "pxp-agent" do |pkg, settings, platform|
     toolchain = ""
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = "-DBOOST_STATIC=OFF"
+    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -28,7 +28,7 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc"
   end
 
-  if platform.is_cross_compiled?
+  if platform.is_cross_compiled? || !platform.is_macos?
     libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib")
     libdir = File.join("/opt/pl-build-tools", settings[:platform_triple], "lib64") if platform.architecture =~ /aarch64|ppc64/
   elsif platform.is_solaris? || platform.architecture =~ /i\d86/

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,0 +1,22 @@
+platform "osx-11-arm64" do |plat|
+  plat.servicetype "launchd"
+  plat.servicedir "/Library/LaunchDaemons"
+  plat.codename "bigsur"
+  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
+  plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "sudo dscl . -create /Users/test"
+  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
+  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
+  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
+  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
+  plat.provision_with "sudo dscl . -passwd /Users/test password"
+  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
+  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
+  plat.provision_with "mkdir -p /etc/homebrew"
+  plat.provision_with "cd /etc/homebrew"
+  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+  plat.provision_with "sudo chown -R test:admin /Users/test/"
+  plat.vmpooler_template "macos-112-x86_64"
+  plat.cross_compiled true
+  plat.output_dir File.join('apple', '11', 'puppet6', 'arm64')
+end


### PR DESCRIPTION
Add support for building the puppet-agent project for macOS 11 ARM64 (M1) via cross-compilation from an x86 host.

ARM64 package (shipped to the wrong directory but fixed it afterwards): http://builds.delivery.puppetlabs.net/puppet-agent/291a6e60a792848ebe95aa11ad6b6d922759823b/artifacts/apple/11/puppet6/x86_64/puppet-agent-6.19.1.483.g291a6e60a-1.osx11.dmg

How to confirm:
```sh-session
> curl -O http://builds.delivery.puppetlabs.net/puppet-agent/291a6e60a792848ebe95aa11ad6b6d922759823b/artifacts/apple/11/puppet6/x86_64/puppet-agent-6.19.1.483.g291a6e60a-1.osx11.dmg
> hdiutil attach puppet-agent-6.19.1.483.g291a6e60a-1.osx11.dmg
> xar -xf /Volumes/puppet-agent-6.19.1.483.g291a6e60a-1.osx11/puppet-agent-6.19.1.483.g291a6e60a-1-installer.pkg
> tar xvf ./puppet-agent-6.19.1.483.g291a6e60a-1.pkg/Payload
> find opt | egrep "\.bundle|\.dylib" | xargs file
...
opt/puppetlabs/puppet/lib/libfa.dylib:                                                             Mach-O 64-bit dynamically linked shared library arm64
opt/puppetlabs/puppet/lib/libxslt.1.dylib:                                                         Mach-O 64-bit dynamically linked shared library arm64
opt/puppetlabs/puppet/lib/leatherman_dynamic_library.dylib:                                        Mach-O 64-bit dynamically linked shared library arm64
...
```

Depends on https://github.com/puppetlabs/packaging/pull/1114 (probably), https://github.com/puppetlabs/puppet-runtime/pull/468 (definitely), and https://github.com/puppetlabs/pxp-agent-vanagon/pull/29 (for puppet-agent#main)