### PR TITLE
(maint) Change ubuntu-22.04 to inherit from defaults

### DIFF
--- a/configs/platforms/ubuntu-22.04-aarch64.rb
+++ b/configs/platforms/ubuntu-22.04-aarch64.rb
@@ -1,10 +1,3 @@
 platform "ubuntu-22.04-aarch64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "jammy"
-
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "ubuntu-2204-arm64"
+  plat.inherit_from_default
 end

--- a/configs/platforms/ubuntu-22.04-amd64.rb
+++ b/configs/platforms/ubuntu-22.04-amd64.rb
@@ -1,11 +1,3 @@
 platform "ubuntu-22.04-amd64" do |plat|
-  plat.servicedir "/lib/systemd/system"
-  plat.defaultdir "/etc/default"
-  plat.servicetype "systemd"
-  plat.codename "jammy"
-
-  packages = ['build-essential', 'devscripts', 'rsync', 'fakeroot', 'debhelper']
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
-  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
-  plat.vmpooler_template "ubuntu-2204-x86_64"
+  plat.inherit_from_default
 end


### PR DESCRIPTION
The default settings (as set in vanagon) for ubuntu-22.04 include 'make'. That
is a hard requirement that we need to make sure is installed. We didn't include that
in our platform definition here, but we do in the defaults. So lets just inherit those.