### PR TITLE
(PA-5399) Install and configure the fips provider on Windows

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -27,6 +27,6 @@ group(:test) do
   gem "rspec", "~> 2.14.0", :require => false
   gem "mocha", "~> 0.10.5", :require => false
 end
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -1,9 +1,19 @@
+require 'puppet/acceptance/temp_file_utils'
+
 test_name 'Validate openssl version and fips' do
+  extend Puppet::Acceptance::TempFileUtils
+
   tag 'audit:high'
 
   def openssl_command(host)
     puts "privatebindir=#{host['privatebindir']}"
     "env PATH=\"#{host['privatebindir']}:${PATH}\" openssl"
+  end
+
+  def create_bat_wrapper(host, file, command)
+    tempfile = get_test_file_path(agent, file)
+    create_remote_file(agent, tempfile, command)
+    "cmd /c $(cygpath -w #{tempfile})"
   end
 
   agents.each do |agent|
@@ -15,7 +25,7 @@ test_name 'Validate openssl version and fips' do
       end
     end
 
-    if agent['template'] =~ /^redhat-fips/
+    if agent['template'] =~ /fips/
       step "check fips_enabled fact" do
         on(agent, facter("fips_enabled")) do |result|
           assert_match(/^true/, result.stdout)
@@ -23,7 +33,16 @@ test_name 'Validate openssl version and fips' do
       end
 
       step "check openssl providers" do
-        on(agent, "#{openssl} list -providers") do |result|
+        if agent['template'] =~ /^win/
+          list_command = create_bat_wrapper(agent, "list_providers.bat", <<~END)
+          call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" %0 %*
+          openssl list -providers
+          END
+        else
+          list_command = "#{openssl} list -providers"
+        end
+
+        on(agent, list_command) do |result|
           assert_match(Regexp.new(<<~END, Regexp::MULTILINE), result.stdout)
           \s*fips
           \s*name: OpenSSL FIPS Provider
@@ -34,7 +53,16 @@ test_name 'Validate openssl version and fips' do
       end
 
       step "check fipsmodule.cnf" do
-        on(agent, "#{openssl} fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -in /opt/puppetlabs/puppet/ssl/fipsmodule.cnf -verify") do |result|
+        if agent['template'] =~ /^win/
+          verify_command = create_bat_wrapper(agent, "verify_fips.bat", <<~END)
+          call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" %0 %*
+          openssl fipsinstall -module "%OPENSSL_MODULES%\\fips.dll" -provider_name fips -in "%OPENSSL_CONF_INCLUDE%\\fipsmodule.cnf" -verify
+          END
+        else
+          verify_command = "#{openssl} fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -in /opt/puppetlabs/puppet/ssl/fipsmodule.cnf -verify"
+        end
+
+        on(agent, verify_command) do |result|
           assert_match(/VERIFY PASSED/, result.stderr)
         end
       end

--- a/configs/components/openssl-fips.rb
+++ b/configs/components/openssl-fips.rb
@@ -52,6 +52,7 @@ component "openssl-fips" do |pkg, settings, platform|
   # enabled to regenerate `fipsmodule.conf`
   #
   if platform.is_rpm?
