### PR TITLE
(FACT-3101) Build Facter for JRuby on debian 11

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -49,7 +49,7 @@ component "facter" do |pkg, settings, platform|
   when /(debian-9|ubuntu-(15|16|18.04-amd64))/
     pkg.build_requires 'openjdk-8-jdk'
     java_home = "/usr/lib/jvm/java-8-openjdk-#{platform.architecture}"
-  when /debian-10|ubuntu-20/
+  when /debian-10|debian-11|ubuntu-20/
     pkg.build_requires 'openjdk-11-jdk'
     java_home = "/usr/lib/jvm/java-11-openjdk-#{platform.architecture}"
   when /sles-12/


### PR DESCRIPTION
See https://github.com/puppetlabs/puppet-agent/commit/a036837f89fa6e7477963aee6a5c8add968693f1 for an example of the last time this was needed.

I don't _think_ this is necessary in 7.x anymore, with the move to Facter 4. The config file looks totally different now.