### PR TITLE
(PA-5882) Add macOS 14 (Intel) platform definition to puppet-agent-7.x

### DIFF
--- a/configs/platforms/osx-14-x86_64.rb
+++ b/configs/platforms/osx-14-x86_64.rb
@@ -1,0 +1,4 @@
+platform 'osx-14-x86_64' do |plat|
+  plat.inherit_from_default
+  plat.output_dir File.join('apple', '14', 'puppet7', 'x86_64')
+end


### PR DESCRIPTION
[build](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=osx-14-x86_64,SLAVE_LABEL=k8s-worker/2525/console)

[Artifact](http://builds.delivery.puppetlabs.net/puppet-agent/903ceea7ef242cb8508b56562636d08d390c27a5/artifacts/?C=M&O=D)