### PR TITLE
(maint) Update puppet to e89bc9f1e0

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"de8edfd7849289f6e0f7be40a913ec7e4f11f92d"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"e89bc9f1e0a9365cb7f0e8b105c04c50a7b43395"}


### PR DESCRIPTION
Bump puppet to e89bc9f1e0 to pull in the commit from https://github.com/puppetlabs/puppet/commit/bbc6d413ce048712388699d54f0fe466e2b972e8