### PR TITLE
(maint) Use SSH protocol when cloning

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "https://github.com/puppetlabs/cpp-hocon.git", "ref": "f6ba8d4ae898ae8e0e9c2e3f96a27e5fd566752d"}
+{"url": "git@github.com:puppetlabs/cpp-hocon.git", "ref": "f6ba8d4ae898ae8e0e9c2e3f96a27e5fd566752d"}

--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/cpp-pcp-client.git","ref":"db234c7d2ec20eb2370bb5c00d249e10ddc12365"}
+{"url":"git@github.com:puppetlabs/cpp-pcp-client.git","ref":"db234c7d2ec20eb2370bb5c00d249e10ddc12365"}

--- a/configs/components/facter.json
+++ b/configs/components/facter.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/facter.git","ref":"6d7ffc6efdfbc3b1fc79311cdeb4581ac2098d9c"}
+{"url":"git@github.com:puppetlabs/facter.git","ref":"6d7ffc6efdfbc3b1fc79311cdeb4581ac2098d9c"}

--- a/configs/components/hiera.json
+++ b/configs/components/hiera.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/hiera.git","ref":"3e506fc4f4d660bb662f955359ef6c7a536a0670"}
+{"url":"git@github.com:puppetlabs/hiera.git","ref":"3e506fc4f4d660bb662f955359ef6c7a536a0670"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/leatherman.git","ref":"d9d2b1f579e0cdf286c0178c990a14f8c8cf7517"}
+{"url":"git@github.com:puppetlabs/leatherman.git","ref":"d9d2b1f579e0cdf286c0178c990a14f8c8cf7517"}

--- a/configs/components/libwhereami.json
+++ b/configs/components/libwhereami.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/libwhereami.git","ref":"ac1d995eaccb435082f31b33c655800e474f53fd"}
+{"url":"git@github.com:puppetlabs/libwhereami.git","ref":"ac1d995eaccb435082f31b33c655800e474f53fd"}

--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/nssm.git","ref":"refs/tags/2.25.0"}
+{"url":"git@github.com:puppetlabs/nssm.git","ref":"refs/tags/2.25.0"}

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/puppet.git","ref":"302f2f1baae62a0e0a612e9098a17794c77126b1"}
+{"url":"git@github.com:puppetlabs/puppet.git","ref":"302f2f1baae62a0e0a612e9098a17794c77126b1"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/puppetlabs/pxp-agent.git","ref":"c0e159ec8e850f01d2d3dd2b806de0fd4d02543b"}
+{"url":"git@github.com:puppetlabs/pxp-agent.git","ref":"c0e159ec8e850f01d2d3dd2b806de0fd4d02543b"}

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -11,7 +11,7 @@ platform "solaris-10-i386" do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don\'t want to prompt for are conflicting files.
+# The key thing we don't want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -25,7 +25,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn\'t enough
+# DO check for available free space and abort if there isn't enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -15,7 +15,7 @@ platform "solaris-10-sparc" do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don\'t want to prompt for are conflicting files.
+# The key thing we don't want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -29,7 +29,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn\'t enough
+# DO check for available free space and abort if there isn't enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -31,8 +31,8 @@ project "puppet-agent" do |proj|
   end
 
   if platform.is_fedora?
-    proj.package_override("# Disable check-rpaths since /opt/* is not a valid path\n%global __brp_check_rpaths \%{nil}")
-    proj.package_override("# Disable the removal of la files, they are still required\n%global __brp_remove_la_files \%{nil}")
+    proj.package_override("# Disable check-rpaths since /opt/* is not a valid path\n%global __brp_check_rpaths %{nil}")
+    proj.package_override("# Disable the removal of la files, they are still required\n%global __brp_remove_la_files %{nil}")
   end
 
   # Project level settings our components will care about


### PR DESCRIPTION
Cloning components via https in CI is not authenticated, so it's subject to github rate limiting. To avoid that, always use the SSH protocol.