### PR TITLE
(PA-4317) Snyk monitor pushes to 6.x and main

### DIFF
--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -1,0 +1,33 @@
+---
+name: Snyk Monitor
+on:
+  push:
+    branches:
+      - main
+      - 6.x
+
+jobs:
+  snyk_monitor:
+    if: ${{ github.repository_owner == 'puppetlabs' }}
+    runs-on: ubuntu-latest
+    name: Snyk Monitor
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME})"
+        id: extract_branch
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/ruby@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_PE_TOKEN }}
+        with:
+          command: monitor
+          args: --org=puppet-enterprise --project-name=${{ github.repository }} --target-reference ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
Adds workflow for snyk monitoring pushes to 6.x or main. Note the workflow only needs to exist in the default branch (`main`) but it will be triggered on pushes to `6.x`.

Also use the newish `GITHUB_REF_NAME` environment variable to determine the current branch which we use as the `target-reference` in snyk, so dependencies are grouped by the branch.