### PR TITLE
(maint) Merge up `6.x` into `main`

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -12,6 +12,11 @@ component "hiera" do |pkg, settings, platform|
             --sitelibdir=#{settings[:ruby_vendordir]} \
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
+  if platform.is_cross_compiled? && platform.is_macos?
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+    pkg.build_requires "ruby@#{ruby_version_y}"
+  end
+
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"

--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -8,14 +8,30 @@
 # This component should also be present in the puppet-runtime project
 component "pl-ruby-patch" do |pkg, settings, platform|
   if platform.is_cross_compiled?
+    if platform.is_macos?
+      pkg.build_requires 'gnu-sed'
+      pkg.environment "PATH", "/usr/local/opt/gnu-sed/libexec/gnubin:$(PATH)"
+    end
+
     ruby_api_version = settings[:ruby_version].gsub(/\.\d*$/, '.0')
-    base_ruby = "/opt/pl-build-tools/lib/ruby/2.1.0"
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+
+    base_ruby = case platform.name
+                when /solaris-10/
+                  "/opt/csw/lib/ruby/2.0.0"
+                when /osx/
+                  "/usr/local/opt/ruby@#{ruby_version_y}/lib/ruby/#{ruby_api_version}"
+                else
+                  "/opt/pl-build-tools/lib/ruby/2.1.0"
+                end
 
     # weird architecture naming conventions...
     target_triple = if platform.architecture =~ /ppc64el|ppc64le/
                       "powerpc64le-linux"
-                    elsif platform.name =~ /solaris-11-sparc/
+                    elsif platform.name == 'solaris-11-sparc'
                       "sparc-solaris-2.11"
+                    elsif platform.is_macos?
+                      "aarch64-darwin"
                     else
                       "#{platform.architecture}-linux"
                     end
@@ -28,7 +44,12 @@ component "pl-ruby-patch" do |pkg, settings, platform|
     end
 
     # make rubygems use our target rbconfig when installing gems
-    sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    if ruby_version_y == '2.7'
+      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    else
+      sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    end
+
     pkg.build do
       [
         %(#{platform[:sed]} -i "#{sed_command}" #{base_ruby}/rubygems/ext/ext_conf_builder.rb)

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,0 +1,22 @@
+platform "osx-11-arm64" do |plat|
+  plat.servicetype "launchd"
+  plat.servicedir "/Library/LaunchDaemons"
+  plat.codename "bigsur"
+  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
+  plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "sudo dscl . -create /Users/test"
+  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
+  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
+  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
+  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
+  plat.provision_with "sudo dscl . -passwd /Users/test password"
+  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
+  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
+  plat.provision_with "mkdir -p /etc/homebrew"
+  plat.provision_with "cd /etc/homebrew"
+  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+  plat.provision_with "sudo chown -R test:admin /Users/test/"
+  plat.vmpooler_template "macos-112-x86_64"
+  plat.cross_compiled true
+  plat.output_dir File.join('apple', '11', 'puppet6', 'arm64')
+end

--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -164,7 +164,7 @@ function install_puppetdb_from_package() {
   local yum_cmd="yum --releasever=7"
 
   echo "STEP: Set-up postgresql 9.6 to use with PuppetDB"
-  on_master ${master_vm} "rpm --query --quiet pgdg-redhat96-9.6-3.noarch || ${yum_cmd} install -y https://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-42.0-11.noarch.rpm"
+  on_master ${master_vm} "rpm --query --quiet pgdg-redhat96-9.6-3.noarch || ${yum_cmd} install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-42.0-18.noarch.rpm"
   on_master ${master_vm} "rpm --query --quiet postgresql96-server || ${yum_cmd} install -y postgresql96-server"
   on_master ${master_vm} "rpm --query --quiet postgresql96-contrib || ${yum_cmd} install -y postgresql96-contrib"
   on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=stopped"
@@ -172,7 +172,7 @@ function install_puppetdb_from_package() {
   on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=running enable=true"
 
   #After postgress has been installed we need to remove the postgress repo or else other yum install commands will fail.
-  on_master ${master_vm} "${yum_cmd} remove -y pgdg-redhat-repo-42.0-11.noarch"
+  on_master ${master_vm} "${yum_cmd} remove -y pgdg-redhat-repo-42.0-18.noarch"
 
   # Enters 'puppet' as the password.
   on_master ${master_vm} "runuser -l postgres -c '(echo puppet && echo puppet) | createuser -DRSP puppetdb'"


### PR DESCRIPTION
Merged up from 6.x:
-   (maint) Update facter-ng to f4094d9624d0984d861656e7e205a978f86fb84d
-   (maint) Update puppet to 1d6f9e61ef4c3350f55ef60a4ab66eaabbca7d4b
-   (maint) fix compilation
-   (maint) Update facter-ng to b2d2757ec7a54da0341563b83b1abda7dbe460ec
-   (maint) Fix release-lead.rake to properly clone both facter and facter-ng
-   (maint) Update puppet-runtime to 202107140
-   (PA-3854) Fix pgdg repo location in smoke test
-   (PA-3829) Add macOS 11 arm64 platform

Conflicts:
- 	configs/components/facter.rb
- 	configs/components/pl-ruby-patch.rb
- 	configs/components/puppet.json
- 	configs/components/pxp-agent.rb

Conflict was due to macOS 11 arm64 platform addition.