### PR TITLE
(maint) Removes macOS 12 support

### DIFF
--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -1,4 +1,0 @@
-platform 'osx-12-x86_64' do |plat|
-  plat.inherit_from_default
-  plat.output_dir File.join('apple', '12', 'puppet6', 'x86_64')
-end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -19,7 +19,6 @@ foss_platforms:
   - fedora-34-x86_64
   - osx-10.15-x86_64
   - osx-11-x86_64
-  - osx-12-x86_64
   - sles-11-i386
   - sles-11-x86_64
   - sles-12-x86_64
@@ -114,8 +113,6 @@ platform_repos:
     repo_location: repos/apple/10.15/**/x86_64/*.dmg
   - name: osx-11
     repo_location: repos/apple/11/**/x86_64/*.dmg
-  - name: osx-12
-    repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: solaris-10-i386
     repo_location: repos/solaris/10/**/*.i386.pkg.gz
   - name: solaris-10-sparc


### PR DESCRIPTION
We are encountering some issues with our build tools on macOS 12
and are temporarily removing support on just the 6.x branch
until we can resolve them.