### PR TITLE
(maint) Update github action branches for main

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,9 +2,9 @@ name: Checks
 
 on:
   push:
-    branches: [7.x]
+    branches: [main]
   pull_request:
-    branches: [7.x]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker test and publish
 
 on:
   push:
-    branches: [7.x]
+    branches: [main]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -2,7 +2,7 @@
 name: Snyk Monitor
 on:
   push:
-    branches: [7.x]
+    branches: [main]
 
 jobs:
   snyk_monitor:


### PR DESCRIPTION
The promotion from 7.x overwrote our changes. Revert back to main. This change will ensure the file conflicts in any future merge.