### PR TITLE
(PA-5881) Add macOS 14 (Intel) platform definition to puppet-agent-main

### DIFF
--- a/configs/platforms/osx-14-x86_64.rb
+++ b/configs/platforms/osx-14-x86_64.rb
@@ -1,0 +1,4 @@
+platform 'osx-14-x86_64' do |plat|
+  plat.inherit_from_default
+  plat.output_dir File.join('apple', '14', 'puppet8', 'x86_64')
+end


### PR DESCRIPTION
Build: [2524](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=osx-14-x86_64,SLAVE_LABEL=k8s-worker/2524/console)

artifact: [c8cd808b4cdbedf9346a69002607c9482845657a](http://builds.delivery.puppetlabs.net/puppet-agent/c8cd808b4cdbedf9346a69002607c9482845657a/artifacts/?C=M&O=D)