### PR TITLE
(maint) Bump scheduled_task module

### DIFF
--- a/configs/components/module-puppetlabs-scheduled_task.json
+++ b/configs/components/module-puppetlabs-scheduled_task.json
@@ -1,1 +1,1 @@
-{"url":"git@github.com:puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/v3.1.1"}
+{"url":"git@github.com:puppetlabs/puppetlabs-scheduled_task.git","ref":"refs/tags/v3.2.0"}


### PR DESCRIPTION
This commit bumps the scheduled_task module from 3.1.1 to 3.2.0. The primary change is managing the description field for a scheduled task.