### PR TITLE
Use older rubygems-update on AIX 7.2

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -21,7 +21,8 @@ def setup_build_environment(agent)
   # We add `--enable-system-libraries` to use system libsqlite3
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-  on(agent, "#{gem_command(agent)} update --system")
+  rubygems_version = agent['platform'] =~ /aix-7\.2/ ? '3.4.22' : ''
+  on(agent, "#{gem_command(agent)} update --system #{rubygems_version}")
 
   case agent['platform']
   when /aix/
@@ -155,7 +156,8 @@ test_name 'PA-1319: Validate that the vendored ruby can load gems and is configu
     agents_to_skip = select_hosts({:platform => [/windows/, /cisco/, /eos/, /cumulus/]}, agents)
     agents_to_test = agents - agents_to_skip
     agents_to_test.each do |agent|
-      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system")
+      rubygems_version = agent['platform'] =~ /aix-7\.2/ ? '3.4.22' : ''
+      on(agent, "/opt/puppetlabs/puppet/bin/gem update --system #{rubygems_version}")
       list_env = on(agent, "/opt/puppetlabs/puppet/bin/gem env").stdout.chomp
       unless list_env.include?("/opt/puppetlabs/puppet/lib/ruby/vendor_gems")
         fail_test("Failed to keep vendor_gems directory in GEM_PATH!")


### PR DESCRIPTION
The validate_vendored_ruby test started failing on AIX 7.2 when loading the
gemspecs from artifactory:

    # /opt/puppetlabs/puppet/bin/gem update --system -V
    GET https://rubygems.org/specs.4.8.gz
    304 Not Modified
    GET https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/specs.4.8.gz
    304 Not Modified
    [FATAL] failed to allocate memory

It appears the new behavior is triggered when using the new safe marshall code
introduced in rubygems-update[1]:

    # truss -f -i -t kopen /opt/puppetlabs/puppet/bin/gem update --system
    ...
    10813880: 11338039: kopen("/root/.local/share/gem/specs/rubygems.org%443/specs.4.8", 0440000002) = 9
    10813880: 11338039: kopen("/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0/rubygems/safe_marshal.rb", 0440000004) = 9
    ...
    10813880: 11338039: kopen("/root/.local/share/gem/specs/artifactory.delivery.puppetlabs.net%443/artifactory/api/gems/rubygems/specs.4.8", 0440000004) = 10
    [FATAL] failed to allocate memory

Pin back to an older rubygems-update on AIX 7.2.

[1] https://github.com/rubygems/rubygems/pull/6896