### PR TITLE
(maint) PA-4182 replace git:// with https://

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/facter.git","ref":"6ec89bfea5c1063a2f6de1fe19a126c7d4afe82c"}
+{"url":"https://github.com/puppetlabs/facter.git","ref":"6ec89bfea5c1063a2f6de1fe19a126c7d4afe82c"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/hiera.git","ref":"2c67b2947e399ecf72d741b8f03086638a98bfe4"}
+{"url":"https://github.com/puppetlabs/hiera.git","ref":"2c67b2947e399ecf72d741b8f03086638a98bfe4"}

--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.8.14"}
+{"url":"https://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/v1.8.14"}


### PR DESCRIPTION
Replacing Git protocol since it will no longer be supported.