### PR TITLE
(maint) sim_link gcc for solaris

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -35,6 +35,7 @@ def setup_build_environment(agent)
     on(agent, "curl -O http://pl-build-tools.delivery.puppetlabs.net/solaris/11/sol-11-i386-compiler.tar.gz")
     on(agent, "gunzip -f sol-11-i386-compiler.tar.gz && tar -xf sol-11-i386-compiler.tar && rm -f sol-11-i386-compiler.tar")
     on(agent, "mv pl-build-tools/ /opt/")
+    on(agent, "ln -s i386/bin /opt/pl-build-tools/bin")
     gem_install_sqlite3 = "export PATH=\"/opt/pl-build-tools/i386/bin:/usr/sfw/bin:$PATH\" && #{gem_install_sqlite3}"
   when /solaris-11-sparc/
     install_package_on_agent.call("developer/gcc-48")


### PR DESCRIPTION
When building on solaris, gcc si set to /opt/pl-build-tools/bin/
https://github.com/puppetlabs/puppet-runtime/blob/2a73942cf6a65a2f201c292e3bd1014685a66cda/configs/components/_base-ruby.rb#L30
but when running tests it will need gcc provided by pl-build-tools installed in /opt/pl-build-tools/i386/bin/

Created a sim_link in case something else uses gcc from /opt/pl-build-tools/bin/