### PR TITLE
Use F36 repos instead of rawhide

### DIFF
--- a/configs/platforms/fedora-36-x86_64.rb
+++ b/configs/platforms/fedora-36-x86_64.rb
@@ -1,22 +1,6 @@
 platform 'fedora-36-x86_64' do |plat|
-  plat.servicedir '/usr/lib/systemd/system'
-  plat.defaultdir '/etc/sysconfig'
-  plat.servicetype 'systemd'
-  plat.dist 'fc36'
+  plat.inherit_from_default
 
-  # There's an issue with the version of binutils (2.37) in Fedora 36's repos
-  # We temporarily use a newer version from rawhide. See PA-4448
-  plat.provision_with('/usr/bin/dnf install -y fedora-repos-rawhide')
-  plat.provision_with('/usr/bin/dnf install -y --enablerepo rawhide binutils')
-
-  packages = %w[
-    autoconf automake bzip2-devel gcc gcc-c++ libselinux-devel
-    libsepol libsepol-devel make cmake pkgconfig readline-devel
-    rpmdevtools rsync swig zlib-devel systemtap-sdt-devel
-    perl-lib perl-FindBin
-  ]
+  packages = %w[binutils]
   plat.provision_with("/usr/bin/dnf install -y --best --allowerasing #{packages.join(' ')}")
-
-  plat.install_build_dependencies_with '/usr/bin/dnf install -y --best --allowerasing'
-  plat.vmpooler_template 'fedora-36-x86_64'
 end


### PR DESCRIPTION
Installing binutils on F36 from the rawhide repos started failing:

    Downloading Packages:
    (1/8): jansson-2.13.1-9.fc40.x86_64.rpm          97 kB/s |  44 kB     00:00
    (2/8): binutils-gold-2.41-32.fc40.x86_64.rpm    1.1 MB/s | 782 kB     00:00
    (3/8): glibc-common-2.39-2.fc40.x86_64.rpm      3.5 MB/s | 383 kB     00:00
    (4/8): binutils-2.41-32.fc40.x86_64.rpm         6.5 MB/s | 6.2 MB     00:00
    (5/8): glibc-2.39-2.fc40.x86_64.rpm             4.2 MB/s | 2.2 MB     00:00
    (6/8): glibc-gconv-extra-2.39-2.fc40.x86_64.rpm 7.5 MB/s | 1.7 MB     00:00
    (7/8): glibc-langpack-en-2.39-2.fc40.x86_64.rpm 4.3 MB/s | 694 kB     00:00
    (8/8): libstdc++-14.0.1-0.6.fc40.x86_64.rpm     3.9 MB/s | 872 kB     00:00
    --------------------------------------------------------------------------------
    Total                                           6.5 MB/s |  13 MB     00:01
    Fedora - Rawhide - Developmental packages for t 1.6 MB/s | 1.6 kB     00:00
    Importing GPG key 0xEB10B464:
    Userid     : "Fedora (38) <fedora-38-primary@fedoraproject.org>"
    Fingerprint: 6A51 BBAB BA3D 5467 B617 1221 809A 8D7C EB10 B464
    From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-rawhide-x86_64
    Key imported successfully
    Fedora - Rawhide - Developmental packages for t 1.6 MB/s | 1.6 kB     00:00
    Importing GPG key 0xA15B79CC:
    Userid     : "Fedora (40) <fedora-40-primary@fedoraproject.org>"
    Fingerprint: 115D F9AE F857 853E E844 5D0A 0727 707E A15B 79CC
    From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-40-x86_64
    Key imported successfully
    Import of key(s) didn't help, wrong key(s)?
    Public key for binutils-2.41-32.fc40.x86_64.rpm is not installed. Failing package is: binutils-2.41-32.fc40.x86_64
    GPG Keys are configured as:
    file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-rawhide-x86_64,
    file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-40-x86_64

We were originally forced to use the rawhide repos to work around a bug in binutils[1], see c37fc41c2b015b3df3e40a166700579050647c8c.

The binutils bug was fixed in binutils-2.37-35.fc36, so drop the rawhide repos and inherit most of the defaults from vanagon.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2114597