### PR TITLE
(maint) Update Solaris 11 publisher

### DIFF
--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -3,7 +3,7 @@ platform "solaris-11-i386" do |plat|
   plat.defaultdir "/lib/svc/method"
   plat.servicetype "smf"
   plat.vmpooler_template "solaris-11-x86_64"
-  plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
+  plat.add_build_repository 'http://ci-ipsrepo-prod-1.delivery.puppetlabs.net', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "puppet7")
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -4,7 +4,7 @@ platform "solaris-11-sparc" do |plat|
   plat.servicetype "smf"
   plat.cross_compiled true
   plat.vmpooler_template "solaris-11-x86_64"
-  plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
+  plat.add_build_repository 'http://ci-ipsrepo-prod-1.delivery.puppetlabs.net', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
   plat.output_dir File.join("solaris", "11", "puppet7")
 end


### PR DESCRIPTION
This commit changes the URL for the package repository/publisher for Solaris 11 platforms to Puppet's new server.