### PR TITLE
(maint) Update yumrepo_core to v2.0.0

### DIFF
--- a/configs/components/module-puppetlabs-yumrepo_core.json
+++ b/configs/components/module-puppetlabs-yumrepo_core.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/v1.2.0"}
+{"url":"git@github.com:puppetlabs/puppetlabs-yumrepo_core.git","ref":"refs/tags/v2.0.0"}


### PR DESCRIPTION
This commit update the puppetlabs-yumrepo_core module from v1.2.0 to v2.0.0. This new version includes the addition of the `target` parameter.