### PR TITLE
(maint) Ignore os.release.major related fact diffs on Window 11

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -6,16 +6,16 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
   exclude_list = %w{mountpoints\..*
     partitions\..*\.filesystem
     partitions\..*\.size_bytes
-    partitions\..*\.mount        	
+    partitions\..*\.mount
     partitions\..*\.uuid
-    ldom_.*                   	
-    boardassettag 	
-    dmi\.board\.asset_tag 	
-    is_virtual 	
-    kernelmajversion 	
-    lsbmajdistrelease 	
-    zones 	
-    virtual                   	
+    ldom_.*
+    boardassettag
+    dmi\.board\.asset_tag
+    is_virtual
+    kernelmajversion
+    lsbmajdistrelease
+    zones
+    virtual
     blockdevice_.*_vendor blockdevice_.*_size
     hypervisors.vmware.version
     os\.distro\.description  }
@@ -26,16 +26,15 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
     step 'run puppet facts diff ' do
       on agent, puppet('facts diff') do
         @diff = stdout
-        
       end
     end
 
     step 'compare Facter 3 to Facter 4 outputs' do
-      join_str = agent.platform =~ /windows/ ? '^^^|' : '|' 
+      join_str = agent.platform =~ /windows/ ? '^^^|' : '|'
       ignored_facts = exclude_list.join(join_str)
       on(agent, puppet("facts diff --exclude '#{ignored_facts}'")) do
         diff = JSON.parse(stdout)
-        
+
         rep_diff = diff.delete_if {|key, value| value['old_value'] == nil}
         fail_test("Facter 3 and Facter 4 outputs have the following differences:  #{diff}") if rep_diff.keys.size.positive?
       end

--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -22,6 +22,13 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
 
   agents.each do |agent|
     exclude_list += ['macosx_productversion.*', 'os.macosx.version'] if agent.platform =~ /^osx-1[1-9]/
+    # FACT-3039 was only fixed in facter 4
+    exclude_list += %w[
+      operatingsystemrelease
+      operatingsystemmajrelease
+      os.release.full
+      os.release.major
+    ] if agent.platform =~ /windows-11/
 
     step 'run puppet facts diff ' do
       on agent, puppet('facts diff') do


### PR DESCRIPTION
https://github.com/voxpupuli/beaker/pull/1744, https://github.com/voxpupuli/beaker/pull/1745 must be merged first in order to test Windows 11.

Ignore the fact diff between facter 3 and 4 for os.release.full and related facts