### PR TITLE
(PA-4240) Add Ubuntu 22.04

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -34,6 +34,8 @@ foss_platforms:
   - ubuntu-18.04-aarch64
   - ubuntu-20.04-amd64
   - ubuntu-20.04-aarch64
+  - ubuntu-22.04-amd64
+  - ubuntu-22.04-aarch64
   - windows-2012-x86
   - windows-2012-x64
 pe_platforms:
@@ -110,6 +112,10 @@ platform_repos:
     repo_location: repos/apt/focal
   - name: ubuntu-20.04-aarch64
     repo_location: repos/apt/focal
+  - name: ubuntu-22.04-amd64
+    repo_location: repos/apt/jammy
+  - name: ubuntu-22.04-aarch64
+    repo_location: repos/apt/jammy
   - name: osx-10.15
     repo_location: repos/apple/10.15/**/x86_64/*.dmg
   - name: osx-11


### PR DESCRIPTION
Does `deb_targets` also need to be changed? I see it was done as separate commits for 20.04, but I don't see a ticket mentioning it in Jira.