### PR TITLE
(PUP-10685) Clean up `ext/` directory from puppet

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"bda5769f9a6819115470c319bc03ef0d967ad433"}
+{"url":"git://github.com/luchihoratiu/puppet.git","ref":"PUP-10685"}

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -35,14 +35,12 @@ component "puppet" do |pkg, settings, platform|
   platform.get_service_types.each do |servicetype|
     case servicetype
     when "systemd"
-      pkg.install_service "ext/systemd/puppet.service", "ext/redhat/client.sysconfig", init_system: servicetype
+      pkg.install_service "ext/systemd/puppet.service", init_system: servicetype
     when "sysv"
       if platform.is_deb?
         pkg.install_service "ext/debian/puppet.init", "ext/debian/puppet.default", init_system: servicetype
       elsif platform.is_sles?
-        pkg.install_service "ext/suse/client.init", "ext/redhat/client.sysconfig", init_system: servicetype
-      elsif platform.is_rpm?
-        pkg.install_service "ext/redhat/client.init", "ext/redhat/client.sysconfig", init_system: servicetype
+        pkg.install_service "ext/suse/client.init", init_system: servicetype
       end
     when "launchd"
       pkg.install_service "ext/osx/puppet.plist", nil, "com.puppetlabs.puppet", init_system: servicetype


### PR DESCRIPTION
This commit aids cleanup done in puppet by removing mentions of `ext/redhat/client.sysconfig` from puppet-agent files. See https://github.com/puppetlabs/puppet/pull/8695 for more info.

TODO before merge:

- [ ] Remove `configs/components/puppet.json` changes