### PR TITLE
(PA-3700) Add `facter_interactive.bat` and `run_facter_interactive.bat` in Puppet Agent 7

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -10,8 +10,13 @@ component "facter" do |pkg, settings, platform|
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
   if platform.is_windows?
-    pkg.add_source("file://resources/files/windows/facter.bat", sum: "1521ec859c1ec981a088de5ebe2b270c")
+    pkg.add_source("file://resources/files/windows/facter.bat", sum: "eabed128c7160289790a2b59a84a9a13")
+    pkg.add_source("file://resources/files/windows/facter_interactive.bat", sum: "20a1c0bc5368ffb24980f42432f1b372")
+    pkg.add_source("file://resources/files/windows/run_facter_interactive.bat", sum: "c5e0c0a80e5c400a680a06a4bac8abd4")
+
     pkg.install_file "../facter.bat", "#{settings[:link_bindir]}/facter.bat"
+    pkg.install_file "../facter_interactive.bat", "#{settings[:link_bindir]}/facter_interactive.bat"
+    pkg.install_file "../run_facter_interactive.bat", "#{settings[:link_bindir]}/run_facter_interactive.bat"
   end
 
   pkg.install do


### PR DESCRIPTION
This commit aligns Puppet Agent 7 with Puppet Agent 6 and packages `facter_interactive.bat` and `run_facter_interactive.bat`. The files already existed on the repository before this commit but they were not packaged.

----
Manually tested these changes using:
1. Checking existence of files (cmd):
```cmd
➜ cd "C:\Program Files\Puppet Labs"

➜ dir *facter_interactive* /s /p
 Volume in drive C is Windows
 Volume Serial Number is 60DE-2A91

 Directory of C:\Program Files\Puppet Labs\Puppet\bin

09/14/2021  07:52 AM                87 facter_interactive.bat
09/14/2021  07:52 AM               136 run_facter_interactive.bat
               2 File(s)            223 bytes

     Total Files Listed:
               2 File(s)            223 bytes
               0 Dir(s)  49,301,872,640 bytes free

➜ puppet --version
7.11.0
```
2. Trying `START ➜ Puppet ➜ Run Facter`.
![image](https://user-images.githubusercontent.com/39198766/133252267-9e3a0bc1-106b-4618-840d-15b539434393.png)

Before fix, below window appeared instead of Facter output in cmd window:
![image](https://user-images.githubusercontent.com/39198766/133252047-2f5c89b5-0606-4133-8ad4-c5dc522e7850.png)


----

Build with these changes for further testing: `9cec19a4e1e5c9b7cc00b15b9e5adafeef0bf182`