### PR TITLE
(PA-4576) Removes Debian 9 from Vanagon config

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -33,7 +33,7 @@ component "cpp-hocon" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
         platform.is_aix?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -45,7 +45,7 @@ component "cpp-pcp-client" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -20,7 +20,7 @@ component "facter" do |pkg, settings, platform|
 
   pkg.build_requires 'puppet-runtime' # Provides augeas, boost, curl, openssl, ruby, yaml-cpp
   pkg.build_requires 'leatherman'
-  pkg.build_requires 'runtime' if platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  pkg.build_requires 'runtime' if platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
                                   !platform.is_linux?
   pkg.build_requires 'cpp-hocon'
   pkg.build_requires 'libwhereami'
@@ -46,7 +46,7 @@ component "facter" do |pkg, settings, platform|
   when /ubuntu-14/
     pkg.build_requires 'openjdk-7-jdk'
     java_home = "/usr/lib/jvm/java-7-openjdk-#{platform.architecture}"
-  when /(debian-9|ubuntu-(15|16|18.04-amd64))/
+  when /(ubuntu-(15|16|18.04-amd64))/
     pkg.build_requires 'openjdk-8-jdk'
     java_home = "/usr/lib/jvm/java-8-openjdk-#{platform.architecture}"
   when /debian-10|debian-11|ubuntu-20/
@@ -149,7 +149,7 @@ component "facter" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags += ' -DDYNAMICBASE=OFF' if platform.name =~ /windowsfips-2012r2/
 
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
         platform.is_aix?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"
@@ -237,7 +237,7 @@ component "facter" do |pkg, settings, platform|
   end
 
   # Disable tests for platforms that use the default OS toolchain
-  if platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ || !platform.is_linux?
+  if platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ || !platform.is_linux?
     pkg.check do
       tests
     end

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -17,13 +17,13 @@ component "leatherman" do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires "cmake"
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
     pkg.build_requires "pl-cmake"
     pkg.build_requires "pl-gettext"
   end
 
   pkg.build_requires "puppet-runtime" # Provides curl and ruby
-  pkg.build_requires "runtime" if platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  pkg.build_requires "runtime" if platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
                                   !platform.is_linux?
 
   ruby = "#{settings[:host_ruby]} -rrbconfig"
@@ -70,7 +70,7 @@ component "leatherman" do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
         platform.is_aix?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/libwhereami.rb
+++ b/configs/components/libwhereami.rb
@@ -33,7 +33,7 @@ component "libwhereami" do |pkg, settings, platform|
 
     cmake = "C:/ProgramData/chocolatey/bin/cmake.exe -G \"MinGW Makefiles\""
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
         platform.is_aix?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake"
     cmake = "/opt/pl-build-tools/bin/cmake"

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -12,7 +12,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "pl-gettext-#{platform.architecture}"
   elsif platform.is_aix?
     pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
     pkg.build_requires "pl-gettext"
   end
 
@@ -109,7 +109,7 @@ component "puppet" do |pkg, settings, platform|
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
-    elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+    elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
           platform.is_aix?
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"
     else

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -58,7 +58,7 @@ component "pxp-agent" do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags += ' -DDYNAMICBASE=OFF' if platform.name =~ /windowsfips-2012r2/
 
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -24,7 +24,7 @@ component "runtime" do |pkg, settings, platform|
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
     # We only need zlib because curl is dynamically linking against zlib
     pkg.build_requires "pl-zlib-#{platform.architecture}"
-  elsif platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
+  elsif platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/
     pkg.build_requires "pl-gcc"
   end
 

--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,4 +1,0 @@
-platform "debian-9-amd64" do |plat|
-  plat.inherit_from_default
-  plat.servicetype "sysv", servicedir: "/etc/init.d"
-end

--- a/configs/platforms/debian-9-i386.rb
+++ b/configs/platforms/debian-9-i386.rb
@@ -1,4 +1,0 @@
-platform "debian-9-i386" do |plat|
-  plat.inherit_from_default
-  plat.servicetype "sysv", servicedir: "/etc/init.d"
-end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -123,7 +123,7 @@ project "puppet-agent" do |proj|
     proj.component "shellpath"
   end
 
-  proj.component "runtime" if platform.name =~ /debian-9|el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
+  proj.component "runtime" if platform.name =~ /el-[567]|redhatfips-7|sles-(:?11|12)|ubuntu-(:?14.04|18.04-amd64)/ ||
                               !platform.is_linux?
 
   # Windows doesn't need these wrappers, only unix platforms


### PR DESCRIPTION
Debian 9 ("stretch") hit end the end of its LTS support in June
2022. This commit removes Debian 9 from all Vanagon platforms, components, and projects.