### PR TITLE
(PA-5907) Add macOS 14 (ARM) platform definition to puppet-agent-main

### DIFF
--- a/configs/platforms/osx-14-arm64.rb
+++ b/configs/platforms/osx-14-arm64.rb
@@ -1,0 +1,6 @@
+platform 'osx-14-arm64' do |plat|
+  plat.inherit_from_default
+  packages = %w[cmake pkg-config yaml-cpp]
+  plat.provision_with "su test -c '/opt/homebrew/bin/brew install #{packages.join(' ')}'"
+  plat.output_dir File.join('apple', '14', 'puppet8', 'arm64')
+end


### PR DESCRIPTION
Vanagon generic build: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1348/
Artifacts: https://builds.delivery.puppetlabs.net/puppet-agent/10a0673747bca7fbdc20f10915a23e15271d9597/artifacts/apple/14/puppet8/arm64/