### PR TITLE
(PA-5656) Override gem commands for Solaris 11 SPARC

### DIFF
--- a/configs/projects/puppet-agent.rb
+++ b/configs/projects/puppet-agent.rb
@@ -35,6 +35,14 @@ project "puppet-agent" do |proj|
     proj.package_override("# Disable the removal of la files, they are still required\n%global __brp_remove_la_files %{nil}")
   end
 
+  # Override gem related commands since runtime was natively compiled, but we're
+  # cross compiling this project.
+  if platform.name == 'solaris-11-sparc'
+    proj.setting(:host_ruby, '/opt/pl-build-tools/bin/ruby')
+    proj.setting(:host_gem, '/opt/pl-build-tools/bin/gem')
+    proj.setting(:gem_install, '/opt/pl-build-tools/bin/gem install --no-rdoc --no-ri --local ')
+  end
+
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Puppet Inc")


### PR DESCRIPTION
We natively compile puppet-runtime and pxp-agent-vanagon on Solaris 11 SPARC, because we were not able to install a new enough gcc on x86_64 to cross compile.

However, we only have 2 Solaris 11 SPARC hosts and we don't need gcc to build puppet-agent. We just need a runnable ruby to execute `gem install` and `ruby install.rb`. The latter is used when installing puppet and facter components.

So override the `host_ruby`, etc settings that are inherited from puppet-runtime to point to pl-build-tools ruby. As a result we're "cross-building" puppet-agent#main on Solaris 11 SPARC, just like we're doing in 7.x.

- [x] [Adhoc run](https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1164/)

Note we only run facter tests on `solaris-*-SPARC` due to this combination filter https://github.com/puppetlabs/ci-job-configs/blob/11830ab1410a9dec347c052a3091e991bfd2b8dc/resources/scripts/puppet-agent-composite-filter.txt#L8-L9

Please merge https://github.com/puppetlabs/ci-job-configs/pull/9068 after this