### PR TITLE
(maint) Fix the output_dir for the osx-12 agent

### DIFF
--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -1,4 +1,4 @@
 platform 'osx-12-x86_64' do |plat|
   plat.inherit_from_default
-  plat.output_dir File.join('apple', '12', 'puppet6', 'x86_64')
+  plat.output_dir File.join('apple', '12', 'puppet7', 'x86_64')
 end


### PR DESCRIPTION
Previously we were putting the puppet7's agent in a file path that had puppet6. This PR fixes that.