### PR TITLE
(maint) Update puppet to c9407626cb

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"985d18ce2fcc2131d70676ee66b7693c13f3dbe7"}
+{"url":"git://github.com/puppetlabs/puppet.git","ref":"c9407626cbf62b776ca60f9d814d76691e9f293f"}


### PR DESCRIPTION
Bump puppet to c9407626cb to pull in the commit from https://github.com/puppetlabs/puppet/commit/bbc6d413ce048712388699d54f0fe466e2b972e8

Actual commit https://github.com/puppetlabs/puppet/commit/c9407626cbf62b776ca60f9d814d76691e9f293f