### PR TITLE
(PA-4317) Add missing '='

### DIFF
--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -30,4 +30,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_PE_TOKEN }}
         with:
           command: monitor
-          args: --org=puppet-enterprise --project-name=${{ github.repository }} --target-reference ${{ steps.extract_branch.outputs.branch }}
+          args: --org=puppet-enterprise --project-name=${{ github.repository }} --target-reference=${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
Update travis rake commits task to exclude commits in the base branch that are not in the PR branch, see https://github.com/puppetlabs/puppet-agent/pull/2213/commits/f693074fdc3060f9ed6d663aeef1901cc35ff634 for details.

Add missing '=' after `--target-reference`