### PR TITLE
(maint) Merge 7.x to main

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,20 +1,3 @@
 platform 'osx-10.15-x86_64' do |plat|
-  plat.servicetype 'launchd'
-  plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "catalina"
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-  plat.provision_with 'sudo dscl . -create /Users/test'
-  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-  plat.provision_with 'sudo dscl . -passwd /Users/test password'
-  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-  plat.provision_with 'mkdir -p /etc/homebrew'
-  plat.provision_with 'cd /etc/homebrew'
-  plat.provision_with 'su test -c \'/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-  plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  plat.vmpooler_template 'osx-1015-x86_64'
+  plat.inherit_from_default
 end

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,21 +1,3 @@
 platform "osx-11-arm64" do |plat|
-  plat.servicetype "launchd"
-  plat.servicedir "/Library/LaunchDaemons"
-  plat.codename "bigsur"
-  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
-  plat.provision_with "export HOMEBREW_VERBOSE=true"
-  plat.provision_with "sudo dscl . -create /Users/test"
-  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
-  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
-  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
-  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
-  plat.provision_with "sudo dscl . -passwd /Users/test password"
-  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
-  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
-  plat.provision_with "mkdir -p /etc/homebrew"
-  plat.provision_with "cd /etc/homebrew"
-  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
-  plat.provision_with "sudo chown -R test:admin /Users/test/"
-  plat.vmpooler_template "macos-112-x86_64"
-  plat.cross_compiled true
+  plat.inherit_from_default
 end

--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -1,20 +1,3 @@
 platform 'osx-11-x86_64' do |plat|
-  plat.servicetype 'launchd'
-  plat.servicedir '/Library/LaunchDaemons'
-  plat.codename "bigsur"
-  plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-  plat.provision_with 'export HOMEBREW_VERBOSE=true'
-  plat.provision_with 'sudo dscl . -create /Users/test'
-  plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-  plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-  plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-  plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-  plat.provision_with 'sudo dscl . -passwd /Users/test password'
-  plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-  plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-  plat.provision_with 'mkdir -p /etc/homebrew'
-  plat.provision_with 'cd /etc/homebrew'
-  plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-  plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  plat.vmpooler_template 'macos-112-x86_64'
+  plat.inherit_from_default
 end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -1,28 +1,5 @@
 platform 'osx-12-arm64' do |plat|
-    plat.servicetype 'launchd'
-    plat.servicedir '/Library/LaunchDaemons'
-    plat.codename 'monterey'
-
-    plat.provision_with 'export HOMEBREW_NO_EMOJI=true'
-    plat.provision_with 'export HOMEBREW_VERBOSE=true'
-
-    plat.provision_with 'sudo dscl . -create /Users/test'
-    plat.provision_with 'sudo dscl . -create /Users/test UserShell /bin/bash'
-    plat.provision_with 'sudo dscl . -create /Users/test UniqueID 1001'
-    plat.provision_with 'sudo dscl . -create /Users/test PrimaryGroupID 1000'
-    plat.provision_with 'sudo dscl . -create /Users/test NFSHomeDirectory /Users/test'
-    plat.provision_with 'sudo dscl . -passwd /Users/test password'
-    plat.provision_with 'sudo dscl . -merge /Groups/admin GroupMembership test'
-    plat.provision_with 'echo "test ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/username'
-    plat.provision_with 'mkdir -p /etc/homebrew'
-    plat.provision_with 'cd /etc/homebrew'
-    plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
-    plat.provision_with 'sudo chown -R test:admin /Users/test/Library/'
-
-    packages = %w[cmake pkg-config yaml-cpp]
-
-    plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
-
-    plat.vmpooler_template 'macos-12-x86_64'
-    plat.cross_compiled true
-  end
+  plat.inherit_from_default
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+end


### PR DESCRIPTION
* Inherit from vanagon
* Ignore hiera.rb component (it was removed in main) and component bumps
* We removed the calls to ` plat.output_dir` in d62958d804e7208b2e536280a972113fa45303c0, so preserve that in main
* Preserve `brew install cmake pkg-config yaml-cpp` for macOS 12 ARM