### PR TITLE
(PA-4611) Update build_defaults.yaml to enable Debian 11 (ARM)

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,6 +6,7 @@ project: 'puppet-agent'
 foss_platforms:
   - debian-10-amd64
   - debian-11-amd64
+  - debian-11-aarch64
   - el-7-x86_64
   - el-8-x86_64
   - el-8-ppc64le
@@ -59,6 +60,8 @@ platform_repos:
   - name: debian-10-amd64
     repo_location: repos/apt/buster
   - name: debian-11-amd64
+    repo_location: repos/apt/bullseye
+  - name: debian-11-aarch64
     repo_location: repos/apt/bullseye
   - name: ubuntu-18.04-amd64
     repo_location: repos/apt/bionic


### PR DESCRIPTION
Update build_defaults.yaml to enable Debian 11 (ARM) for internal nightlies ship