### PR TITLE
(PA-5932) Add name to Jira workflow

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,3 +1,6 @@
+---
+name: Export issue to Jira
+
 on:
   issues:
     types: [labeled]


### PR DESCRIPTION
This commit adds a friendly name to the GitHub Actions workflow that exports GitHub issues to Jira.