### PR TITLE
(maint) Fix up Solaris i386 path in built_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -74,9 +74,9 @@ platform_repos:
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: solaris-11-i386
-    repo_location: repos/solaris/11/**/*.i386.p5p
+    repo_location: repos/solaris/11/*/*/*i386.p5p
   # - name: solaris-11-sparc PA-4718
-  #   repo_location: repos/solaris/11/**/*.sparc.p5p
+  #   repo_location: repos/solaris/11/*/*/*sparc.p5p
 deb_targets: 'xenial-amd64 bionic-amd64 focal-amd64 jammy-amd64'
 rpm_targets: 'el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64 sles-15-x86_64'
 sign_tar: FALSE


### PR DESCRIPTION
When we introduced https://github.com/puppetlabs/puppet-agent/commit/d62958d804e7208b2e536280a972113fa45303c0 it looks like it caused some breakage in the shipping of the  agent. This attempts to fix the path. 
