### PR TITLE
Revert "(maint) Update facter to 80c9f0281e95123e357164867569e19460fc…

### DIFF
--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/facter.git","ref":"80c9f0281e95123e357164867569e19460fc9ba7"}
+{"url":"https://github.com/puppetlabs/facter.git","ref":"6ec89bfea5c1063a2f6de1fe19a126c7d4afe82c"}


### PR DESCRIPTION
…9ba7"

This reverts commit dfc64d904a8bc81f5402b1b5d73842367e923e0d.

This is done in order to ship the same facter version in both streams

Depends on https://github.com/puppetlabs/ci-job-configs/pull/8203