### PR TITLE
(PA-4777) Add macOS 13 (ARM) platform definition to puppet-agent

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -112,6 +112,9 @@ component "puppet" do |pkg, settings, platform|
       msgfmt = "/cygdrive/c/tools/pl-build-tools/bin/msgfmt.exe"
     elsif platform.is_macos?
       msgfmt = "/usr/local/opt/gettext/bin/msgfmt"
+      if platform.architecture == 'arm64' && platform.os_version.to_i >= 13
+        msgfmt = "/opt/homebrew/bin/msgfmt"
+      end
     elsif platform.is_aix?
       msgfmt = "/opt/pl-build-tools/bin/msgfmt"
     else

--- a/configs/platforms/osx-13-arm64.rb
+++ b/configs/platforms/osx-13-arm64.rb
@@ -1,0 +1,6 @@
+platform 'osx-13-arm64' do |plat|
+  plat.inherit_from_default
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/opt/homebrew/bin/brew install #{packages.join(' ')}'"
+  plat.output_dir File.join('apple', '13', 'puppet7', 'arm64')
+end


### PR DESCRIPTION
Adhoc pipeline https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1130/