### PR TITLE
Add Debian 11 (ARM) platform definition to puppet-agent#7.x

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,0 +1,3 @@
+platform "debian-11-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
[vanagon-generic-builder_vanagon](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=debian-11-aarch64,SLAVE_LABEL=k8s-worker/2398/console)

[puppet-agent_7.26.0.62.g7f8069ff2-1bullseye_arm64.deb](https://builds.delivery.puppetlabs.net/puppet-agent/7f8069ff2d52fd60f9250ea84a1333e640ae7b22/artifacts/deb/bullseye/puppet7/puppet-agent_7.26.0.62.g7f8069ff2-1bullseye_arm64.deb)


