### PR TITLE
(PUP-11786) Enable Ruby 3.1 compatibility

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,11 +12,11 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
-gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1")
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 1")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem "beaker-vcloud", *location_for(ENV['BEAKER_VCLOUD_VERSION'] || "~> 1")
 gem "rake", ">= 12.3.3"
@@ -27,6 +27,6 @@ group(:test) do
   gem "rspec", "~> 2.14.0", :require => false
   gem "mocha", "~> 0.10.5", :require => false
 end
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/acceptance/tests/ensure_facter_values_for_custom_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_custom_overrides_core_top_fact.rb
@@ -60,7 +60,7 @@ FILE
 
       step 'check that json custom fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_external_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_external_overrides_core_top_fact.rb
@@ -53,7 +53,7 @@ test_name 'Ensure Facter values usage for external fact overriding core top fact
 
       step 'check that external json fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_external_overrides_custom_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_external_overrides_custom_overrides_core_top_fact.rb
@@ -64,7 +64,7 @@ FILE
 
       step 'check that json custom fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_json_custom_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_json_custom_fact.rb
@@ -57,25 +57,25 @@ FILE
 
       step 'check that json custom fact key is not visible to puppet in $facts' do
         on agent, puppet("apply -e 'notice(\$facts[\"fizz.buzz\"])'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in $facts.dig' do
         on agent, puppet("apply -e 'notice(\$facts.dig(\"fizz.buzz\"))'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in $facts.get' do
         on agent, puppet("apply -e 'notice(\$facts.get(\"fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in getvar' do
         on agent, puppet("apply -e 'notice(getvar(\"facts.fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_json_external_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_json_external_fact.rb
@@ -51,25 +51,25 @@ test_name 'Ensure Facter values usage for json external fact' do
 
       step 'check that json external fact key is not visible to puppet in $facts' do
         on agent, puppet("apply -e 'notice(\$facts[\"fizz.buzz\"])'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in $facts.dig' do
         on agent, puppet("apply -e 'notice(\$facts.dig(\"fizz.buzz\"))'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in $facts.get' do
         on agent, puppet("apply -e 'notice(\$facts.get(\"fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in getvar' do
         on agent, puppet("apply -e 'notice(getvar(\"facts.fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
     end


### PR DESCRIPTION
This PR comprises changes to enable puppet-agent (and its dependencies) to run its CI pipeline end-to-end on Ruby 3.1.