### PR TITLE
(PA-6676) Install ruby@2.7 from internal source

### DIFF
--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -45,7 +45,12 @@ component 'puppet-runtime' do |pkg, settings, platform|
       pkg.build_requires 'pl-ruby'
     elsif platform.is_macos?
       ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-      pkg.build_requires "ruby@#{ruby_version_y}"
+      # Pin to an older version of ruby@2.7. This can be removed once we're no longer cross-compiling
+      if ruby_version_y == "2.7"
+        pkg.build_requires "puppetlabs/puppet/ruby@2.7"
+      else
+        pkg.build_requires "ruby@#{ruby_version_y}"
+      end
     end
   end
 


### PR DESCRIPTION
When building puppet-agent-7.x on macOS 11 & 12, we now install ruby@2.7 from our homebrew-puppet tap.

vanagon generic : https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/3020/