### PR TITLE
(maint) Use ssh for manually promoted components

### DIFF
--- a/configs/components/module-puppetlabs-augeas_core.json
+++ b/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.1.2"}
+{"url":"git@github.com:puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.1.2"}

--- a/configs/components/module-puppetlabs-cron_core.json
+++ b/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.5"}
+{"url":"git@github.com:puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.5"}

--- a/configs/components/module-puppetlabs-host_core.json
+++ b/configs/components/module-puppetlabs-host_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.3"}
+{"url":"git@github.com:puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.3"}

--- a/configs/components/module-puppetlabs-mount_core.json
+++ b/configs/components/module-puppetlabs-mount_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.4"}
+{"url":"git@github.com:puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.4"}

--- a/configs/components/module-puppetlabs-scheduled_task.json
+++ b/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}

--- a/configs/components/module-puppetlabs-selinux_core.json
+++ b/configs/components/module-puppetlabs-selinux_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.1.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.1.0"}

--- a/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/2.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/2.2.0"}

--- a/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.7"}
+{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.7"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.2.0"}

--- a/configs/components/module-puppetlabs-zone_core.json
+++ b/configs/components/module-puppetlabs-zone_core.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/1.0.3"}
+{"url":"git@github.com:puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/1.0.3"}

--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.8.16"}
+{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.8.16"}


### PR DESCRIPTION
Conflicts were due to newer sshkeys_core and resource_api tags in main.

(cherry picked from commit bd688a3fc5d516943a7b5f357f32c015254f2e2c)