### PR TITLE
(maint) Updates Rubocop version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,6 @@ gem 'artifactory'
 gem 'rake'
 gem 'json'
 gem 'octokit'
-gem 'rubocop', "~> 1.22"
+gem 'rubocop', "< 1.29"
 
 eval_gemfile("#{__FILE__}.local") if File.exist?("#{__FILE__}.local")


### PR DESCRIPTION
Rubocop 1.29 drops support for Ruby 2.5. The 6.x branch of puppet-
agent use Ruby 2.5.9, so we'll set Rubocop in the Gemfile to
"< 1.29".