### PR TITLE
(maint) Use agent-runtime-main (again)

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -6,7 +6,7 @@ project "puppet-agent" do |proj|
   # - Settings included in this file should apply only to local components in this repository.
   runtime_details = JSON.parse(File.read('configs/components/puppet-runtime.json'))
   pxp_agent_details = JSON.parse(File.read('configs/components/pxp-agent.json'))
-  agent_branch = '7.x'
+  agent_branch = 'main'
 
   settings[:puppet_runtime_version] = runtime_details['version']
   settings[:puppet_runtime_location] = runtime_details['location']


### PR DESCRIPTION
The merge up from 7.x brought in 9a69f5809667be734f3f48e5f5e076989346de97 causing us to ship agent-runtime-7.x in puppet-agent#main. Pin back to agent-runtime-main.