### PR TITLE
(PA-4749) Add solaris-10-sparc

### DIFF
--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -26,21 +26,23 @@ component "pl-ruby-patch" do |pkg, settings, platform|
                 end
 
     # weird architecture naming conventions...
-    target_triple = if platform.architecture =~ /ppc64el|ppc64le/
-                      "powerpc64le-linux"
-                    elsif platform.name == 'solaris-11-sparc'
-                      "sparc-solaris-2.11"
-                    elsif platform.is_macos?
-                      "aarch64-darwin"
-                    else
-                      "#{platform.architecture}-linux"
-                    end
+    unless platform.name =~ /solaris-10/
+      target_triple = if platform.architecture =~ /ppc64el|ppc64le/
+                        "powerpc64le-linux"
+                      elsif platform.name == 'solaris-11-sparc'
+                        "sparc-solaris-2.11"
+                      elsif platform.is_macos?
+                        "aarch64-darwin"
+                      else
+                        "#{platform.architecture}-linux"
+                      end
 
-    pkg.build do
-      [
-        %(#{platform[:sed]} -i 's/Gem::Platform.local.to_s/"#{target_triple}"/' #{base_ruby}/rubygems/basic_specification.rb),
-        %(#{platform[:sed]} -i 's/Gem.extension_api_version/"#{ruby_api_version}"/' #{base_ruby}/rubygems/basic_specification.rb)
-      ]
+      pkg.build do
+        [
+          %(#{platform[:sed]} -i 's/Gem::Platform.local.to_s/"#{target_triple}"/' #{base_ruby}/rubygems/basic_specification.rb),
+          %(#{platform[:sed]} -i 's/Gem.extension_api_version/"#{ruby_api_version}"/' #{base_ruby}/rubygems/basic_specification.rb)
+        ]
+      end
     end
 
     # make rubygems use our target rbconfig when installing gems

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -1,8 +1,12 @@
-platform "solaris-10-i386" do |plat|
+platform "solaris-10-sparc" do |plat|
   plat.servicedir "/var/svc/manifest"
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
+  plat.cross_compiled true
   plat.vmpooler_template "solaris-10-x86_64"
+  plat.tar "/usr/sfw/bin/gtar"
+  plat.patch "/usr/bin/gpatch"
+  plat.num_cores "/usr/bin/kstat cpu_info | /opt/csw/bin/ggrep -E '[[:space:]]+core_id[[:space:]]' | wc -l"
 
   base_pkgs = ['arc', 'gnu-idn', 'gpch', 'gtar', 'hea', 'libm', 'wgetu', 'xcu4']
   base_url = 'http://pl-build-tools.delivery.puppetlabs.net/solaris/10/depends'
@@ -11,7 +15,7 @@ platform "solaris-10-i386" do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don't want to prompt for are conflicting files.
+# The key thing we don not want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -25,7 +29,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn't enough
+# DO check for available free space and abort if there is not enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck
@@ -36,13 +40,13 @@ action=nocheck
 # Install to the default base directory.
 basedir=default" > /var/tmp/vanagon-noask;
   echo "mirror=https://artifactory.delivery.puppetlabs.net/artifactory/generic__remote_opencsw_mirror/testing" > /var/tmp/vanagon-pkgutil.conf;
-  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep;
-  ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
+  /opt/csw/bin/pkgutil --config=/var/tmp/vanagon-pkgutil.conf -y -i rsync gmake pkgconfig ggrep ruby20;
   # RE-6121 openssl 1.0.2e requires functionality not in sytem grep
   ln -sf /opt/csw/bin/ggrep /usr/bin/grep;
+  ln -sf /opt/csw/bin/rsync /usr/bin/rsync;
   # RE-5250 - Solaris 10 templates are awful
   /opt/csw/bin/pkgutil -l gcc | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
-  /opt/csw/bin/pkgutil -l ruby | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
+  /opt/csw/bin/pkgutil -l ruby18 | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
   /opt/csw/bin/pkgutil -l readline | xargs -I{} pkgrm -n -a /var/tmp/vanagon-noask {};
 
   # Install base build dependencies


### PR DESCRIPTION
Also fix the solaris-10-x86_64 output dir, was pointing at puppet6. Added back in some logic to the pl-ruby-patch for the older version of ruby that is on solaris-10.