### PR TITLE
(FACT-2477) Add dependency on lsb-release

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -26,6 +26,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
   pkg.replaces 'pe-rubygem-net-ssh'
 
   pkg.requires 'findutils' if platform.is_linux?
+  pkg.requires 'lsb-release' if platform.is_deb?
 
   pkg.install_only true
 


### PR DESCRIPTION
Puppet 6 bundles Facter 3 which needs lsb-release to gather some facts required by puppetlabs modules apt and postgresql.

When the package is not installed, these modules raise the most cryptic error for new users:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Operator '[]' is not applicable to an Undef Value. (file: /etc/puppetlabs/code/environments/production/modules/apt/manifests/source.pp, line: 102, column: 9) (file: /etc/puppetlabs/code/modules/syslog_ng/manifests/repo.pp, line: 22) on node ubuntu1804-64.example.com
```

This PR is intended to add an explicit dependency on lsb-release so that we do not have to care about this aspect when using Puppet 6 in CI.
