### PR TITLE
(maint) Update resource_api component

### DIFF
--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"aa3f867d905d70673d17badaef190a0f47e66f2d"}
+{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.8.18"}


### PR DESCRIPTION
This commit updates the puppet-resource_api component to the latest release, 1.8.18, which includes fixes for Ruby 3.2 (see PA-5641).

This change was already completed in 7.x with 9bfac06.