### PR TITLE
(maint) Inherit macOS platform defaults from vanagon

### DIFF
--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,22 +1,4 @@
 platform "osx-11-arm64" do |plat|
-  plat.servicetype "launchd"
-  plat.servicedir "/Library/LaunchDaemons"
-  plat.codename "bigsur"
-  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
-  plat.provision_with "export HOMEBREW_VERBOSE=true"
-  plat.provision_with "sudo dscl . -create /Users/test"
-  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
-  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
-  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
-  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
-  plat.provision_with "sudo dscl . -passwd /Users/test password"
-  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
-  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
-  plat.provision_with "mkdir -p /etc/homebrew"
-  plat.provision_with "cd /etc/homebrew"
-  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
-  plat.vmpooler_template "macos-112-x86_64"
-  plat.cross_compiled true
+  plat.inherit_from_default
   plat.output_dir File.join('apple', '11', 'puppet6', 'arm64')
 end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,29 +1,7 @@
 platform 'osx-12-arm64' do |plat|
-    plat.servicetype 'launchd'
-    plat.servicedir '/Library/LaunchDaemons'
-    plat.codename 'monterey'
+  plat.inherit_from_default
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
 
-    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-    plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-
-    packages = %w[cmake pkg-config yaml-cpp]
-
-    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-
-    plat.vmpooler_template 'macos-12-x86_64'
-    plat.cross_compiled true
-    plat.output_dir File.join('apple', '12', 'puppet6', 'arm64')
-  end
+  plat.output_dir File.join('apple', '12', 'puppet6', 'arm64')
+end


### PR DESCRIPTION
See VANAGON-214

Updates osx-\*-\*.rb platform defintions to inherit from vanagon, except for [osx-10.15-x86_64, which already does](https://github.com/puppetlabs/puppet-agent/blob/6.x/configs/platforms/osx-10.15-x86_64.rb).