### PR TITLE
(maint) Update test to work with new puppet facts show behavior

### DIFF
--- a/acceptance/tests/env_windows_installdir_fact.rb
+++ b/acceptance/tests/env_windows_installdir_fact.rb
@@ -3,8 +3,7 @@
 # present and accurate.
 test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
 
-  tag 'audit:low',       # important runtime environment/packaging integration, rarely changed?
-      'audit:delete',    # Move to puppet-agent suite
+  tag 'audit:high', # PE and modules rely on this fact in order to execute ruby, curl, etc
       'audit:acceptance'
 
   confine :to, :platform => 'windows'
@@ -22,7 +21,7 @@ test_name 'PA-466: Ensure env_windows_installdir fact is present and correct' do
 
       on agent, puppet('facts', '--render-as json') do |result|
         facts = JSON.parse(result.stdout)
-        actual_value = facts["values"]["env_windows_installdir"]
+        actual_value = facts["env_windows_installdir"]
         assert_equal(install_dir, actual_value, "env_windows_installdir fact did not match expected output")
       end
     end


### PR DESCRIPTION
The `puppet facts` command used to default to the `find` action which returned a
Puppet::Node::Facts object, so the test had to dig into its 'values'. In Puppet
7, the default action was changed to `show` which returns just the fact values[1].

Also increase the risk level due to Windows 11

[1] https://github.com/puppetlabs/puppet/commit/cac467756b3eb70fe0c2b0a07ed108714b383ff1