### PR TITLE
(PA-5802) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,7 +18,7 @@ jobs:
         check: [ 'rubocop', 'commits' ]
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Ruby version 2.7

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Mend Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.