### PR TITLE
(PA-6480) Update opensslfips version check test to expect 3.0.9

### DIFF
--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -46,7 +46,7 @@ test_name 'Validate openssl version and fips' do
           assert_match(Regexp.new(<<~END, Regexp::MULTILINE), result.stdout)
           \s*fips
           \s*name: OpenSSL FIPS Provider
-          \s*version: 3.0.0
+          \s*version: 3.0.9
           \s*status: active
           END
         end


### PR DESCRIPTION
- Opensslfips was bumped to 3.0.9 from 3.0.0 in https://github.com/puppetlabs/openssl-fips/pull/8
- Update the expected opensslfips version to be 3.0.9 for all fips platforms in acceptance tests.