### PR TITLE
(PA-3918) Adds macOS M1 builds to foss_platforms

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,7 +17,9 @@ foss_platforms:
   - el-9-x86_64
   - fedora-34-x86_64
   - osx-10.15-x86_64
+  - osx-11-arm64
   - osx-11-x86_64
+  - osx-12-arm64
   - osx-12-x86_64
   - sles-11-i386
   - sles-11-x86_64


### PR DESCRIPTION
This was an oversight and should have been added in https://github.com/puppetlabs/puppet-agent/pull/2258