### PR TITLE
(maint) Prune platforms

### DIFF
--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -1,3 +1,5 @@
 platform 'osx-11-x86_64' do |plat|
   plat.inherit_from_default
+  # PA-5471 override default 'osx' directory
+  plat.output_dir File.join('apple', '11', 'puppet8', 'x86_64')
 end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -2,4 +2,6 @@ platform 'osx-12-arm64' do |plat|
   plat.inherit_from_default
   packages = %w[cmake pkg-config yaml-cpp]
   plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
+  # PA-5471 override default 'osx' directory
+  plat.output_dir File.join('apple', '12', 'puppet8', 'arm64')
 end

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -1,3 +1,5 @@
 platform 'osx-12-x86_64' do |plat|
   plat.inherit_from_default
+  # PA-5471 override default 'osx' directory
+  plat.output_dir File.join('apple', '12', 'puppet8', 'x86_64')
 end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -4,17 +4,12 @@ project: 'puppet-agent'
 foss_platforms:
   - debian-10-amd64
   - debian-11-amd64
-  - el-6-i386
-  - el-6-x86_64
   - el-7-x86_64
-  - el-7-aarch64
   - el-8-x86_64
   - el-8-ppc64le
   - el-8-aarch64
   - el-9-x86_64
   - fedora-36-x86_64
-  - osx-10.15-x86_64
-  - osx-11-arm64
   - osx-11-x86_64
   - osx-12-arm64
   - osx-12-x86_64
@@ -32,22 +27,14 @@ pe_platforms:
   - aix-7.1-power
   - redhatfips-7-x86_64
   - redhatfips-8-x86_64
-  - solaris-10-i386
-  - solaris-10-sparc
   - solaris-11-i386
   - solaris-11-sparc
   - windowsfips-2012-x64
 platform_repos:
   - name: aix-7.1-power
     repo_location: repos/aix/7.1/**/ppc
-  - name: el-6-i386
-    repo_location: repos/el/6/**/i386
-  - name: el-6-x86_64
-    repo_location: repos/el/6/**/x86_64
   - name: el-7-x86_64
     repo_location: repos/el/7/**/x86_64
-  - name: el-7-aarch64
-    repo_location: repos/el/7/**/aarch64
   - name: el-8-x86_64
     repo_location: repos/el/8/**/x86_64
   - name: el-8-ppc64le
@@ -82,26 +69,18 @@ platform_repos:
     repo_location: repos/apt/jammy
   - name: ubuntu-22.04-aarch64
     repo_location: repos/apt/jammy
-  - name: osx-10.15-x86_64
-    repo_location: repos/apple/10.15/**/x86_64/*.dmg
-  - name: osx-11-arm64
-    repo_location: repos/apple/11/**/arm64/*.dmg
   - name: osx-11-x86_64
     repo_location: repos/apple/11/**/x86_64/*.dmg
   - name: osx-12-arm64
     repo_location: repos/apple/12/**/arm64/*.dmg
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
-  - name: solaris-10-i386
-    repo_location: repos/solaris/10/**/*.i386.pkg.gz
-  - name: solaris-10-sparc
-    repo_location: repos/solaris/10/**/*.sparc.pkg.gz
   - name: solaris-11-i386
     repo_location: repos/solaris/11/**/*.i386.p5p
   - name: solaris-11-sparc
     repo_location: repos/solaris/11/**/*.sparc.p5p
 deb_targets: 'xenial-amd64 bionic-amd64 focal-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64 sles-15-x86_64'
+rpm_targets: 'el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64 sles-15-x86_64'
 sign_tar: FALSE
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -24,15 +24,15 @@ foss_platforms:
   - windows-2012-x86
   - windows-2012-x64
 pe_platforms:
-  - aix-7.1-power
+  # - aix-7.1-power PA-4719
   - redhatfips-7-x86_64
   - redhatfips-8-x86_64
-  - solaris-11-i386
-  - solaris-11-sparc
-  - windowsfips-2012-x64
+  # - solaris-11-i386 PA-4818
+  # - solaris-11-sparc PA-4818
+  # - windowsfips-2012-x64 PA-4877
 platform_repos:
-  - name: aix-7.1-power
-    repo_location: repos/aix/7.1/**/ppc
+  # - name: aix-7.1-power PA-4719
+  #   repo_location: repos/aix/7.1/**/ppc
   - name: el-7-x86_64
     repo_location: repos/el/7/**/x86_64
   - name: el-8-x86_64
@@ -75,10 +75,10 @@ platform_repos:
     repo_location: repos/apple/12/**/arm64/*.dmg
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
-  - name: solaris-11-i386
-    repo_location: repos/solaris/11/**/*.i386.p5p
-  - name: solaris-11-sparc
-    repo_location: repos/solaris/11/**/*.sparc.p5p
+  # - name: solaris-11-i386 PA-4718
+  #   repo_location: repos/solaris/11/**/*.i386.p5p
+  # - name: solaris-11-sparc PA-4718
+  #   repo_location: repos/solaris/11/**/*.sparc.p5p
 deb_targets: 'xenial-amd64 bionic-amd64 focal-amd64'
 rpm_targets: 'el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64 sles-15-x86_64'
 sign_tar: FALSE


### PR DESCRIPTION
The packaging rake task attempts to create tarball of all the signed repos using the `platform_repos` data in this repo: https://github.com/puppetlabs/packaging/blob/609cbceac5ba5d8dad7b4408c8e17d8e1e2de0a9/lib/packaging/repo.rb#L93

This fails since some platforms we're never going to support in Puppet 8 and some platforms aren't supported yet. So delete the former and comment out the latter.