### PR TITLE
(PA-5002) Add Red Hat 9 (ARM64) platform definition to puppet-agent#7.x

### DIFF
--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -1,0 +1,11 @@
+platform "el-9-aarch64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  packages = %w(gcc-c++ rsync make rpm-libs rpm-build)
+
+  plat.provision_with "dnf install -y --allowerasing #{packages.join(' ')}"
+  plat.install_build_dependencies_with "dnf install -y --allowerasing "
+  plat.vmpooler_template "redhat-9-arm64"
+end


### PR DESCRIPTION
puppet-agent build: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2341/