### PR TITLE
(maint) Updates git URL to HTTPS in release rake

### DIFF
--- a/ext/release-lead.rake
+++ b/ext/release-lead.rake
@@ -31,7 +31,7 @@ namespace :release_lead do
     json = JSON.parse(File.read(json_file))
     version = json['version']
 
-    url = "git://github.com/puppetlabs/#{component_name}.git"
+    url = "https://github.com/puppetlabs/#{component_name}.git"
 
     Dir.chdir(where_to_clone) do
       puts "Cloning #{component_name}..."


### PR DESCRIPTION
GitHub deprecated git URLs in March 2022. This updates a git
URL in the release-lead rake task to HTTPS

This is not present in `6.x`, so this PR targets `main`