### PR TITLE
(PA-3918) Adds architecture to macOS ship paths

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -118,9 +118,13 @@ platform_repos:
     repo_location: repos/apt/jammy
   - name: osx-10.15
     repo_location: repos/apple/10.15/**/x86_64/*.dmg
-  - name: osx-11
+  - name: osx-11-arm64
+    repo_location: repos/apple/11/**/arm64/*.dmg
+  - name: osx-11-x86_64
     repo_location: repos/apple/11/**/x86_64/*.dmg
-  - name: osx-12
+  - name: osx-12-arm64
+    repo_location: repos/apple/12/**/arm64/*.dmg
+  - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: solaris-10-i386
     repo_location: repos/solaris/10/**/*.i386.pkg.gz


### PR DESCRIPTION
We have recently added a new CPU architecture (M1/ARM64) to macOS
builds, which have historically only used one architecture
(x86-64). This commit adds additional directory structure to
separate builds into their respective CPU architectures.