### PR TITLE
(maint) Update beaker-hostgenerator version

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,7 +14,7 @@ end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")


### PR DESCRIPTION
beaker-hostgenerator released 2.0 earlier this year, and since that release all new platforms, features, and fixes have been going into 2.x releases.

This commit updates the acceptance Gemfile to depend on beaker-hostgenerator ~> 2 instead of ~> 1.1.