### PR TITLE
(PUP-11939) Don't manage firewall in smoke test

### DIFF
--- a/ext/smoke/helpers.sh
+++ b/ext/smoke/helpers.sh
@@ -117,7 +117,9 @@ function install_puppetdb_from_module() {
     class { 'puppetdb::globals':
     version => '${puppetdb_version}'
     }
-  include puppetdb
+  class { 'puppetdb':
+    manage_firewall => false
+  }
   include puppetdb::master::config
   }
   node default {


### PR DESCRIPTION
The latest release of puppetlabs-puppetdb depends on a version of firewall that doesn't support puppet8.

I intentionally didn't target 7.x, because it's only an issue with puppet8 and the puppetdb/firewall modules.

There are two 2 smoke tests described in https://github.com/puppetlabs/puppet-agent/tree/main/ext/smoke#overview

- [x] install from packages
`./packages/run-smoke-test.sh suave-easement.delivery.puppetlabs.net retentive-creed.delivery.puppetlabs.net  8.2.0 8.2.1 8.1.0`
- [x] install from shared repository
`./repos/run-smoke-test.sh coy-pageantry.delivery.puppetlabs.net tart-breeze.delivery.puppetlabs.net astral-roomful.delivery.puppetlabs.net faulty-repeater.delivery.puppetlabs.net 8.2.0 8.2.1 8.1.0`