### PR TITLE
(PA-5743) Add debian-11 AARCH 64 platform definition file

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,0 +1,3 @@
+platform "debian-11-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
The build using vanagon generic builder is available at: https://builds.delivery.puppetlabs.net/puppet-agent/ccc3f45d4269c93b7fe5d6b619cf4f754620aac0/artifacts/?C=M&O=D