### PR TITLE
(maint) Updates sqlite3 install command

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -22,7 +22,10 @@ def setup_build_environment(agent)
   # We set the gem path for install here to our internal shared vendor
   # path. This allows us to verify that our Ruby is able to read from
   # this path when listing / loading gems in the test below.
-  gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3"
+
+  # The sqlite3 gem >= 1.5.0 bundles libsqlite3, which breaks some tests
+  # We add `--enable-system-libraries` to use system libsqlite3
+  gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
   on(agent, "#{gem_command(agent)} update --system")
 


### PR DESCRIPTION
Starting with version 1.5.0 of the sqlite3 gem, it bundles in libsqlite3, which breaks our tests. This commit adds a flag (`--enable-system-libraries`) to continue to use system libsqlite3. 

Originally, this commit was only merged into main since we didn't see any issues in 6.x. However, now 6.x is starting to have the same issues main.