### PR TITLE
(PA-4596) add macos-13-x86_64 to build defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -16,6 +16,7 @@ foss_platforms:
   - osx-12-arm64
   - osx-13-arm64
   - osx-12-x86_64
+  - osx-13-x86_64
   - sles-12-x86_64
   - sles-15-x86_64
   - ubuntu-18.04-amd64
@@ -76,6 +77,8 @@ platform_repos:
     repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: osx-13-arm64
     repo_location: repos/apple/13/**/arm64/*.dmg
+  - name: osx-13-x86_64
+    repo_location: repos/apple/13/**/x86_64/*.dmg
   - name: solaris-11-i386
     repo_location: repos/solaris/11/*/*/*i386.p5p
   # - name: solaris-11-sparc PA-4718


### PR DESCRIPTION
build defaults updated for macos-13 intel

NOTE : DO NOT MERGE UNTIL BUILD_TARGETS are merged