### PR TITLE
(PA-4337) Update libwhereami special_flags for MacOS

### DIFF
--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -11,7 +11,7 @@ component "libwhereami" do |pkg, settings, platform|
   if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
-    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
+    special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -1,0 +1,4 @@
+platform 'osx-12-x86_64' do |plat|
+  plat.inherit_from_default
+  plat.output_dir File.join('apple', '12', 'puppet6', 'x86_64')
+end


### PR DESCRIPTION
MacOS 12 fails to build libwhereami due to a flag not being added in that
component. We've added the flag to other components so this looks like an oversight.

Also adds back the platform definition for osx-12-x86_64.