### PR TITLE
(maint) Fix fact collection script on Windows

### DIFF
--- a/acceptance/util/puppet_facts_output.rb
+++ b/acceptance/util/puppet_facts_output.rb
@@ -132,7 +132,7 @@ test_name "get facts, obfuscate, and save to a local file for uploading to facte
   end
 
   agents.each do |agent|
-    on agent, "facter --show-legacy -p -j", :acceptable_exit_codes => [0] do
+    on agent, facter('--show-legacy -p -j'), :acceptable_exit_codes => [0] do
       facts = JSON.parse(stdout)
       facter_major_version = facts['facterversion']
       primary_network = facts['networking']['primary']


### PR DESCRIPTION
Previously we were directly shelling out to cygwin on Windows boxes, causing the facter command to fail with:

    bash: facter: command not found

Fortunately, there's a helper `facter` method that properly namespaces the executable for the target platform:

    cmd.exe /c facter --show-legacy -p -j