### PR TITLE
(PA-5651) Add AIX 7.2 for Puppet 8

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -3,6 +3,7 @@ require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::CommandUtils
 
 confine :except, :platform => 'sles-12-ppc64le'
+confine :except, :platform => 'aix-7.2-power' # PA-5654
 
 def package_installer(agent)
   # for some reason, beaker does not have a configured package installer

--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.8.16"}
+{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"aa3f867d905d70673d17badaef190a0f47e66f2d"}

--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -10,10 +10,7 @@ component "puppet" do |pkg, settings, platform|
     pkg.build_requires "gettext"
   elsif platform.is_windows?
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.is_aix?
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gcc-5.2.0-11.aix#{platform.os_version}.ppc.rpm"
-    pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/aix/#{platform.os_version}/ppc/pl-gettext-0.19.8-2.aix#{platform.os_version}.ppc.rpm"
-  elsif platform.is_solaris?
+  elsif platform.is_solaris? || platform.is_aix?
     # do nothing
   else #rubocop:disable Lint/DuplicateBranch
     pkg.build_requires "gettext"
@@ -90,14 +87,12 @@ component "puppet" do |pkg, settings, platform|
     pkg.install_configfile 'puppet-agent.conf', File.join(settings[:tmpfilesdir], 'puppet-agent.conf')
   end
 
-  # We do not currently support i18n on Solaris
-  unless platform.is_solaris?
+  # We do not currently support i18n on Solaris or AIX
+  unless platform.is_solaris? || platform.is_aix?
     if platform.is_windows?
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
-    elsif platform.is_aix?
-      msgfmt = "/opt/pl-build-tools/bin/msgfmt"
     else
       msgfmt = "msgfmt"
     end

--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -1,4 +1,4 @@
-platform "aix-7.1-ppc" do |plat|
+platform "aix-7.2-ppc" do |plat|
   plat.servicetype "aix"
 
   plat.make "gmake"
@@ -9,6 +9,9 @@ platform "aix-7.1-ppc" do |plat|
   # Basic vanagon operations require mktemp, rsync, coreutils, make, tar and sed so leave this in there
   plat.provision_with "rpm -Uvh --replacepkgs http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/mktemp-1.7-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/rsync-3.0.6-1.aix5.3.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/coreutils-5.2.1-2.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/sed-4.1.1-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/make-3.80-1.aix5.1.ppc.rpm http://osmirror.delivery.puppetlabs.net/AIX_MIRROR/tar-1.22-1.aix6.1.ppc.rpm"
 
+  # lots of things expect mktemp to be installed in the usual place, so link it
+  plat.provision_with "ln -sf /opt/freeware/bin/mktemp /usr/bin/mktemp"
+
   # We use --force with rpm because the pl-gettext and pl-autoconf
   # packages conflict with a charset.alias file.
   #
@@ -16,5 +19,5 @@ platform "aix-7.1-ppc" do |plat|
   # for pl-autoconf) we'll need to force the installation
   #                                         Sean P. McD.
   plat.install_build_dependencies_with "rpm -Uvh --replacepkgs --force "
-  plat.vmpooler_template "aix-7.1-power"
+  plat.vmpooler_template "aix-7.2-power"
 end


### PR DESCRIPTION
* Since AIX 7.1 is EOL, we build on 7.2
* Disable gettext build machinery on AIX, because we [disable_i18n by default](https://github.com/puppetlabs/puppet/blob/1f413e9b044a5933a31792bc1510a7a63d69f348/lib/puppet/defaults.rb#L212) and if it's enabled, fast_gettext will default to strings in https://github.com/puppetlabs/puppet/blob/main/locales/puppet.pot
* The beaker tests for installing gems with native extensions needs to be updated to support AIX 7.2, so skip for now. Filed https://tickets.puppetlabs.com/browse/PA-5654 to fix that.

Adhoc https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1126/

Please merge https://github.com/puppetlabs/ci-job-configs/pull/9005 after this.

Due to the pxp-agent bump, I'm rebuilding in https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-suite-init_adhoc-ad_hoc/1299/