### PR TITLE
(PA-4646) Backport pl-ruby-patch fixes

### DIFF
--- a/configs/components/facter.rb
+++ b/configs/components/facter.rb
@@ -2,7 +2,6 @@ component "facter" do |pkg, settings, platform|
   pkg.load_from_json('configs/components/facter.json')
 
   pkg.build_requires 'puppet-runtime' # Provides ruby and rubygem-deep-merge
-  pkg.build_requires "pl-ruby-patch"
 
   flags = " --bindir=#{settings[:bindir]} \
             --sitelibdir=#{settings[:ruby_vendordir]} \

--- a/configs/components/hiera.rb
+++ b/configs/components/hiera.rb
@@ -12,11 +12,6 @@ component "hiera" do |pkg, settings, platform|
             --sitelibdir=#{settings[:ruby_vendordir]} \
             --ruby=#{File.join(settings[:bindir], 'ruby')} "
 
-  if platform.is_cross_compiled? && platform.is_macos?
-    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-    pkg.build_requires "ruby@#{ruby_version_y}"
-  end
-
   if platform.is_windows?
     pkg.add_source("file://resources/files/windows/hiera.bat", sum: "bbe0a513808af61ed9f4b57463851326")
     pkg.install_file "../hiera.bat", "#{settings[:link_bindir]}/hiera.bat"

--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -46,10 +46,11 @@ component "pl-ruby-patch" do |pkg, settings, platform|
     end
 
     # make rubygems use our target rbconfig when installing gems
-    if ruby_version_y == '2.7'
-      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
-    else
+    case File.basename(base_ruby)
+    when '2.0.0', '2.1.0'
       sed_command = %(s|Gem.ruby|&, '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
+    else
+      sed_command = %(s|Gem.ruby.shellsplit|& << '-r/opt/puppetlabs/puppet/share/doc/rbconfig-#{settings[:ruby_version]}-orig.rb'|)
     end
 
     pkg.build do

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -37,6 +37,9 @@ component 'puppet-runtime' do |pkg, settings, platform|
     end
   elsif platform.is_cross_compiled_linux?
     pkg.build_requires 'pl-ruby'
+  elsif platform.is_cross_compiled? && platform.is_macos?
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+    pkg.build_requires "ruby@#{ruby_version_y}"
   end
 
   if platform.is_windows?

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -31,15 +31,22 @@ component 'puppet-runtime' do |pkg, settings, platform|
 
   # Even though puppet's ruby comes from puppet-runtime, we still need a ruby
   # to build with on these platforms:
-  if platform.architecture == "sparc"
-    if platform.os_version == "11"
+  if platform.is_cross_compiled?
+    if platform.is_solaris?
+      case platform.os_version
+      when "11"
+        pkg.build_requires 'pl-ruby'
+      when "10"
+        # ruby20 installed from OpenCSW in solaris-10-sparc platform definition
+      else
+        raise "Unknown solaris os_version: #{platform.os_version}"
+      end
+    elsif platform.is_linux?
       pkg.build_requires 'pl-ruby'
+    elsif platform.is_macos?
+      ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+      pkg.build_requires "ruby@#{ruby_version_y}"
     end
-  elsif platform.is_cross_compiled_linux?
-    pkg.build_requires 'pl-ruby'
-  elsif platform.is_cross_compiled? && platform.is_macos?
-    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-    pkg.build_requires "ruby@#{ruby_version_y}"
   end
 
   if platform.is_windows?

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -143,7 +143,7 @@ project "puppet-agent" do |proj|
   # Set the $DEV_BUILD environment variable to leave headers in place.
   proj.component "cleanup"
 
-  proj.component "pl-ruby-patch"
+  proj.component 'pl-ruby-patch' if platform.is_cross_compiled?
 
   unless ENV['DEV_BUILD'].to_s.empty?
     proj.settings[:dev_build] = true


### PR DESCRIPTION
Backports https://github.com/puppetlabs/puppet-agent/pull/2328 to 7.x

Apply ruby regex fix from puppet-runtime

Move ruby@x.y build requirement from hiera to puppet-runtime

Building against all current 7.x build targets in https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1926/
and https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1927/