### PR TITLE
(maint) Add ruby gem update before sqlite3 install

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -24,6 +24,7 @@ def setup_build_environment(agent)
   # this path when listing / loading gems in the test below.
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3"
   install_package_on_agent = package_installer(agent)
+  on(agent, "#{gem_command(agent)} update --system")
 
   case agent['platform']
   when /aix/


### PR DESCRIPTION
After executing the sqlite3 install command, an error where the requested platform is "x64-unknown" in https://api.rubygems.org/quick/Marshal.4.8/sqlite3-1.5.0-x64-unknown.gemspec.rz. Updating ruby gems before installing sqlite3 resolves this error.

Since this error only occurs in the puppet-agent#6.x suite pipeline, this change will only be going into 6.x and **SHOULD NOT** be merged up to main.