### PR TITLE
(maint) Legacy cleanup

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -2,7 +2,6 @@ require 'puppet/acceptance/common_utils.rb'
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::CommandUtils
 
-confine :except, :platform => 'sles-12-ppc64le'
 confine :except, :platform => 'aix-7.2-power' # PA-5654
 confine :except, :platform => 'solaris-11.4-i386' # PA-5665
 

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -29,7 +29,7 @@ def setup_build_environment(agent)
   # We add `--enable-system-libraries` to use system libsqlite3
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-  on(agent, "#{gem_command(agent)} update --system 3.3.26")
+  on(agent, "#{gem_command(agent)} update --system")
 
   case agent['platform']
   when /aix/
@@ -191,13 +191,11 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
     end
   end
 
-  # Rubygems >= 3.4.0 drops compatibility with Ruby 2.5, which puppet-agent 6.x uses.
-  # We use Rubygems 3.3.26, the last release before then.
   step "'gem update --system' keeps vendor_gems still in path" do
     agents_to_skip = select_hosts({:platform => [/windows/, /cisco/, /eos/, /cumulus/]}, agents)
     agents_to_test = agents - agents_to_skip
     agents_to_test.each do |agent|
-      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system 3.3.26")
+      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system")
       list_env = on(agent, "/opt/puppetlabs/puppet/bin/gem env").stdout.chomp
       unless list_env.include?("/opt/puppetlabs/puppet/lib/ruby/vendor_gems")
         fail_test("Failed to keep vendor_gems directory in GEM_PATH!")

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -17,14 +17,8 @@ component 'puppet-runtime' do |pkg, settings, platform|
   # to build with on these platforms:
   if platform.is_cross_compiled?
     if platform.is_solaris?
-      case platform.os_version
-      when "11"
-        pkg.build_requires 'pl-ruby'
-      when "10"
-        # ruby20 installed from OpenCSW in solaris-10-sparc platform definition
-      else
-        raise "Unknown solaris os_version: #{platform.os_version}"
-      end
+      raise "Unknown solaris os_version: #{platform.os_version}" unless platform.os_version == '11'
+      pkg.build_requires 'pl-ruby'
     elsif platform.is_linux?
       pkg.build_requires 'pl-ruby'
     elsif platform.is_macos?


### PR DESCRIPTION
This PR comprises cleanup related to operating systems no longer supported in Puppet 8 and a workaround for the now-EOL Puppet 6.