### PR TITLE
(PA-6265) Added AL2 in platform definition for 7.x

### DIFF
--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'amazon-7-aarch64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
Vanagon Generic Build : https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-7-aarch64,SLAVE_LABEL=k8s-worker/2959/