### PR TITLE
(maint) Ignore duplicate branch

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -15,7 +15,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
   elsif platform.is_solaris?
     # do nothing
-  else
+  else #rubocop:disable Lint/DuplicateBranch
     pkg.build_requires "gettext"
   end
 


### PR DESCRIPTION
Commit f66fdcb95 enabled several rubocops, but the `puppet` component didn't
fail until the change was merged to `main`.