### PR TITLE
(MODULES-11371) Update core module references

### DIFF
--- a/configs/components/module-puppetlabs-augeas_core.json
+++ b/configs/components/module-puppetlabs-augeas_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/1.1.2"}
+{"url":"git@github.com:puppetlabs/puppetlabs-augeas_core.git","ref":"refs/tags/v1.3.0"}

--- a/configs/components/module-puppetlabs-cron_core.json
+++ b/configs/components/module-puppetlabs-cron_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/1.0.5"}
+{"url":"git@github.com:puppetlabs/puppetlabs-cron_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-host_core.json
+++ b/configs/components/module-puppetlabs-host_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/1.0.3"}
+{"url":"git@github.com:puppetlabs/puppetlabs-host_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-mount_core.json
+++ b/configs/components/module-puppetlabs-mount_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/1.0.4"}
+{"url":"git@github.com:puppetlabs/puppetlabs-mount_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-scheduled_task.json
+++ b/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/1.0.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/v3.1.1"}

--- a/configs/components/module-puppetlabs-selinux_core.json
+++ b/configs/components/module-puppetlabs-selinux_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/1.1.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-selinux_core.git","ref":"refs/tags/v1.3.0"}

--- a/configs/components/module-puppetlabs-sshkeys_core.json
+++ b/configs/components/module-puppetlabs-sshkeys_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/2.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-sshkeys_core.git","ref":"refs/tags/v2.4.0"}

--- a/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/1.0.7"}
+{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/v1.2.0"}

--- a/configs/components/module-puppetlabs-zfs_core.json
+++ b/configs/components/module-puppetlabs-zfs_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/1.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-zfs_core.git","ref":"refs/tags/v1.4.0"}

--- a/configs/components/module-puppetlabs-zone_core.json
+++ b/configs/components/module-puppetlabs-zone_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/1.0.3"}
+{"url":"git@github.com:puppetlabs/puppetlabs-zone_core.git","ref":"refs/tags/v1.1.0"}

--- a/configs/components/shellpath.rb
+++ b/configs/components/shellpath.rb
@@ -1,17 +1,7 @@
 component "shellpath" do |pkg, settings, platform|
-  pkg.version "2015-09-18"
+  pkg.version "2023-02-15"
   pkg.add_source "file://resources/files/puppet-agent.sh", sum: "f5987a68adf3844ca15ba53813ad6f63"
   pkg.add_source "file://resources/files/puppet-agent.csh", sum: "62b360a7d15b486377ef6c7c6d05e881"
   pkg.install_file("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh")
-
-  # The cisco platforms have non-standard packages for /etc/profile.d and also try to run the csh
-  if platform.name =~ /cisco-wrlinux-5/
-    pkg.requires 'platform'
-    # cisco-wrlinux-5 has a bug that requires profile.d scripts to be executable
-    pkg.install_file("./puppet-agent.sh", "/etc/profile.d/puppet-agent.sh", mode: '0755')
-  elsif platform.name =~ /cisco-wrlinux-7/
-    pkg.requires 'cisco-config'
-  else
-    pkg.install_file("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
-  end
+  pkg.install_file("./puppet-agent.csh", "/etc/profile.d/puppet-agent.csh")
 end


### PR DESCRIPTION
This commit updates the references for all core module Vanagon components, enabling compatibilty with Puppet 8 and other minor changes.