### PR TITLE
Bump Ruby in checks action to 3.3

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Ruby version 3.2
+      - name: Install Ruby version 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Update rubygems and install gems
         run: |
           gem update --system --silent --no-document


### PR DESCRIPTION
A recent update to the Ubuntu GitHub Action runner added Ruby 3.2 to the image. This causes conflicts when we try to install Ruby 3.2 with the setup-ruby action.

This commit bumps the Ruby version used in the checks action from 3.2 to 3.3.

See also puppetlabs/puppet-runtime@f25d32c