### PR TITLE
(maint) Merge 6.x to 7.x

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,21 +1,4 @@
 platform 'osx-10.15-x86_64' do |plat|
-  plat.servicetype 'launchd'
-  plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "catalina"
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-  plat.provision_with 'sudo dscl . -create /Users/test'
-  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-  plat.provision_with 'sudo dscl . -passwd /Users/test password'
-  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-  plat.provision_with 'mkdir -p /etc/homebrew'
-  plat.provision_with 'cd /etc/homebrew'
-  plat.provision_with 'su test -c \'/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-  plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  plat.vmpooler_template 'osx-1015-x86_64'
+  plat.inherit_from_default
   plat.output_dir File.join('apple', '10.15', 'puppet7', 'x86_64')
 end

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,22 +1,4 @@
 platform "osx-11-arm64" do |plat|
-  plat.servicetype "launchd"
-  plat.servicedir "/Library/LaunchDaemons"
-  plat.codename "bigsur"
-  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
-  plat.provision_with "export HOMEBREW_VERBOSE=true"
-  plat.provision_with "sudo dscl . -create /Users/test"
-  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
-  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
-  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
-  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
-  plat.provision_with "sudo dscl . -passwd /Users/test password"
-  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
-  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
-  plat.provision_with "mkdir -p /etc/homebrew"
-  plat.provision_with "cd /etc/homebrew"
-  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
-  plat.vmpooler_template "macos-112-x86_64"
-  plat.cross_compiled true
+  plat.inherit_from_default
   plat.output_dir File.join('apple', '11', 'puppet7', 'arm64')
 end

--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -1,21 +1,4 @@
 platform 'osx-11-x86_64' do |plat|
-  plat.servicetype 'launchd'
-  plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "bigsur"
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-  plat.provision_with 'sudo dscl . -create /Users/test'
-  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-  plat.provision_with 'sudo dscl . -passwd /Users/test password'
-  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-  plat.provision_with 'mkdir -p /etc/homebrew'
-  plat.provision_with 'cd /etc/homebrew'
-  plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-  plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  plat.vmpooler_template 'macos-112-x86_64'
+  plat.inherit_from_default
   plat.output_dir File.join('apple', '11', 'puppet7', 'x86_64')
 end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,29 +1,6 @@
 platform 'osx-12-arm64' do |plat|
-    plat.servicetype 'launchd'
-    plat.servicedir '/Library/LaunchDaemons'
-    plat.codename 'monterey'
-
-    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-    plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-
-    packages = %w[cmake pkg-config yaml-cpp]
-
-    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-
-    plat.vmpooler_template 'macos-12-x86_64'
-    plat.cross_compiled true
-    plat.output_dir File.join('apple', '12', 'puppet7', 'arm64')
-  end
+  plat.inherit_from_default
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  plat.output_dir File.join('apple', '12', 'puppet7', 'arm64')
+end


### PR DESCRIPTION
* Inherit from vanagon
* preserve puppet7 collection in `output_dir` (for now)
* preserve brew install cmake pkg-config yaml-cpp on macOS 12 ARM
* exclude facter-ng component and other component bumps