### PR TITLE
(maint) change components sources git:// to https://

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"4d4afa91b226dfa8d2f92c495b7070377134386f"}
+{"url":"https://github.com/puppetlabs/facter.git","ref":"4d4afa91b226dfa8d2f92c495b7070377134386f"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet.git","ref":"74406a14381f0bc3e2f355668d4098e44d0d6a1f"}
+{"url":"https://github.com/puppetlabs/puppet.git","ref":"74406a14381f0bc3e2f355668d4098e44d0d6a1f"}


### PR DESCRIPTION
This change had to be done again since the vanagon component
promotion script was not updated and it changed back sources
from https:// to git://

depends on https://github.com/puppetlabs/ci-job-configs/pull/8196