### PR TITLE
Pin rubygems-update for Ruby 2.7

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,6 +27,6 @@ jobs:
           ruby-version: 2.7
       - name: Update rubygems and install gems
         run: |
-          gem update --system --silent --no-document
+          gem update --system 3.4.22 --silent --no-document
           bundle install --jobs 4 --retry 3
       - run: bundle exec rake ${{ matrix.check }}

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -27,7 +27,7 @@ def setup_build_environment(agent)
   # We add `--enable-system-libraries` to use system libsqlite3
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-  on(agent, "#{gem_command(agent)} update --system")
+  on(agent, "#{gem_command(agent)} update --system 3.4.22")
 
   case agent['platform']
   when /aix/
@@ -189,11 +189,14 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
     end
   end
 
+  # rubygems-update >= 3.5.0 drops compatibility with Ruby 2.7, which
+  # puppet-agent 7.x uses. We pin to the last version that supports Ruby 2.7,
+  # rubygems-update 3.4.22.
   step "'gem update --system' keeps vendor_gems still in path" do
     agents_to_skip = select_hosts({:platform => [/windows/, /cisco/, /eos/, /cumulus/]}, agents)
     agents_to_test = agents - agents_to_skip
     agents_to_test.each do |agent|
-      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system")
+      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system 3.4.22")
       list_env = on(agent, "/opt/puppetlabs/puppet/bin/gem env").stdout.chomp
       unless list_env.include?("/opt/puppetlabs/puppet/lib/ruby/vendor_gems")
         fail_test("Failed to keep vendor_gems directory in GEM_PATH!")


### PR DESCRIPTION
When Rubygems attempts to run `gem update --system` under Ruby 2.7, it errors when pulling in rubygems-update >= 3.5.0, which drops support for Ruby < 3.0.

This commit pins rubygems-update to 3.4.22, the last version that supports Ruby 2.7.