### PR TITLE
(PA-4736) Add Solaris 10 (x86_64) to build_defaults

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -35,10 +35,12 @@ project "puppet-agent" do |proj|
     proj.signing_command 'security -q unlock-keychain -p \$$OSX_SIGNING_KEYCHAIN_PW \$$OSX_SIGNING_KEYCHAIN; codesign --timestamp --keychain \$$OSX_SIGNING_KEYCHAIN -vfs \"\$$OSX_CODESIGNING_CERT\"'
   end
 
+  # rubocop:disable Style/RedundantStringEscape
   if platform.is_fedora?
     proj.package_override("# Disable check-rpaths since /opt/* is not a valid path\n%global __brp_check_rpaths \%{nil}")
     proj.package_override("# Disable the removal of la files, they are still required\n%global __brp_remove_la_files \%{nil}")
   end
+  # rubocop:enable Style/RedundantStringEscape
 
   # Project level settings our components will care about
   if platform.is_windows?

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -32,6 +32,7 @@ pe_platforms:
   - aix-7.1-power
   - redhatfips-7-x86_64
   - redhatfips-8-x86_64
+  - solaris-10-i386
   - solaris-11-i386
   - solaris-11-sparc
   - windowsfips-2012-x64
@@ -90,6 +91,8 @@ platform_repos:
     repo_location: repos/apple/12/**/arm64/*.dmg
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
+  - name: solaris-10-i386
+    repo_location: repos/solaris/10/**/*.i386.pkg.gz
   - name: solaris-11-i386
     repo_location: repos/solaris/11/**/*.i386.p5p
   - name: solaris-11-sparc


### PR DESCRIPTION
This PR adds Solaris 10 (x86_64) to build_defaults as a pe platform. Additionally, it disables the Style/RedundantStringEscape RuboCop in puppet-agent.rb that is causing the RuboCop PR checks to fail.