### PR TITLE
(PA-4686) Add acceptance test to validate Augeas package and resource type

### DIFF
--- a/acceptance/tests/augeas_validation.rb
+++ b/acceptance/tests/augeas_validation.rb
@@ -1,0 +1,38 @@
+skip_test 'non-windows only test' if hosts.any? { |host| host.platform =~ /windows/ }
+tag 'audit:high'
+test_name 'Augeas Validation' do
+  teardown do
+    hosts.each do |agent|
+      file = <<-EOF
+augeas { 'test_ssh':
+  lens    => 'Ssh.lns',
+  incl    => '/etc/ssh/ssh_config',
+  context => '/files/etc/ssh/ssh_config',
+  changes => [
+    'remove Host testing.testville.nil'
+  ]
+}
+EOF
+      on(agent, "puppet apply -e \"#{file}\"")
+    end
+  end
+
+  hosts.each do |agent|
+    step 'validate Augeas binary' do
+      on(agent, '/opt/puppetlabs/puppet/bin/augtool --version')
+    end
+    step 'validate we can apply a resource type augeas' do
+      file = <<-EOF
+augeas { 'test_ssh':
+  lens    => 'Ssh.lns',
+  incl    => '/etc/ssh/ssh_config',
+  context => '/files/etc/ssh/ssh_config',
+  changes => [
+    'set Host testing.testville.nil'
+  ]
+}
+EOF
+      assert_equal(on(agent, "puppet apply -e \"#{file}\"").exit_code, 0, 'Puppet apply of the augeas resource returned a non-zero exit code')
+    end
+  end
+end


### PR DESCRIPTION
We had an escaped bug that broke Augeas for a certian OS type. This test will catch that in the future.