### PR TITLE
(PA-3843) Add option to enable long path names in the Windows Installer

### DIFF
--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -253,9 +253,21 @@ End If
     <%-if @platform.architecture == "x86"-%>
     <Property Id="WixQuietExecCmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;if (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components') { Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Set-ItemProperty -Path $_.PSPath -Name $prop -Value '' -ErrorAction Stop } } }; Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*puppet\bin\nssm.exe*') { Set-ItemProperty -Path $_.PSPath -Name $prop -Value '' -ErrorAction Stop } } } }&quot;"/>
     <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+    <Property Id="WixSilentExecCmdLine"  Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; try {$check_long_path_enabled = Get-ItemProperty -Path &quot;HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem&quot; | Select-Object -ExpandProperty  &quot;LongPathsEnabled&quot; -ErrorAction Stop;if($check_long_path_enabled -ne 1 ){throw  &quot;Value needs to be 1&quot;}} catch { New-ItemProperty -Path  &quot;HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem&quot; -Name  &quot;LongPathsEnabled&quot; -Value 1 -PropertyType DWORD -Force }"/>
+    <CustomAction Id="EnableLongPathName"
+            BinaryKey="WixCA"
+            DllEntry="WixSilentExec"
+            Execute="immediate"
+            Impersonate="yes" />
     <%-else-%>
     <Property Id="WixQuietExec64CmdLine" Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -Command &quot;if (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components') { Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*service\nssm.exe*') { Set-ItemProperty -Path $_.PSPath -Name -Value '' $prop -ErrorAction Stop } } }; Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components' -Recurse | foreach { foreach ($prop in $_.Property) { if($_.GetValue($prop) -like '*puppet\bin\nssm.exe*') { Set-ItemProperty -Path $_.PSPath -Name $prop -Value '' -ErrorAction Stop } } } }&quot;"/>
     <CustomAction Id="RemoveLegacyNssmRegistryKey" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>
+    <Property Id="WixSilentExec64CmdLine"  Value="&quot;[%WINDIR]\System32\WindowsPowerShell\v1.0\powershell.exe&quot; try{$check_long_path_enabled = Get-ItemProperty -Path &quot;HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem&quot; | Select-Object -ExpandProperty  &quot;LongPathsEnabled&quot; -ErrorAction Stop;if($check_long_path_enabled -ne 1 ){throw  &quot;Value needs to be 1&quot;}} catch { New-ItemProperty -Path  &quot;HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem&quot; -Name  &quot;LongPathsEnabled&quot; -Value 1 -PropertyType DWORD -Force }"/>
+    <CustomAction Id="EnableLongPathName"
+            BinaryKey="WixCA"
+            DllEntry="WixSilentExec64"
+            Execute="immediate"
+            Impersonate="yes" />
     <%-end-%>
 
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->

--- a/resources/windows/wix/properties.wxs.erb
+++ b/resources/windows/wix/properties.wxs.erb
@@ -50,6 +50,10 @@
       Id="WIXUI_EXITDIALOGOPTIONALTEXT"
       Value="Manage your first resources on this node, explore the Puppet community and get support using the shortcuts in the Documentation folder of your Start Menu." />
 
+    <Property
+      Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT"
+      Value="Disable Windows path length limit (260 character MAX_PATH limitation, requires Windows 10 1607 or later)" />
+
     <!--                  ***NOTE***
         When originally moving to vanagon builds of puppet-agent (specifically for 1.6.0 and 1.6.1),
         we wrote several registry entries to the wrong place. We fixed the issue in 1.6.2, but in order

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -150,7 +150,9 @@
       <Custom Action='SetFromIniPuppetServerPort' Before='FileCost'>
         INI_PUPPET_SERVER_PORT AND NOT PUPPET_SERVER_PORT
       </Custom>
-
+       <Custom Action='EnableLongPathName' Before='InstallFiles'>
+        ENABLE_LONG_PATHS
+       </Custom>
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
       <!-- Also resets permissions for children beneath each appdir -->
       <Custom Action='ResetDataPermissions' After='InstallFiles'>

--- a/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
+++ b/resources/windows/wix/ui/WixUI_PuppetInstallDir.wxs.erb
@@ -59,6 +59,7 @@ Patch dialog sequence:
       <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="EnableLongPathName" Order="999">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1</Publish>
 
      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg" Order="1"><![CDATA[NOT Installed]]></Publish>
      <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="1"><![CDATA[Installed AND PATCH]]></Publish>
@@ -93,6 +94,7 @@ Patch dialog sequence:
       <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+      <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="EnableLongPathName" Order="999">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1</Publish>
 
       <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg" Order="1"><![CDATA[NOT VersionNT64 AND NOT Installed]]></Publish>
       <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="1"><![CDATA[NOT VersionNT64 AND Installed AND PATCH]]></Publish>


### PR DESCRIPTION
Add `Enable Long Path Names` checkbox at the ExitDialog window, which adds the LongPathsEnabled registry key, and sets its value to 1

Picture of the new option:
<img width="527" alt="Screenshot 2021-07-30 at 14 18 33" src="https://user-images.githubusercontent.com/58110929/127645580-94acc074-05b4-4cbf-92d2-594b0d97172b.png">

Also added command line option to enable long path names (`ENABLE_LONG_PATHS`), and updated the powershell logic to check if the registry was already set correctly.