### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"https://builds.delivery.puppetlabs.net/puppet-runtime/202203150/artifacts/","version":"202203150"}
+{"location":"https://builds.delivery.puppetlabs.net/puppet-runtime/202203160/artifacts/","version":"202203160"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/202203151/artifacts/","version":"202203151"}
+{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/202203160/artifacts/","version":"202203160"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/202203150/artifacts/","version":"202203150"}
+{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/202203151/artifacts/","version":"202203151"}


### PR DESCRIPTION
* upstream/6.x:
  (maint) Update puppet to 8f5e224a37373cd94a188619c7167735c89a01b9
  (PA-4224) Update build_defaults.yaml to include macOS 12 Monterey
  (PA-4223) Add macOS 12 Monterey
  (maint) Update puppet-runtime to 202203150

Conflicts:
	ext/build_defaults.yaml

Deleted SLES11 and Solaris 10 since those are supported in 6.x but not main
Added macOS 12 to main