### PR TITLE
(PA-5632) Set SELinux test to high

### DIFF
--- a/acceptance/tests/selinux.rb
+++ b/acceptance/tests/selinux.rb
@@ -1,6 +1,6 @@
 test_name 'PA-3067: Manage selinux' do
 
-  tag 'audit:low',
+  tag 'audit:high',
       'audit:acceptance'
 
   confine :to, :platform => /el-|fedora-|debian-|ubuntu-/

--- a/acceptance/tests/selinux.rb
+++ b/acceptance/tests/selinux.rb
@@ -4,7 +4,7 @@ test_name 'PA-3067: Manage selinux' do
       'audit:acceptance'
 
   confine :to, :platform => /el-|fedora-|debian-|ubuntu-/
-  confine :except, :platform => /ubuntu-.*-ppc64el|ubuntu-14|el-6/
+  confine :except, :platform => /el-6/
 
   require 'puppet/acceptance/common_utils'
 


### PR DESCRIPTION
Prior to this PR, the SELinux acceptance test was set to low priority, causing the test to be skipped.

However, we've seen multiple regressions on SELinux behavior in puppet-agent, so we should always run this test to catch them early.

This PR updates the SELinux acceptance test to high priority, ensuring that it's always run.
