### PR TITLE
(PA-6543) Bump wix to 3.14.1 for puppet-agent 7.x

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -10,7 +10,7 @@ platform "windows-2012r2-x64" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y wixtoolset -version 3.14.1 -debug -x86 --no-progress --ignore-dependencies"
 
   plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -10,7 +10,7 @@ platform "windows-2012r2-x86" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
+  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y wixtoolset -version 3.14.1 -debug -x86 --no-progress --ignore-dependencies"
 
   plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 

--- a/configs/platforms/windowsfips-2012r2-x64.rb
+++ b/configs/platforms/windowsfips-2012r2-x64.rb
@@ -14,7 +14,7 @@ platform "windowsfips-2012r2-x64" do |plat|
 
   #FIXME we need Fips Compliant Wix, currently not in choco repositories
   #plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
-  plat.provision_with "curl -L -o /tmp/wix314-binaries.zip https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/wix3/wix3.14.0.6526-binaries.zip && \"C:/Program Files/7-Zip/7z.exe\" x -y -o\"C:/Program Files (x86)/WiX Toolset v3.14/bin\" C:/cygwin64/tmp/wix314-binaries.zip && rm /tmp/wix314-binaries.zip && SETX WIX \"C:\\Program Files (x86)\\WiX Toolset v3.14\" /M"
+  plat.provision_with "curl -L --fail --retry 3 -o /tmp/wix314-binaries.zip https://artifactory.delivery.puppetlabs.net/artifactory/generic__buildsources/buildsources/wix314-binaries.zip && \"C:/Program Files/7-Zip/7z.exe\" x -y -o\"C:/Program Files (x86)/WiX Toolset v3.14/bin\" C:/cygwin64/tmp/wix314-binaries.zip && rm /tmp/wix314-binaries.zip && SETX WIX \"C:\\Program Files (x86)\\WiX Toolset v3.14\" /M"
 
   plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
 


### PR DESCRIPTION
 We use '--ignore-dependencies' flag to install wixtoolset since it depends on DotNet3.5 which breaks when installing: https://github.com/wixtoolset/issues/issues/5523. Seems we don't need it for our use case, we can leave it out.