### PR TITLE
(PA-5663) Add Solaris 11 SPARC to ext/build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -81,8 +81,8 @@ platform_repos:
     repo_location: repos/apple/13/**/x86_64/*.dmg
   - name: solaris-11-i386
     repo_location: repos/solaris/11/**/*.i386.p5p
-  # - name: solaris-11-sparc PA-4718
-  #   repo_location: repos/solaris/11/**/*.sparc.p5p
+  - name: solaris-11-sparc
+    repo_location: repos/solaris/11/**/*.sparc.p5p
 deb_targets: 'xenial-amd64 bionic-amd64 focal-amd64 jammy-amd64'
 rpm_targets: 'el-7-x86_64 el-8-x86_64 el-9-x86_64 redhatfips-7-x86_64 redhatfips-8-x86_64 sles-12-x86_64 sles-15-x86_64'
 sign_tar: FALSE


### PR DESCRIPTION
This causes the solaris11-sparc puppet-agent package to be included in puppet-agent-all.tar.gz which is shipped to:

    http://agent-downloads.delivery.puppetlabs.net/<PE VER>/puppet-agent/8.X.X.X/puppet-agent-all.tar.gz