### PR TITLE
(PA-5398) Add fips shared library

### DIFF
--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -1,0 +1,43 @@
+test_name 'Validate openssl version and fips' do
+  tag 'audit:high'
+
+  def openssl_command(host)
+    puts "privatebindir=#{host['privatebindir']}"
+    "env PATH=\"#{host['privatebindir']}:${PATH}\" openssl"
+  end
+
+  agents.each do |agent|
+    openssl = openssl_command(agent)
+
+    step "check openssl version" do
+      on(agent, "#{openssl} version -v") do |result|
+        assert_match(/^OpenSSL 3\./, result.stdout)
+      end
+    end
+
+    if agent['template'] =~ /^redhat-fips/
+      step "check fips_enabled fact" do
+        on(agent, facter("fips_enabled")) do |result|
+          assert_match(/^true/, result.stdout)
+        end
+      end
+
+      step "check openssl providers" do
+        on(agent, "#{openssl} list -providers") do |result|
+          assert_match(Regexp.new(<<~END, Regexp::MULTILINE), result.stdout)
+          \s*fips
+          \s*name: OpenSSL FIPS Provider
+          \s*version: 3.0.0
+          \s*status: active
+          END
+        end
+      end
+
+      step "check fipsmodule.cnf" do
+        on(agent, "#{openssl} fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -in /opt/puppetlabs/puppet/ssl/fipsmodule.cnf -verify") do |result|
+          assert_match(/VERIFY PASSED/, result.stderr)
+        end
+      end
+    end
+  end
+end

--- a/configs/components/openssl-fips.json
+++ b/configs/components/openssl-fips.json
@@ -1,0 +1,1 @@
+{"location":"https://builds.delivery.puppetlabs.net/openssl-fips/202305090/artifacts/","version":"202305090"}

--- a/configs/components/openssl-fips.rb
+++ b/configs/components/openssl-fips.rb
@@ -1,0 +1,65 @@
+component "openssl-fips" do |pkg, settings, platform|
+
+  pkg.build_requires "puppet-runtime"
+
+  openssl_fips_details = JSON.parse(File.read('configs/components/openssl-fips.json'))
+  openssl_fips_version = openssl_fips_details['version']
+  openssl_fips_location = openssl_fips_details['location']
+
+  tarball_name = "#{pkg.get_name}-#{openssl_fips_version}.#{platform.name}.tar.gz"
+  pkg.url File.join(openssl_fips_location, tarball_name)
+  pkg.sha1sum File.join(openssl_fips_location, "#{tarball_name}.sha1")
+  pkg.version openssl_fips_version
+  pkg.install_only true
+
+  pkg.add_source("file://resources/patches/openssl/openssl-fips.cnf.patch")
+
+  # Overlay openssl-fips shared library onto puppet-runtime in /opt at *build* time
+  #
+  # Don't generate `fipsmodule.cnf` during the build. It must be generated
+  # during postinstall action.
+  #
+  # Don't include FIPS-enabled `openssl.cnf` in the package. It must be moved
+  # into place after `fipsmodule.cnf` is generated. So ship `openssl-fips.cnf`
+  # and rename it to `openssl.cnf` during postinstall action.
+  #
+  # REMIND: update for Windows
+  pkg.install do
+    [
+      "#{platform.tar} --skip-old-files --directory=/ --extract --gunzip --file=#{tarball_name}",
+      "mv /opt/puppetlabs/puppet/ssl/openssl.cnf /opt/puppetlabs/puppet/ssl/openssl-fips.cnf",
+      "#{platform.patch} --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch -d /opt/puppetlabs/puppet/ssl/ < openssl-fips.cnf.patch"
+    ]
+  end
+
+  # See "Making all applications use the FIPS module by default" in
+  # https://www.openssl.org/docs/man3.0/man7/fips_module.html
+  #
+  # We have to run `openssl fipsinstall` to generate `fipsmodule.cnf`. This
+  # generates an HMAC for the `fips.so` and stores that value in `fipsmodule.cnf`.
+  # Only later can we enable fips, by overwriting `openssl.cnf` with the fips
+  # enabled version.
+  #
+  # During an upgrade, `fips.so` may be modified, invaliding the checksum in
+  # `fipsmodule.cnf`, and that will prevent `openssl fipsinstall` from working.
+  # So override OPENSSL_CONF to use the pristine `openssl.cnf` without fips
+  # enabled to regenerate `fipsmodule.conf`
+  #
+  # REMIND: update for Windows
+  pkg.add_postinstall_action ["install", "upgrade"],
+    [<<-HERE.undent
+      OPENSSL_CONF=/opt/puppetlabs/puppet/ssl/openssl.cnf.dist /opt/puppetlabs/puppet/bin/openssl fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -out /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
+      /usr/bin/cp --preserve /opt/puppetlabs/puppet/ssl/openssl-fips.cnf /opt/puppetlabs/puppet/ssl/openssl.cnf
+      /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/openssl.cnf
+      /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
+     HERE
+    ]
+
+  # Delete generated files, they may not exist, so force
+  #
+  # REMIND: update for Windows
+  pkg.add_preremove_action ["removal"], [
+    "rm --force /opt/puppetlabs/puppet/ssl/openssl.cnf",
+    "rm --force /opt/puppetlabs/puppet/ssl/fipsmodule.cnf"
+  ]
+end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -103,6 +103,7 @@ project "puppet-agent" do |proj|
 
   # Provides augeas, curl, libedit, libxml2, libxslt, openssl, puppet-ca-bundle, ruby and rubygem-*
   proj.component "puppet-runtime"
