### PR TITLE
Update stdout and stderr methods

### DIFF
--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -90,20 +90,18 @@ end
 
 step 'test configprint outputs'
 agents.each do |agent|
-  on(agent, puppet_agent('--configprint all')) do
-    output = stdout
+  on(agent, puppet_agent('--configprint all')) do |result|
     config_options(agent).select {|v| !v[:not_puppet_config] }.each do |config_option|
-      assert_match("#{config_option[:name]} = #{config_option[:expected]}", output)
+      assert_match("#{config_option[:name]} = #{config_option[:expected]}", result.stdout)
     end
   end
 end
 
 step 'test puppet genconfig entries'
 agents.each do |agent|
-  on(agent, puppet_agent('--genconfig')) do
-    output = stdout
+  on(agent, puppet_agent('--genconfig')) do |result|
     config_options(agent).select {|v| !v[:not_puppet_config] }.each do |config_option|
-      assert_match("#{config_option[:name]} = #{config_option[:expected]}", output)
+      assert_match("#{config_option[:name]} = #{config_option[:expected]}", result.stdout)
     end
   end
 end

--- a/acceptance/tests/ensure_puppet-agent_paths.rb
+++ b/acceptance/tests/ensure_puppet-agent_paths.rb
@@ -18,11 +18,7 @@ def config_options(agent)
   platform = agent[:platform]
   case platform
   when /windows/
-    if platform =~ /2003/
-      common_app_data = 'C:/Documents and Settings/All Users/Application Data'
-    else
-      common_app_data = 'C:/ProgramData'
-    end
+    common_app_data = 'C:/ProgramData'
     puppetlabs_data = "#{common_app_data}/PuppetLabs"
 
     codedir = "#{puppetlabs_data}/code"

--- a/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
+++ b/acceptance/tests/ensure_puppet_facts_can_use_facter.rb
@@ -4,19 +4,19 @@ test_name 'Ensure puppet facts can use facter' do
 
   agents.each do |agent|
     step 'test puppet facts with correct facter version' do
-      on agent, puppet('facts'), :acceptable_exit_codes => [0] do
-        facter_major_version =  Integer(JSON.parse(stdout)["facterversion"].split('.').first)
+      on(agent, puppet('facts'), :acceptable_exit_codes => [0]) do |result|
+        facter_major_version =  Integer(JSON.parse(result.stdout)["facterversion"].split('.').first)
         assert(4 >= facter_major_version, "wrong facter version")
       end
     end
 
     step "test puppet facts with facter has all the dependencies installed" do
-      on agent, puppet('facts --debug'), :acceptable_exit_codes => [0] do
+      on(agent, puppet('facts --debug'), :acceptable_exit_codes => [0]) do |result|
         if agent['platform'] =~ /win/
           # exclude augeas as it is not provided on Windows
-          unresolved_fact = stdout.match(/(resolving fact (?!augeas).+\, but)/)
+          unresolved_fact = result.stdout.match(/(resolving fact (?!augeas).+\, but)/)
         else
-          unresolved_fact = stdout.match(/(resolving fact .+\, but)/)
+          unresolved_fact = result.stdout.match(/(resolving fact .+\, but)/)
         end
 
         assert_nil(unresolved_fact, "missing dependency for facter from: #{unresolved_fact.inspect}")
@@ -24,8 +24,8 @@ test_name 'Ensure puppet facts can use facter' do
     end
 
     step "test that stderr is empty on puppet facts'" do
-      on agent, puppet('facts'), :acceptable_exit_codes => [0] do
-        assert_empty(stderr, "Expected `puppet facts` stderr to be empty")
+      on(agent, puppet('facts'), :acceptable_exit_codes => [0]) do |result|
+        assert_empty(result.stderr, "Expected `puppet facts` stderr to be empty")
       end
     end
   end

--- a/acceptance/tests/test_manpage_clobber.rb
+++ b/acceptance/tests/test_manpage_clobber.rb
@@ -10,20 +10,20 @@ test_name 'PA-2768: Extend manpath instead of overriding it' do
   agents.each do |agent|
     man_command = nil
 
-    step "test for man command" do
-      on agent, "command -v man", :acceptable_exit_codes => [0, 1] do
-        man_command = stdout.chomp
+    step 'test for man command' do
+      on(agent, 'command -v man', :acceptable_exit_codes => [0, 1]) do |result|
+        man_command = result.stdout.chomp
       end
     end
 
     skip_test "man command not found on #{agent.hostname} (#{agent.platform})" unless man_command
 
-    step "test if we have puppet manpages" do
-      on agent, "#{man_command} puppet"
+    step 'test if we have puppet manpages' do
+      on(agent, "#{man_command} puppet")
     end
 
-    step "test if we have unix manpages" do
-      on agent, "#{man_command} ls"
+    step 'test if we have unix manpages' do
+      on(agent, "#{man_command} ls")
     end
   end
 end

--- a/acceptance/tests/windows_eventlog.rb
+++ b/acceptance/tests/windows_eventlog.rb
@@ -24,12 +24,12 @@ agents.each do |agent|
   # generate an error, no master on windows boxes
   # we use `agent` because it creates an eventlog log destination by default,
   # whereas `apply` does not.
-  on agent, puppet('agent', '--server', '127.0.0.1', '--test'), :acceptable_exit_codes => [1]
+  on(agent, puppet('agent', '--server', '127.0.0.1', '--test'), :acceptable_exit_codes => [1])
 
   # make sure there's a Puppet error message in the log
   # cygwin + ssh + wmic hangs trying to read stdin, so echo '' |
-  on agent, "cmd /c echo '' | wmic ntevent where \"LogFile='Application' and SourceName='Puppet' and TimeWritten >= '#{now}'\"  get Message,Type /format:csv" do
+  on(agent, "cmd /c echo '' | wmic ntevent where \"LogFile='Application' and SourceName='Puppet' and TimeWritten >= '#{now}'\"  get Message,Type /format:csv") do |result|
     fail_test "Event not found in Application event log" unless
-      stdout.include?('target machine actively refused it. - connect(2) for "127.0.0.1"')
+      result.stdout.include?('target machine actively refused it. - connect(2) for "127.0.0.1"')
   end
 end


### PR DESCRIPTION
Previously in Beaker, you could use standalone stdout and stderr methods to access output from remote machines.

These methods were deprecated in 2013 with https://github.com/voxpupuli/beaker/commit/28b2510 and dropped entirely in https://github.com/voxpupuli/beaker/commit/73a31c7.

This commit removes these updates from puppet-agent tests in favor of calling stdout and stderr methods on Result objects.