### PR TITLE
Revert "(PA-6267) Update build_defaults.yaml to enable Amazon Linux2 main"

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,7 +6,6 @@ project: 'puppet-agent'
 foss_platforms:
   - amazon-2023-x86_64
   - amazon-2023-aarch64
-  - amazon-7-aarch64
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64
@@ -47,8 +46,6 @@ platform_repos:
     repo_location: repos/amazon/2023/**/x86_64
   - name: amazon-2023-aarch64
     repo_location: repos/amazon/2023/**/aarch64
-  - name: amazon-7-aarch64
-    repo_location: repos/amazon/7/**/aarch64
   - name: el-7-x86_64
     repo_location: repos/el/7/**/x86_64
   - name: el-8-x86_64


### PR DESCRIPTION
This reverts commit 3d181f60a614a7062f8416143715f53a5f19b2c3.

The beaker changes to test amazon7-AARCH64 haven't been released yet in Beaker 5, so we can't test it in CI. As a result, we're not ready to ship packages.