### PR TITLE
(maint) Bump wix 3.14.0.6526

### DIFF
--- a/configs/platforms/windowsfips-2012r2-x64.rb
+++ b/configs/platforms/windowsfips-2012r2-x64.rb
@@ -23,7 +23,7 @@ platform "windowsfips-2012r2-x64" do |plat|
 
   #FIXME we need Fips Compliant Wix, currently not in choco repositories
   #plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
-  plat.provision_with "curl -L -o /tmp/wix314-binaries.zip https://wixtoolset.org/downloads/v3.14.0.3205/wix314-binaries.zip && \"C:/Program Files/7-Zip/7z.exe\" x -y -o\"C:/Program Files (x86)/WiX Toolset v3.14/bin\" C:/cygwin64/tmp/wix314-binaries.zip && rm /tmp/wix314-binaries.zip && SETX WIX \"C:\\Program Files (x86)\\WiX Toolset v3.14\" /M"
+  plat.provision_with "curl -L -o /tmp/wix314-binaries.zip https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/wix3/wix3.14.0.6526-binaries.zip && \"C:/Program Files/7-Zip/7z.exe\" x -y -o\"C:/Program Files (x86)/WiX Toolset v3.14/bin\" C:/cygwin64/tmp/wix314-binaries.zip && rm /tmp/wix314-binaries.zip && SETX WIX \"C:\\Program Files (x86)\\WiX Toolset v3.14\" /M"
 
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long


### PR DESCRIPTION
The wix314-binaries.zip release is no longer available upstream, so I packaged the most recent wix314-binaries.zip I could find (from openvpn) and pushed that to artifactory with the build number 6526.

Here's a diff of what changed between `3.14.0.3205` and `3.14.0.6526`: 
https://github.com/wixtoolset/wix3/compare/20b3ded92859cf401a60d93f39a2e68cacb4867d..6b461364c40e6d1c487043cd0eae7c1a3d15968c