### PR TITLE
(PA-4787) Warnings when running embedded ruby

### DIFF
--- a/resources/files/sysv-wrapper.sh
+++ b/resources/files/sysv-wrapper.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+unset GEM_HOME
+unset GEM_PATH
+unset DLN_LIBRARY_PATH
+unset RUBYLIB
+unset RUBYLIB_PREFIX
+unset RUBYOPT
+unset RUBYPATH
+unset RUBYSHELL
+
 # We keep around any paths in LD_LIBRARY_PATH that start with /opt/rh/. Those paths are
 # from redhat software collections packages and are required for things like SCL python
 # to work. See PUP-8351.
@@ -10,14 +19,6 @@ end"
 LD_LIBRARY_PATH=`/opt/puppetlabs/puppet/bin/ruby -e "$STRIP_LDLYP_COMMAND"`
 export LD_LIBRARY_PATH
 unset LD_PRELOAD
-unset GEM_HOME
-unset GEM_PATH
-unset DLN_LIBRARY_PATH
-unset RUBYLIB
-unset RUBYLIB_PREFIX
-unset RUBYOPT
-unset RUBYPATH
-unset RUBYSHELL
 
 # If $PATH does not match a regex for /opt/puppetlabs/bin
 if [ `expr "${PATH}" : '.*/opt/puppetlabs/bin'` -eq 0 ]; then


### PR DESCRIPTION
Getting warnings when running the wrapped binaries when bundler has
exported some environment variables. The fix is to clean out the
environment before running the ruby process which strips the
`LD_LIBRARY_PATH`.
