### PR TITLE
(maint) point release package to root of yum.p.c

### DIFF
--- a/ext/smoke/repos/steps/setup-masters.sh
+++ b/ext/smoke/repos/steps/setup-masters.sh
@@ -43,7 +43,7 @@ echo "STEP: Install puppetserver and puppet-agent on both masters"
 
 for master_vm in ${master_vm1} ${master_vm2}; do
   which_master=`identify_master ${master_vm}`
-  on_master ${master_vm} "rpm -Uvh http://yum.puppetlabs.com/${collection}/${collection}-release-el-7.noarch.rpm --force"
+  on_master ${master_vm} "rpm -Uvh http://yum.puppetlabs.com/${collection}-release-el-7.noarch.rpm --force"
 
   echo "STEP: Install puppet-agent on ${which_master}"
   on_master ${master_vm} "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"

--- a/ext/smoke/steps/setup-agent.sh
+++ b/ext/smoke/steps/setup-agent.sh
@@ -56,7 +56,7 @@ echo "STEP: Install the puppet-agent package"
 master_ip=`on_master "facter ipaddress" | tail -n 1`
 on_agent "echo ${master_ip} puppet >> /etc/hosts"
 if [[ "${type}" = "repo" ]]; then
-  on_agent "rpm -Uvh http://yum.puppetlabs.com/${collection}/${collection}-release-el-7.noarch.rpm --force"
+  on_agent "rpm -Uvh http://yum.puppetlabs.com/${collection}-release-el-7.noarch.rpm --force"
   on_agent "rpm --quiet --query puppet-agent-${agent_version} || yum install -y puppet-agent-${agent_version}"
 elif [[ "${type}" = "package" ]]; then
   on_agent "curl -f -O http://builds.delivery.puppetlabs.net/puppet-agent/${agent_version}/artifacts/el/7/${collection}/x86_64/puppet-agent-${agent_version}-1.el7.x86_64.rpm"


### PR DESCRIPTION
We no longer maintain release packages in the puppetN subdirectories.
Update smoke tests to toplevel location.