### PR TITLE
(FACT-3136) Add exclude to facter 3 and 4 output test

### DIFF
--- a/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
+++ b/acceptance/tests/ensure_facter_3_and_facter_4_output_matches.rb
@@ -18,6 +18,7 @@ test_name 'Ensure Facter 3 and Facter 4 outputs match' do
     virtual
     blockdevice_.*_vendor blockdevice_.*_size
     hypervisors.vmware.version
+    gce\.project\.attributes\.sshKeys # until we can fix FACT-3136
     os\.distro\.description  }
 
   agents.each do |agent|


### PR DESCRIPTION
gce.project.attributes.sshKeys fact in facter 4 is not the same as it is in facter 3.
This PR adds that to the exclusion list and once we fix that we can then remove that
fact from the exclusion list in the test.