### PR TITLE
(RE-14411) Add redhatfips-8 as an rpm target

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -95,7 +95,7 @@ platform_repos:
   - name: solaris-11-sparc
     repo_location: repos/solaris/11/**/*.sparc.p5p
 deb_targets: 'xenial-amd64 bionic-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"


### PR DESCRIPTION
redhatfips-8 as an rpm target is needed by puppet-enterprise-vanagon to build PE packages.