### PR TITLE
(maint) Update the puppet-agent project file to use the 7.x branch

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -6,7 +6,7 @@ project "puppet-agent" do |proj|
   # - Settings included in this file should apply only to local components in this repository.
   runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
   pxp_agent_details = JSON.parse(File.read('configs/components/pxp-agent.json'))
-  agent_branch = 'main'
+  agent_branch = '7.x'
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']


### PR DESCRIPTION
The puppet-agent vanagon build needs to know the name of the branch in order to download the puppet and pxp-agent runtimes.