### PR TITLE
(PA-4700) Update github actions branch for 7.x branch

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,13 +2,9 @@ name: Checks
 
 on:
   push:
-    branches: 
-      - main
-      - 6.x
+    branches: [7.x]
   pull_request:
-    branches: 
-      - main
-      - 6.x
+    branches: [7.x]
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,7 @@ name: Docker test and publish
 
 on:
   push:
-    branches:
-      - main
+    branches: [7.x]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -2,9 +2,7 @@
 name: Snyk Monitor
 on:
   push:
-    branches:
-      - main
-      - 6.x
+    branches: [7.x]
 
 jobs:
   snyk_monitor:


### PR DESCRIPTION
Puppet 6.x will be end of life on February 28, 2023 and Puppet 7.x will become the long term support (LTS) branch. In preparation for this, a new Puppet-Agent 7.x branch will be created and Puppet-Agent's GitHub Actions & protection rules must be updated. This PR updates Puppet-Agent's GitHub Actions to account for 7.x being the new LTS branch.