### PR TITLE
(PA-5761x) Update build_defaults.yaml to enable Debian 12 (ARM) for i…

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -7,6 +7,7 @@ foss_platforms:
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64
+  - debian-12-aarch64
   - el-6-i386
   - el-6-x86_64
   - el-7-x86_64
@@ -82,6 +83,8 @@ platform_repos:
     repo_location: repos/apt/bullseye
   - name: debian-11-aarch64
     repo_location: repos/apt/bullseye
+  - name: debian-12-aarch64
+    repo_location: repos/apt/bookworm
   - name: ubuntu-18.04-amd64
     repo_location: repos/apt/bionic
   - name: ubuntu-18.04-aarch64


### PR DESCRIPTION
…nternal nightlies ship 7.x