### PR TITLE
(maint) Update assert_not_match to refute_match

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,6 +85,9 @@ Style/PercentLiteralDelimiters:
 Style/RedundantInterpolation:
   Enabled: false
 
+Style/RedundantLineContinuation:
+  Enabled: false
+
 Style/SignalException:
   Enabled: false
 

--- a/acceptance/tests/ensure_facter_values_for_custom_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_custom_overrides_core_top_fact.rb
@@ -60,7 +60,7 @@ FILE
 
       step 'check that json custom fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_external_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_external_overrides_core_top_fact.rb
@@ -53,7 +53,7 @@ test_name 'Ensure Facter values usage for external fact overriding core top fact
 
       step 'check that external json fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_external_overrides_custom_overrides_core_top_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_external_overrides_custom_overrides_core_top_fact.rb
@@ -64,7 +64,7 @@ FILE
 
       step 'check that json custom fact is interpreted as text' do
         on agent, puppet("apply -e 'notice(\$facts[\"ruby\"][\"version\"])'") , acceptable_exit_codes: [1]  do |output|
-          assert_not_match(/Notice: .*: 1.1.1/, output.stdout)
+          refute_match(/Notice: .*: 1.1.1/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_json_custom_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_json_custom_fact.rb
@@ -57,25 +57,25 @@ FILE
 
       step 'check that json custom fact key is not visible to puppet in $facts' do
         on agent, puppet("apply -e 'notice(\$facts[\"fizz.buzz\"])'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in $facts.dig' do
         on agent, puppet("apply -e 'notice(\$facts.dig(\"fizz.buzz\"))'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in $facts.get' do
         on agent, puppet("apply -e 'notice(\$facts.get(\"fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json custom fact key is not visible to puppet in getvar' do
         on agent, puppet("apply -e 'notice(getvar(\"facts.fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
     end

--- a/acceptance/tests/ensure_facter_values_for_json_external_fact.rb
+++ b/acceptance/tests/ensure_facter_values_for_json_external_fact.rb
@@ -51,25 +51,25 @@ test_name 'Ensure Facter values usage for json external fact' do
 
       step 'check that json external fact key is not visible to puppet in $facts' do
         on agent, puppet("apply -e 'notice(\$facts[\"fizz.buzz\"])'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in $facts.dig' do
         on agent, puppet("apply -e 'notice(\$facts.dig(\"fizz.buzz\"))'") do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in $facts.get' do
         on agent, puppet("apply -e 'notice(\$facts.get(\"fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
 
       step 'check that json external fact key is not visible to puppet in getvar' do
         on agent, puppet("apply -e 'notice(getvar(\"facts.fizz.buzz\"))'"), acceptable_exit_codes: [1] do |output|
-          assert_not_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
+          refute_match(/Notice: .*: {"bizz": "buzz"}/, output.stdout)
         end
       end
     end


### PR DESCRIPTION
In Beaker, the assert_not_match method was removed in commit voxpupuli/beaker@6282311 in favor of MiniTest::Assertions#refute_match. This change was released in Beaker 5.0.0.

This commit updates all instances of the assert_not_match with refute_match in preparation for a future switch to Beaker 5.