+    # If you modify the following code, update customactions.wxs.erb too!
     pkg.add_postinstall_action ["install", "upgrade"],
       [<<-HERE.undent
         OPENSSL_CONF=/opt/puppetlabs/puppet/ssl/openssl.cnf.dist /opt/puppetlabs/puppet/bin/openssl fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -out /opt/puppetlabs/puppet/ssl/fipsmodule.cnf

--- a/configs/components/openssl-fips.rb
+++ b/configs/components/openssl-fips.rb
@@ -1,5 +1,7 @@
 component "openssl-fips" do |pkg, settings, platform|
 
+  raise "openssl-fips is not a valid component on non-fips platforms" unless platform.is_fips?
+
   pkg.build_requires "puppet-runtime"
 
   openssl_fips_details = JSON.parse(File.read('configs/components/openssl-fips.json'))
@@ -14,6 +16,10 @@ component "openssl-fips" do |pkg, settings, platform|
 
   pkg.add_source("file://resources/patches/openssl/openssl-fips.cnf.patch")
 
+  openssl_ssldir   = File.join(settings[:prefix], 'ssl')
+  openssl_cnf      = File.join(openssl_ssldir, 'openssl.cnf')
+  openssl_fips_cnf = File.join(openssl_ssldir, 'openssl-fips.cnf')
+
   # Overlay openssl-fips shared library onto puppet-runtime in /opt at *build* time
   #
   # Don't generate `fipsmodule.cnf` during the build. It must be generated
@@ -23,12 +29,12 @@ component "openssl-fips" do |pkg, settings, platform|
   # into place after `fipsmodule.cnf` is generated. So ship `openssl-fips.cnf`
   # and rename it to `openssl.cnf` during postinstall action.
   #
-  # REMIND: update for Windows
+  extract_dir = platform.is_windows? ? '/cygdrive/c' : '/'
   pkg.install do
     [
-      "#{platform.tar} --skip-old-files --directory=/ --extract --gunzip --file=#{tarball_name}",
-      "mv /opt/puppetlabs/puppet/ssl/openssl.cnf /opt/puppetlabs/puppet/ssl/openssl-fips.cnf",
-      "#{platform.patch} --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch -d /opt/puppetlabs/puppet/ssl/ < openssl-fips.cnf.patch"
+      "#{platform.tar} --skip-old-files --directory=#{extract_dir} --extract --gunzip --file=#{tarball_name}",
+      "mv #{openssl_cnf} #{openssl_fips_cnf}",
+      "#{platform.patch} --strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch -d #{openssl_ssldir}/ < openssl-fips.cnf.patch"
     ]
   end
 
@@ -45,21 +51,22 @@ component "openssl-fips" do |pkg, settings, platform|
   # So override OPENSSL_CONF to use the pristine `openssl.cnf` without fips
   # enabled to regenerate `fipsmodule.conf`
   #
-  # REMIND: update for Windows
-  pkg.add_postinstall_action ["install", "upgrade"],
-    [<<-HERE.undent
-      OPENSSL_CONF=/opt/puppetlabs/puppet/ssl/openssl.cnf.dist /opt/puppetlabs/puppet/bin/openssl fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -out /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
-      /usr/bin/cp --preserve /opt/puppetlabs/puppet/ssl/openssl-fips.cnf /opt/puppetlabs/puppet/ssl/openssl.cnf
-      /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/openssl.cnf
-      /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
-     HERE
-    ]
+  if platform.is_rpm?
+    pkg.add_postinstall_action ["install", "upgrade"],
+      [<<-HERE.undent
+        OPENSSL_CONF=/opt/puppetlabs/puppet/ssl/openssl.cnf.dist /opt/puppetlabs/puppet/bin/openssl fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -out /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
+        /usr/bin/cp --preserve /opt/puppetlabs/puppet/ssl/openssl-fips.cnf /opt/puppetlabs/puppet/ssl/openssl.cnf
+        /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/openssl.cnf
+        /usr/bin/chmod 0644 /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
+        HERE
+      ]
 
-  # Delete generated files, they may not exist, so force
-  #
-  # REMIND: update for Windows
-  pkg.add_preremove_action ["removal"], [
-    "rm --force /opt/puppetlabs/puppet/ssl/openssl.cnf",
-    "rm --force /opt/puppetlabs/puppet/ssl/fipsmodule.cnf"
-  ]
+    # Delete generated files, they may not exist, so force
+    #
+    # REMIND: update for Windows
+    pkg.add_preremove_action ["removal"], [
+      "rm --force /opt/puppetlabs/puppet/ssl/openssl.cnf",
+      "rm --force /opt/puppetlabs/puppet/ssl/fipsmodule.cnf"
+    ]
+  end
 end

--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -103,7 +103,7 @@ project "puppet-agent" do |proj|
 
   # Provides augeas, curl, libedit, libxml2, libxslt, openssl, puppet-ca-bundle, ruby and rubygem-*
   proj.component "puppet-runtime"
-  proj.component 'openssl-fips' if platform.is_fips? && !platform.is_windows? # REMIND not yet on windows
+  proj.component 'openssl-fips' if platform.is_fips?
   proj.component "pxp-agent" if ENV['NO_PXP_AGENT'].to_s.empty?
 
   proj.component "puppet"

--- a/resources/files/windows/environment.bat
+++ b/resources/files/windows/environment.bat
@@ -24,3 +24,6 @@ REM Set SSL variables to ensure trusted locations are used
 SET SSL_CERT_FILE=%PUPPET_DIR%\ssl\cert.pem
 SET SSL_CERT_DIR=%PUPPET_DIR%\ssl\certs
 SET OPENSSL_CONF=%PUPPET_DIR%\ssl\openssl.cnf
+SET OPENSSL_CONF_INCLUDE=%PUPPET_DIR%\ssl
+SET OPENSSL_MODULES=%PUPPET_DIR%\lib\ossl-modules
+SET OPENSSL_ENGINES=%PUPPET_DIR%\lib\engines-3

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -268,6 +268,38 @@ End If
             DllEntry="WixSilentExec64"
             Execute="immediate"
             Impersonate="yes" />
+
+        <!-- Fips is only supported in 64-bit -->
+        <%-if @platform.is_fips?-%>
+            <!--
+                 The FipsInstall custom action depends on the user-specified
+                 INSTALLDIR, so it can't be an immediate action. Also, "custom
+                 actions that change the system directly, or call another system
+                 service, must be deferred to the time when the installation
+                 script is executed."
+                 https://learn.microsoft.com/en-us/windows/win32/msi/deferred-execution-custom-actions
+
+                 To create a deferred action, first the "SetProperty" custom
+                 action interpolates the values *Before* the "FipsInstall"
+                 custom action runs. And "the property Id used in the
+                 SetProperty custom action must match the Id value used in the
+                 deferred custom action"
+                 https://wixtoolset.org/docs/v3/customactions/qtexec/#deferred-execution
+
+                 The action runs "openssl fipsinstall" and copies openssl-fips.cnf
+                 to openssl.cnf If you modify the following code, update the rpm
+                 postinstall action in configs/components/openssl-fips.rb too!
+            -->
+        <SetProperty Id="FipsInstall"
+                     Value="&quot;[%WINDIR]\system32\cmd.exe&quot; /c set OPENSSL_CONF=&quot;[INSTALLDIR]\puppet\ssl\openssl.cnf.dist&quot; &amp; &quot;[INSTALLDIR]\puppet\bin\openssl.exe&quot; fipsinstall -module &quot;[INSTALLDIR]\puppet\lib\ossl-modules\fips.dll&quot; -provider_name fips -out &quot;[INSTALLDIR]\puppet\ssl\fipsmodule.cnf&quot; &amp; copy /y &quot;[INSTALLDIR]\puppet\ssl\openssl-fips.cnf&quot; &quot;[INSTALLDIR]\puppet\ssl\openssl.cnf&quot;"
+                     Before="FipsInstall"
+                     Sequence="execute" />
+        <CustomAction Id="FipsInstall"
+                      BinaryKey="WixCA"
+                      DllEntry="WixSilentExec64"
+                      Execute="deferred"
+                      Impersonate="no" />
+    <%-end-%>
     <%-end-%>
 
     <!-- Due to PUP-6729, system may not have permission to modify DACL, so first take ownership -->

--- a/resources/windows/wix/sequences.wxs.erb
+++ b/resources/windows/wix/sequences.wxs.erb
@@ -150,9 +150,14 @@
       <Custom Action='SetFromIniPuppetServerPort' Before='FileCost'>
         INI_PUPPET_SERVER_PORT AND NOT PUPPET_SERVER_PORT
       </Custom>
-       <Custom Action='EnableLongPathName' Before='InstallFiles'>
-        ENABLE_LONG_PATHS
-       </Custom>
+      <Custom Action='EnableLongPathName' Before='InstallFiles'>
+          ENABLE_LONG_PATHS
+      </Custom>
+      <%- if @platform.is_fips? -%>
+        <Custom Action='FipsInstall' After='InstallFiles'>
+          NOT REMOVE
+        </Custom>
+      <%-end %>
       <!-- Due to PUP-6729, make sure admins and system have permision to reset permissions -->
       <!-- Also resets permissions for children beneath each appdir -->
       <Custom Action='ResetDataPermissions' After='InstallFiles'>


### PR DESCRIPTION
* Include the fips.dll provider in the fips build for Windows
* Execute a deferred custom action to run `openssl fipsinstall` and update `openssl.cnf` to point to the new generated `fipsmodule.cnf`
* Set more `OPENSSL_*` environment variables to ensure we're only loading configuration and shared libraries from trusted locations.

Passed adhoc CI https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1114/

I made changes to the beaker tests after the adhoc pipeline passed and manually tested the beaker test using the previously built puppet-agent MSI [f46d202](https://github.com/puppetlabs/puppet-agent/pull/2347/commits/f46d20258e6c016ca2808243594c83968f5b4d0b)

```
❯ bx beaker exec tests/validate_vendored_openssl.rb
...
  * check openssl version
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:56$ env PATH="/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/sys/ruby/bin:${PATH}" openssl version -v
      Warning: Skipping ip method to ssh to host as its value is not set. Refer to https://github.com/puppetlabs/beaker/tree/master/docs/how_to/ssh_connection_preference.md to remove this warning
      Attempting ssh connection to willing-loyalty.delivery.puppetlabs.net, user: Administrator, opts: {:config=>false, :verify_host_key=>false, :auth_methods=>["publickey"], :port=>22, :forward_agent=>true, :keys=>["id_rsa_acceptance", "~/.ssh/id_rsa-acceptance"], :user_known_hosts_file=>"/home/josh/.ssh/known_hosts", :keepalive=>true}
verify_host_key: false is deprecated, use :never
      OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.50 seconds
  
  * check fips_enabled fact
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:56$ cmd.exe /c facter fips_enabled
      true
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.66 seconds
  
  * check openssl providers
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:57$ cygpath -m $(mktemp -td validate_vendored_openssl.XXXXXX)
      C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.22 seconds
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:57$ chmod 755 C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.16 seconds
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:57$ cmd.exe /c sc query BvSshServer
      [SC] EnumQueryServicesStatus:OpenService FAILED 1060:
      
      The specified service does not exist as an installed service.
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.14 seconds
    Exited: 36
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:57$ cmd.exe /c sc qc sshd
      [SC] QueryServiceConfig SUCCESS
      
      SERVICE_NAME: sshd
              TYPE               : 10  WIN32_OWN_PROCESS 
              START_TYPE         : 2   AUTO_START
              ERROR_CONTROL      : 1   NORMAL
              BINARY_PATH_NAME   : C:\cygwin64\bin\cygrunsrv.exe
              LOAD_ORDER_GROUP   : 
              TAG                : 0
              DISPLAY_NAME       : CYGWIN sshd
              DEPENDENCIES       : tcpip
              SERVICE_START_NAME : .\cyg_server
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.14 seconds
    localhost $ scp /tmp/beaker20230516-3049898-645m2l willing-loyalty.delivery.puppetlabs.net:C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W/list_providers.bat {:ignore => }
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:58$ cmd /c $(cygpath -w C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W/list_providers.bat)
      
      C:\cygwin64\home\Administrator>call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" C:\cygwin64\tmp\validate_vendored_openssl.oc4q3W\list_providers.bat  
      Providers:
        default
          name: OpenSSL Default Provider
          version: 3.0.8
          status: active
        fips
          name: OpenSSL FIPS Provider
          version: 3.0.0
          status: active
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.20 seconds
  
  * check fipsmodule.cnf
    localhost $ scp /tmp/beaker20230516-3049898-1rlds0s willing-loyalty.delivery.puppetlabs.net:C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W/verify_fips.bat {:ignore => }
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) 09:52:58$ cmd /c $(cygpath -w C:/cygwin64/tmp/validate_vendored_openssl.oc4q3W/verify_fips.bat)
      
      C:\cygwin64\home\Administrator>call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" C:\cygwin64\tmp\validate_vendored_openssl.oc4q3W\verify_fips.bat  
      VERIFY PASSED
    
    willing-loyalty.delivery.puppetlabs.net (willing-loyalty.delivery.puppetlabs.net) executed in 0.22 seconds
Begin teardown
End teardown
tests/validate_vendored_openssl.rb passed in 2.88 seconds
```