### PR TITLE
PA-5572: Update build defaults yaml to enable amazon linux 2023 for internal nightlies for 7.x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,6 +2,8 @@
 project: 'puppet-agent'
 # foss_platforms will be shipped to the nightly repos
 foss_platforms:
+  - amazon-2023-x86_64
+  - amazon-2023-aarch64
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64
@@ -42,6 +44,10 @@ pe_platforms:
 platform_repos:
   - name: aix-7.1-power
     repo_location: repos/aix/7.1/**/ppc
+  - name: amazon-2023-x86_64
+    repo_location: repos/amazon/2023/**/x86_64
+  - name: amazon-2023-aarch64
+    repo_location: repos/amazon/2023/**/aarch64
   - name: el-6-i386
     repo_location: repos/el/6/**/i386
   - name: el-6-x86_64


### PR DESCRIPTION
Updated build defaults YAML to enable Amazon Linux 2023 for Internal Nightlies for 7.x branch