### PR TITLE
(maint) In el-8-x86 platform switch centos-8 for redhat-8-x86_64

### DIFF
--- a/configs/platforms/el-8-x86_64.rb
+++ b/configs/platforms/el-8-x86_64.rb
@@ -6,5 +6,5 @@ platform "el-8-x86_64" do |plat|
   packages = ['make', 'rsync', 'rpm-build']
   plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
   plat.install_build_dependencies_with "dnf install -y --allowerasing "
-  plat.vmpooler_template "centos-8-x86_64"
+  plat.inherit_from_default
 end


### PR DESCRIPTION
With recent EOL of centos-8 builds have started to fail using centos-8.
This PR switches centos-8-x86_64 for redhat-8-x86_64.