### PR TITLE
(maint) Fix RedundantRegexpAgrument cop

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -65,7 +65,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
     # so cmd.exe was not working as expected.
     install_command = [
       "gunzip -c #{tarball_name} | tar -k -C /cygdrive/c/ -xf -",
-      "chmod 755 #{settings[:bindir].sub(/C:/, '/cygdrive/c')}/*"
+      "chmod 755 #{settings[:bindir].sub('C:', '/cygdrive/c')}/*"
     ]
   elsif platform.is_macos?
     # We can't untar into '/' because of SIP on macOS; Just copy the contents

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -18,7 +18,7 @@ component "pxp-agent" do |pkg, settings, platform|
     # so cmd.exe was not working as expected.
     install_command = [
       "gunzip -c #{tarball_name} | tar --skip-old-files -C /cygdrive/c/ -xf -",
-      "chmod 755 #{settings[:bindir].sub(/C:/, '/cygdrive/c')}/*"
+      "chmod 755 #{settings[:bindir].sub('C:', '/cygdrive/c')}/*"
     ]
   elsif platform.is_macos?
     # We can't untar into '/' because of SIP on macOS; Just copy the contents


### PR DESCRIPTION
This commit addresses issues identified by the RuboCop Style/RedundantRegexpArgument cop and changes two instances of String.sub to use 'C:' instead of /C:/.