### PR TITLE
(PA-5786) Use postinstall_required_action for fips

### DIFF
--- a/configs/components/openssl-fips.rb
+++ b/configs/components/openssl-fips.rb
@@ -73,7 +73,7 @@ component "openssl-fips" do |pkg, settings, platform|
   #
   if platform.is_rpm?
     # If you modify the following code, update customactions.wxs.erb too!
-    pkg.add_postinstall_action ["install", "upgrade"],
+    pkg.add_postinstall_required_action ["install", "upgrade"],
       [<<-HERE.undent
         OPENSSL_CONF=/opt/puppetlabs/puppet/ssl/openssl.cnf.dist /opt/puppetlabs/puppet/bin/openssl fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -out /opt/puppetlabs/puppet/ssl/fipsmodule.cnf
         /usr/bin/cp --preserve /opt/puppetlabs/puppet/ssl/openssl-fips.cnf /opt/puppetlabs/puppet/ssl/openssl.cnf


### PR DESCRIPTION
`#add_postinstall_action` puts scriptlets in the `%posttrans` section of an rpm spec file. This action must complete before restarting puppet, so prefer the `#add_postinstall_required_action` from vanagon to ensure it completes before restarting puppet.