### PR TITLE
(PA-4596) update build defaults for macos13(x86-64)

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -13,6 +13,7 @@ foss_platforms:
   - osx-11-x86_64
   - osx-12-arm64
   - osx-12-x86_64
+  - osx-13-x86_64
   - sles-12-x86_64
   - sles-15-x86_64
   - ubuntu-18.04-amd64
@@ -75,6 +76,8 @@ platform_repos:
     repo_location: repos/apple/12/**/arm64/*.dmg
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
+  - name: osx-13-x86_64
+    repo_location: repos/apple/13/**/x86_64/*.dmg
   # - name: solaris-11-i386 PA-4718
   #   repo_location: repos/solaris/11/**/*.i386.p5p
   # - name: solaris-11-sparc PA-4718


### PR DESCRIPTION
updated build defaults for macos13 intel chipset