### PR TITLE
(PA-6004) Add SLES-11 (Intel) support

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -27,7 +27,7 @@ component "pxp-agent" do |pkg, settings, platform|
       "tar -xzf #{tarball_name}",
       "for d in opt var private; do rsync -ka --ignore-existing \"$${d}/\" \"/$${d}/\"; done"
     ]
-  elsif platform.is_aix? || platform.is_solaris?
+  elsif platform.is_aix? || platform.is_solaris? || platform.name =~ /sles-11-x86_64/
     install_command = ["gunzip -c #{tarball_name} | #{platform.tar} -C / -xf -"]
   else
     install_command = ["gunzip -c #{tarball_name} | #{platform.tar} --skip-old-files -C / -xf -"]

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -1,0 +1,9 @@
+platform "sles-11-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+  packages = ["make", "rsync"]
+  plat.provision_with "zypper -n --no-gpg-checks install -y #{packages.join(' ')}"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-11-x86_64"
+end


### PR DESCRIPTION
 - Add SLES-11 (Intel) definition file
 - Since tar command on the SLES-11 VM doesn't understand --skip-old-files option due to it being an older version, do not use that option while installing puppet-runtime (pxp-agent.rb)