### PR TITLE
(maint) Pgdg repo location + certificate fix

### DIFF
--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -164,7 +164,8 @@ function install_puppetdb_from_package() {
   local yum_cmd="yum --releasever=7"
 
   echo "STEP: Set-up postgresql 9.6 to use with PuppetDB"
-  on_master ${master_vm} "rpm --query --quiet pgdg-redhat96-9.6-3.noarch || ${yum_cmd} install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-42.0-18.noarch.rpm"
+  on_master ${master_vm} "yum install -y ca-certificates"
+  on_master ${master_vm} "rpm --query --quiet pgdg-redhat96-9.6-3.noarch || ${yum_cmd} install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-42.0-20.noarch.rpm"
   on_master ${master_vm} "rpm --query --quiet postgresql96-server || ${yum_cmd} install -y postgresql96-server"
   on_master ${master_vm} "rpm --query --quiet postgresql96-contrib || ${yum_cmd} install -y postgresql96-contrib"
   on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=stopped"
@@ -172,7 +173,7 @@ function install_puppetdb_from_package() {
   on_master ${master_vm} "puppet resource service postgresql-9.6 ensure=running enable=true"
 
   #After postgress has been installed we need to remove the postgress repo or else other yum install commands will fail.
-  on_master ${master_vm} "${yum_cmd} remove -y pgdg-redhat-repo-42.0-18.noarch"
+  on_master ${master_vm} "${yum_cmd} remove -y pgdg-redhat-repo-42.0-20.noarch"
 
   # Enters 'puppet' as the password.
   on_master ${master_vm} "runuser -l postgres -c '(echo puppet && echo puppet) | createuser -DRSP puppetdb'"


### PR DESCRIPTION
The previous URL for the pgdg repo returns 404 Not Found.
Updated with a newer version and updated certificates
with `yum install -y ca-certificates` as it could not
verify download.postgresql.org's certificate