### PR TITLE
(CAT-761) Update puppet-resource_api version

### DIFF
--- a/configs/components/puppet-resource_api.json
+++ b/configs/components/puppet-resource_api.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.8.18"}
+{"url":"git@github.com:puppetlabs/puppet-resource_api.git","ref":"refs/tags/1.9.0"}


### PR DESCRIPTION
This PR backports the resource_api bump made in https://github.com/puppetlabs/puppet-agent/pull/2383