### PR TITLE
Temporarily disable macOS 12 ARM

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -22,7 +22,6 @@ foss_platforms:
   - fedora-36-x86_64
   - fedora-40-x86_64
   - osx-11-x86_64
-  - osx-12-arm64
   - osx-13-arm64
   - osx-12-x86_64
   - osx-13-x86_64
@@ -108,8 +107,6 @@ platform_repos:
     repo_location: repos/apt/noble
   - name: osx-11-x86_64
     repo_location: repos/apple/11/**/x86_64/*.dmg
-  - name: osx-12-arm64
-    repo_location: repos/apple/12/**/arm64/*.dmg
   - name: osx-12-x86_64
     repo_location: repos/apple/12/**/x86_64/*.dmg
   - name: osx-13-arm64


### PR DESCRIPTION
Due to an issue with macOS 12 ARM and XCode (see ITHELP-102634), we are temporarily disabling building and shipping that platform.