### PR TITLE
(PA-6264) Add Amazon Linux2 platform definition to puppet-agent-main

### DIFF
--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'amazon-7-aarch64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
Build [amazon-7-aarch64](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-7-aarch64,SLAVE_LABEL=k8s-worker/2922/consoleFull)

[artifacts](https://builds.delivery.puppetlabs.net/puppet-agent/975c70c45046d1d2798aee5e01e01a4a2b46fc31/artifacts/)