### PR TITLE
[Backport 7.x] Rename Amazon 7 to 2

### DIFF
--- a/configs/platforms/amazon-2-aarch64.rb
+++ b/configs/platforms/amazon-2-aarch64.rb
@@ -1,0 +1,3 @@
+platform 'amazon-2-aarch64' do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,3 +1,0 @@
-platform 'amazon-7-aarch64' do |plat|
-  plat.inherit_from_default
-end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -4,7 +4,7 @@ project: 'puppet-agent'
 foss_platforms:
   - amazon-2023-x86_64
   - amazon-2023-aarch64
-  - amazon-7-aarch64
+  - amazon-2-aarch64
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64
@@ -56,8 +56,8 @@ platform_repos:
     repo_location: repos/amazon/2023/**/x86_64
   - name: amazon-2023-aarch64
     repo_location: repos/amazon/2023/**/aarch64
-  - name: amazon-7-aarch64
-    repo_location: repos/amazon/7/**/aarch64
+  - name: amazon-2-aarch64
+    repo_location: repos/amazon/2/**/aarch64
   - name: el-6-i386
     repo_location: repos/el/6/**/i386
   - name: el-6-x86_64


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is named Amazon 2

(cherry picked from commit 8c4b5b644510402e8441468fde3868f6c080a310)