### PR TITLE
(PA-4463) Add macOS 12 Monterey ARM64 (M1) support

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -6,14 +6,17 @@ component "cpp-hocon" do |pkg, settings, platform|
   make = platform[:make]
   boost_static_flag = ""
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
+  # cmake on macOS is provided by brew
+  # a toolchain is not currently required for macOS since we're building with clang.
   if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -29,7 +29,10 @@ component "cpp-pcp-client" do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     toolchain = ""
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -114,15 +114,18 @@ component "facter" do |pkg, settings, platform|
   boost_static_flag = ""
   yamlcpp_static_flag = ""
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
+  # cmake on macOS is provided by brew
+  # a toolchain is not currently required for macOS since we're building with clang.
   if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     yamlcpp_static_flag = "-DYAMLCPP_STATIC=OFF"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -32,14 +32,17 @@ component "leatherman" do |pkg, settings, platform|
   special_flags = ""
   boost_static_flag = ""
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
+  # cmake on macOS is provided by brew
+  # a toolchain is not currently required for macOS since we're building with clang.
   if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     boost_static_flag = "-DBOOST_STATIC=OFF"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -6,14 +6,17 @@ component "libwhereami" do |pkg, settings, platform|
   make = platform[:make]
   boost_static_flag = ""
 
-  # cmake on OSX is provided by brew
-  # a toolchain is not currently required for OSX since we're building with clang.
+  # cmake on macOS is provided by brew
+  # a toolchain is not currently required for macOS since we're building with clang.
   if platform.is_macos?
     toolchain = ""
     cmake = "/usr/local/bin/cmake"
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -33,7 +33,10 @@ component "pxp-agent" do |pkg, settings, platform|
     toolchain = ""
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = "-DBOOST_STATIC=OFF"
-    pkg.environment "CXX", "clang++ -target arm64-apple-macos11" if platform.is_cross_compiled?
+    if platform.is_cross_compiled?
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
+      pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
+    end
   elsif platform.is_cross_compiled_linux?
     cmake = "/opt/pl-build-tools/bin/cmake"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,0 +1,29 @@
+platform 'osx-12-arm64' do |plat|
+    plat.servicetype 'launchd'
+    plat.servicedir '/Library/LaunchDaemons'
+    plat.codename 'monterey'
+
+    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
+    plat.provision_with 'export HOMEBREW_VERBOSE=true'
+
+    plat.provision_with 'sudo dscl . -create /Users/test'
+    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
+    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
+    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
+    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
+    plat.provision_with 'sudo dscl . -passwd /Users/test password'
+    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
+    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
+    plat.provision_with 'mkdir -p /etc/homebrew'
+    plat.provision_with 'cd /etc/homebrew'
+    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
+    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
+
+    packages = %w[cmake pkg-config yaml-cpp]
+
+    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+
+    plat.vmpooler_template 'macos-12-x86_64'
+    plat.cross_compiled true
+    plat.output_dir File.join('apple', '12', 'PC1', 'arm64')
+  end


### PR DESCRIPTION
Add support for building the puppet-agent project for macOS 12
Monterey ARM64 (M1) via cross-compilation from an x86-64 host.

Blocked on https://github.com/puppetlabs/pxp-agent-vanagon/pull/49, adding the "don't merge" label til that PR is merged and I can rebase with the updated pxp-agent-vanagon component (for main) and test