### PR TITLE
(maint) Enable new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Include:
     - 'bin/**/*.rb'
     - 'configs/**/*.rb'

--- a/configs/components/facter-precompiled-gem.rb
+++ b/configs/components/facter-precompiled-gem.rb
@@ -6,7 +6,7 @@ component "facter-precompiled-gem" do |pkg, settings, platform|
 
   if platform.is_osx?
     pkg.build_requires "cmake"
-  elsif platform.is_windows?
+  elsif platform.is_windows? #rubocop:disable Lint/DuplicateBranch
     pkg.build_requires "cmake"
   elsif platform.name =~ /sles-15/
     # These platforms use their default OS toolchain and have package

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -120,7 +120,7 @@ component "leatherman" do |pkg, settings, platform|
   # Make test will explode horribly in a cross-compile situation
   # Tests will be skipped on AIX until they are expected to pass
   if !platform.is_cross_compiled? && !platform.is_aix?
-    if platform.is_solaris? && platform.architecture != 'sparc' || platform.name =~ /debian-10/
+    if (platform.is_solaris? && platform.architecture != 'sparc') || platform.name =~ /debian-10/
       test_locale = "LANG=C LC_ALL=C"
     end
 


### PR DESCRIPTION
* Opt into new cops via `NewCops`
* Ignore the duplicate `platform.is_windows?` branch as all `build_requires` are
  defined first, followed by defining commands.
* Add parenthesis to fix Lint/AmbiguousOperatorPrecedence