### PR TITLE
(PA-4620) Use our homebrew tap for ruby@2.5

### DIFF
--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -14,7 +14,12 @@ component "hiera" do |pkg, settings, platform|
 
   if platform.is_cross_compiled? && platform.is_macos?
     ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-    pkg.build_requires "ruby@#{ruby_version_y}"
+    # Pin to an older version of ruby@2.5. This can be removed once we're no longer cross-compiling
+    if ruby_version_y == "2.5"
+      pkg.build_requires "puppetlabs/puppet/ruby@2.5"
+    else
+      pkg.build_requires "ruby@#{ruby_version_y}"
+    end
   end
 
   if platform.is_windows?


### PR DESCRIPTION
Hiera, facter and puppet rely on `ruby install.rb` to install their respective
files into the already built ruby from puppet-runtime. Normally we can just use
that ruby, but when cross-compiling we can't. When using ruby@2.5, brew install
from our homebrew tap instead of upstream, because it's been disabled upstream.

I think `build_requires` is specified in the hiera component, because it's
installed before puppet. Once we're no longer cross compiling on macOS we can
drop that requirement.