### PR TITLE
Pin sqlite3 rubygem to 1.6.9

### DIFF
--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -25,7 +25,8 @@ def setup_build_environment(agent)
 
   # The sqlite3 gem >= 1.5.0 bundles libsqlite3, which breaks some tests
   # We add `--enable-system-libraries` to use system libsqlite3
-  gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
+  # Pin to 1.6.9 which was the last version to support "native gem support for 2.7"
+  gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -v 1.6.9 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
   on(agent, "#{gem_command(agent)} update --system 3.4.22")
 


### PR DESCRIPTION
The test started failing on RHEL8 ARM with:

    $ env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems env PATH="/opt/puppetlabs/puppet/bin:${PATH}" gem install sqlite3 -v 1.7.0 -- --enable-system-libraries
      ERROR:  Error installing sqlite3:
      	The last version of sqlite3 (= 1.7.0) to support your Ruby & RubyGems was 1.7.0. Try installing it with `gem install sqlite3 -v 1.7.0` and then running the current command again
      	sqlite3 requires Ruby version >= 3.0, < 3.4.dev. The current ruby version is 2.7.8.225.

The sqlite3 gem dropped "native gem support for 2.7" in 1.7.0. So pin to the version just prior to that.