### PR TITLE
(PA-4646) Restore homebrew dependency on ruby@x.y when cross-compiling macOS

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -2,7 +2,6 @@ component "facter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/facter.json')
 
   pkg.build_requires 'puppet-runtime' # Provides ruby and rubygem-deep-merge
-  pkg.build_requires "pl-ruby-patch"
 
   flags = " --bindir=#{settings[:bindir]} \
             --sitelibdir=#{settings[:ruby_vendordir]} \

--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -46,10 +46,11 @@ component "pl-ruby-patch" do |pkg, settings, platform|
     end
 
     # make rubygems use our target rbconfig when installing gems
-    if ruby_version_y == '2.7'
-      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
-    else
+    case File.basename(base_ruby)
+    when '2.0.0', '2.1.0'
       sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    else
+      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
     end
 
     pkg.build do

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -21,6 +21,9 @@ component 'puppet-runtime' do |pkg, settings, platform|
     end
   elsif platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
+  elsif platform.is_cross_compiled? && platform.is_macos?
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+    pkg.build_requires "ruby@#{ruby_version_y}"
   end
 
   if platform.is_windows?

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -15,15 +15,22 @@ component 'puppet-runtime' do |pkg, settings, platform|
 
   # Even though puppet's ruby comes from puppet-runtime, we still need a ruby
   # to build with on these platforms:
-  if platform.architecture == "sparc"
-    if platform.os_version == "11"
+  if platform.is_cross_compiled?
+    if platform.is_solaris?
+      case platform.os_version
+      when "11"
+        pkg.build_requires 'pl-ruby'
+      when "10"
+        # ruby20 installed from OpenCSW in solaris-10-sparc platform definition
+      else
+        raise "Unknown solaris os_version: #{platform.os_version}"
+      end
+    elsif platform.is_linux?
       pkg.build_requires 'pl-ruby'
+    elsif platform.is_macos?
+      ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+      pkg.build_requires "ruby@#{ruby_version_y}"
     end
-  elsif platform.is_cross_compiled_linux?
-    pkg.build_requires 'pl-ruby'
-  elsif platform.is_cross_compiled? && platform.is_macos?
-    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-    pkg.build_requires "ruby@#{ruby_version_y}"
   end
 
   if platform.is_windows?

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -137,7 +137,7 @@ project "puppet-agent" do |proj|
   # Set the $DEV_BUILD environment variable to leave headers in place.
   proj.component "cleanup"
 
-  proj.component "pl-ruby-patch"
+  proj.component 'pl-ruby-patch' if platform.is_cross_compiled?
 
   unless ENV['DEV_BUILD'].to_s.empty?
     proj.settings[:dev_build] = true


### PR DESCRIPTION
When patching the host ruby on cross compiled platforms the regex
incorrectly matched either 2.0 or 3.2.0. This was fixed in
puppet-runtime already, see commits:

puppetlabs/puppet-runtime@0ee61dced158aefd917352f0fd542b4e7c5b70d6
puppetlabs/puppet-runtime@90567fb1fc5d8376222edf813cb1ffeb146df640

---

The hiera component was deleted in commit 7c931cda2, but the hiera component had
a side effect of installing ruby@x.y when cross compiling macOS. So later
attempts to patch it via `pl-ruby-patch` failed. This moves the build
requirement to the `puppet-runtime` component, similar to how we handle
cross-compiled Linux and Solaris.

---

For cross-compiled builds for Linux, Solaris and macOS, we rely on pl-ruby,
OpenCSW ruby20 and homebrew ruby@x.y. And this commit makes it more explicit how
those dependencies are resolved.

---

The `pl-ruby-patch` component is only necessary when cross compiling, which is
why the `_shared-agent-component` in `puppet-runtime` specifies:

    proj.component 'pl-ruby-patch' if platform.is_cross_compiled?

So do the same in this repo.

Note strictly speaking, the `pl-ruby-patch` component is only needed prior to
calling `gem install --local xxx.gem`. This happens in the `puppet-runtime` repo,
for example, when installing rubygem-ffi. But `puppet-agent` (currently) only
installs puppet, facter and resource_api gems from source using `install.rb`. So
while it's not strictly needed now, it will be in the future if/when we add a
rubygem-xxx component.

Passed https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-packaging_adhoc-ad_hoc/1250/