### PR TITLE
Update Ruby version in checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Ruby version 2.7
+      - name: Install Ruby version 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
       - name: Update rubygems and install gems
         run: |
           gem update --system --silent --no-document


### PR DESCRIPTION
Prior to this commit, the checks GitHub Action was running on Ruby 2.7. This version of Ruby went end-of-life in early 2023 and libraries (such as rubygems-update) have started to drop support, causing errors with the action.

This commits that Ruby version to 3.2 to match what we're using in puppet-agent main/8.x.