### PR TITLE
Update the acceptance:facts rake task for beaker 5

### DIFF
--- a/acceptance/util/puppet_facts_output.rb
+++ b/acceptance/util/puppet_facts_output.rb
@@ -132,8 +132,8 @@ test_name "get facts, obfuscate, and save to a local file for uploading to facte
   end
 
   agents.each do |agent|
-    on agent, facter('--show-legacy -p -j'), :acceptable_exit_codes => [0] do
-      facts = JSON.parse(stdout)
+    on(agent, facter('--show-legacy -p -j'), :acceptable_exit_codes => [0]) do |result|
+      facts = JSON.parse(result.stdout)
       facter_major_version = facts['facterversion']
       primary_network = facts['networking']['primary']
 


### PR DESCRIPTION
The `output` method is no longer available to the test case. Instead access the output from the result that's yielded to the method.

This job is running against my fork: https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/puppet-facts/job/platform_puppetfacts_puppet-agent-puppetfacts-suite_adhoc/55/ Ignore the AIX failures, I specified the wrong TEST_TARGETS for the 7.x pipeline