### PR TITLE
(maint) Updates core modules

### DIFF
--- a/configs/components/module-puppetlabs-augeas_core.json
+++ b/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.1.2"}
+{"url":"git@github.com:puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-cron_core.json
+++ b/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.5"}
+{"url":"git@github.com:puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/v1.1.0"}

--- a/configs/components/module-puppetlabs-host_core.json
+++ b/configs/components/module-puppetlabs-host_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.3"}
+{"url":"git@github.com:puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/v1.1.0"}

--- a/configs/components/module-puppetlabs-mount_core.json
+++ b/configs/components/module-puppetlabs-mount_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.4"}
+{"url":"git@github.com:puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/v1.1.0"}

--- a/configs/components/module-puppetlabs-selinux_core.json
+++ b/configs/components/module-puppetlabs-selinux_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.1.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/2.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/v2.3.0"}

--- a/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.7"}
+{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/v1.1.0"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/v1.3.0"}


### PR DESCRIPTION
Most of the core modules were upated in 2021 by the Night's Watch team, but their references as Vanagon components weren't updated within puppet-agent.

This commit updates the refs for the core modules that were updated in 2021.