+  proj.component 'openssl-fips' if platform.is_fips? && !platform.is_windows? # REMIND not yet on windows
   proj.component "pxp-agent" if ENV['NO_PXP_AGENT'].to_s.empty?
 
   proj.component "puppet"

--- a/resources/patches/openssl/openssl-fips.cnf.patch
+++ b/resources/patches/openssl/openssl-fips.cnf.patch
@@ -1,0 +1,36 @@
+--- a/openssl-fips.cnf	2023-05-02 16:52:22.883933027 +0000
++++ b/openssl-fips.cnf	2023-05-02 16:52:16.213933118 +0000
+@@ -48,17 +48,18 @@
+ # fips provider. It contains a named section e.g. [fips_sect] which is
+ # referenced from the [provider_sect] below.
+ # Refer to the OpenSSL security policy for more information.
+-# .include fipsmodule.cnf
++.include /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
+ 
+ [openssl_init]
+ providers = provider_sect
++alg_section = evp_properties
+ 
+ # List of providers to load
+ [provider_sect]
+ default = default_sect
+ # The fips section name should match the section name inside the
+ # included fipsmodule.cnf.
+-# fips = fips_sect
++fips = fips_sect
+ 
+ # If no providers are activated explicitly, the default one is activated implicitly.
+ # See man 7 OSSL_PROVIDER-default for more details.
+@@ -69,8 +70,11 @@
+ # OpenSSL may not work correctly which could lead to significant system
+ # problems including inability to remotely access the system.
+ [default_sect]
+-# activate = 1
++activate = 1
+ 
++# IMPORTANT: This ensures only FIPS algorithms are used, e.g. not MD5
++[evp_properties]
++default_properties = "fips=yes"
+ 
+ ####################################################################
+ [ ca ]


### PR DESCRIPTION
* Adds fips.so shared library component to puppet-agent on RHEL 7 & 8 FIPS
* Runs `openssl fipsinstall` as a post-install task and enables the fips provider
* Adds beaker tests to verify openssl version and status of the fips provider

Also see the [OpenSSL 3.0.0 FIPS provider](https://github.com/puppetlabs/openssl-fips/blob/main/README.md).

Open Issues:
- [x] Should the post-install task run on upgrades too? Yes
- [x] Rebase on main after https://github.com/puppetlabs/puppet-runtime/pull/663 is merged
- [x] Run adhoc pipeline on all [redhatfips platforms](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1113/)
- [x] Run [main pipeline](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/Acceptance%20Suites/view/main/view/Suite/job/platform_puppet-agent_puppet-agent-integration-suite_daily-main/1026/) with latest [`puppet-runtime#202305040`](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/Acceptance%20Suites/view/main/view/Suite/job/platform_puppet-agent_puppet-agent-integration-suite_daily-main/1026/)
- [x] validate_vendored_openssl passed on [rhelfips7](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1107/RMM_COMPONENT_TO_TEST_NAME=puppet_agent,SLAVE_LABEL=k8s-beaker,TEST_TARGET=redhatfips7-64a/testReport/(root)/tests/validate_vendored_openssl_rb/) and [rhelfips8](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1107/RMM_COMPONENT_TO_TEST_NAME=puppet_agent,SLAVE_LABEL=k8s-beaker,TEST_TARGET=redhatfips8-64a/testReport/(root)/tests/validate_vendored_openssl_rb/)