### PR TITLE
(maint) Change back the osx-12 x86_64 naming convention

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -121,7 +121,7 @@ platform_repos:
     repo_location: repos/apple/10.15/**/x86_64/*.dmg
   - name: osx-11
     repo_location: repos/apple/11/**/x86_64/*.dmg
-  - name: osx-12-x86_64
+  - name: osx-12
     repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: osx-12-arm64
     repo_location: repos/apple/12/**/arm64/*.dmg


### PR DESCRIPTION
PE is built to assume the osx intel 64 bit tarball is named without the x86_64
in the file name. Changing this breaks things in PE.