### PR TITLE
Update Windows license

### DIFF
--- a/resources/windows/wix/license/LICENSE.rtf
+++ b/resources/windows/wix/license/LICENSE.rtf
@@ -12,17 +12,17 @@ pxp-agent - Apache 2.0\
 curl - MIT/X derivative\
 nssm - Public Domain\
 ruby - Ruby License\
-stomp - Apache 2.0\
 deep-merge -  MIT License\
+fast_gettext - MIT\
+gettext - Ruby\
 hocon - Apache 2.0\
+locale - Ruby\
 minitar - Ruby License\
 net-ssh - MIT License\
+semantic_puppet - Apache 2.0\
+text - MIT License\
 openssl - Openssl Dual License\
 puppet-ca-bundle - Puppet-ca-bundle license\
-win32-dir - Artistic 2.0\
-win32-process - Artistic 2.0\
-win32-security - Artistic 2.0\
-win32-service - Artistic 2.0\
 WiX Toolset - Common Public License 1.0\
 Elevate - MIT License\
 ffi - BSD License\


### PR DESCRIPTION
This license is displayed when installing the puppet-agent MSI.

win32-* gems were removed in puppet 7.0

Added license info for other gems. Some gems like fast_gettext are dual licensed (MIT & Ruby), so I just picked one.

This is a follow up to https://github.com/puppetlabs/puppet-runtime/pull/817