### PR TITLE
(PA-5702) Override default output dir for Solaris 11

### DIFF
--- a/configs/platforms/solaris-11-i386.rb
+++ b/configs/platforms/solaris-11-i386.rb
@@ -5,4 +5,6 @@ platform "solaris-11-i386" do |plat|
   plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
+  # PA-5702 override default directory to exclude 'i386' directory
+  plat.output_dir File.join("solaris", "11", "puppet8")
 end

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -6,4 +6,6 @@ platform "solaris-11-sparc" do |plat|
   plat.vmpooler_template "solaris-11-x86_64"
   plat.add_build_repository 'http://solaris-11-reposync.delivery.puppetlabs.net:81', 'puppetlabs.com'
   plat.install_build_dependencies_with "pkg install ", " || [[ $? -eq 4 ]]"
+  # PA-5702 override default directory to exclude 'sparc' directory
+  plat.output_dir File.join("solaris", "11", "puppet8")
 end


### PR DESCRIPTION
This commit adds the output_dir command to both Solaris 11 platform templates to override the default output directory. Without this change, an extra directory for the architecture is used, i.e. /solaris/11/puppet8/ i386/ instead of /solaris/11/puppet8